### PR TITLE
Clarify Kanto Lorelei strategies

### DIFF
--- a/src/data/kanto/lorelei/articuno.json
+++ b/src/data/kanto/lorelei/articuno.json
@@ -2,11 +2,18 @@
   "id": "articuno",
   "name": "Articuno",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Pantalla Luz",
+  "initialMove": "PANTALLA LUZ",
   "tricks": [
     {
-      "detail": "Sale Nidoking así que cambia a Cloyster para luego cambiar a Metagross, Truco, Cloyster +6 // Carámbano para Lucario",
-      "variant": []
+      "detail": "Si entra Nidoking: cambia a Cloyster y luego cambia a Metagross.",
+      "variant": [
+        {
+          "detail": "Con Metagross: usa Truco."
+        },
+        {
+          "detail": "Después vuelve a Cloyster +6. Si aparece Lucario, usa Carámbano."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/lorelei/claydol.json
+++ b/src/data/kanto/lorelei/claydol.json
@@ -1,7 +1,16 @@
 {
-    "id": "claydol",
-    "name": "Claydol",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "Trampa Rocas, cambia a Cloyster, luego a Metagross/ Contra Lapras, usa Truco para bloquear Hidrobomba, Poliwrath +6+2",
-    "tricks": []
+  "id": "claydol",
+  "name": "Claydol",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "TRAMPA ROCAS",
+  "tricks": [
+    {
+      "detail": "Después de poner Trampa Rocas: cambia a Cloyster y luego a Metagross.",
+      "variant": [
+        {
+          "detail": "Contra Lapras: usa Truco para bloquear Hidrobomba y luego cambia a Poliwrath +6 +2."
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/kanto/lorelei/dragonite.json
+++ b/src/data/kanto/lorelei/dragonite.json
@@ -4,10 +4,20 @@
   "image": "/placeholder.svg?height=80&width=80",
   "initialMove": "CAMBIA A CHANDELURE",
   "tricks": [
-    {"detail": "NO CAMBIA, utiliza Poder Oculto, si aún sigue en el campo y no cambia, sigue usando Poder Oculto:", "variant": [
-      {"detail": "Si luego entra LAPRAS, cambia a Poliwrath 6+2. (Si sorpresivamente utiliza Rayo cambia a Excadrill 6+2)"},
-      {"detail": "Si luego entra LUCARIO, cambia a Scrafty para luego volver con Chandelure, usar Truco para encerrar en Roca Afilada o Triturar, saca a Scrafty +2"}
-    ]},
-    {"detail": "Si cambia a SLOWBRO usa Truco con Chandelure para encerrar en Escaldar, cambia a Poliwrath 6+2", "variant": []}
+    {
+      "detail": "Si Dragonite NO cambia: usa Poder Oculto con Chandelure. Repite Poder Oculto mientras Dragonite siga en campo.",
+      "variant": [
+        {
+          "detail": "Si luego entra Lapras: cambia a Poliwrath. Ejecuta la secuencia 6+2 indicada para Poliwrath. Si Lapras usa Rayo de forma inesperada, cambia a Excadrill y ejecuta 6+2."
+        },
+        {
+          "detail": "Si luego entra Lucario: cambia a Scrafty. Después vuelve a Chandelure, usa Truco para bloquear Triturar o Roca Afilada, y vuelve a sacar a Scrafty +2."
+        }
+      ]
+    },
+    {
+      "detail": "Si Dragonite cambia a Slowbro: usa Truco con Chandelure para bloquear Escaldar. Luego cambia a Poliwrath y ejecuta 6+2.",
+      "variant": []
+    }
   ]
 }

--- a/src/data/kanto/lorelei/golurk.json
+++ b/src/data/kanto/lorelei/golurk.json
@@ -1,10 +1,20 @@
 {
-    "id": "golurk",
-    "name": "Golurk",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "TRUCO (Verificar ya que es lo mismo que Exeggutor)",
-    "tricks": [
-        {"detail": "Si cambia a Magneton / Magnezone, cambia a Excadrill y matalo con Terremoto, debería de salir Lapras, cambia a Poliwrath 6+2", "variant": []},
-        {"detail": "Si cambia a Nidoking, cambia a Cloyster +6", "variant": []}
-    ]
+  "id": "golurk",
+  "name": "Golurk",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "TRUCO",
+  "tricks": [
+    {
+      "detail": "Si cambia a Magneton o Magnezone: cambia a Excadrill y debilítalo con Terremoto.",
+      "variant": [
+        {
+          "detail": "Después debería entrar Lapras: cambia a Poliwrath 6+2."
+        }
+      ]
+    },
+    {
+      "detail": "Si cambia a Nidoking: cambia a Cloyster +6.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/kanto/lorelei/jynx.json
+++ b/src/data/kanto/lorelei/jynx.json
@@ -2,6 +2,11 @@
   "id": "jynx",
   "name": "Jynx",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Scrafty +2 (Utiliza A Bocajarro para acabar con Hariyama, Paliza con Togekiss y Puño drenaje con Lapras)",
-  "tricks": []
+  "initialMove": "CAMBIA A SCRAFTY +2",
+  "tricks": [
+    {
+      "detail": "Con Scrafty preparado: usa A Bocajarro contra Hariyama, Paliza contra Togekiss y Puño Drenaje contra Lapras.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/kanto/lorelei/lapras.json
+++ b/src/data/kanto/lorelei/lapras.json
@@ -4,25 +4,82 @@
   "image": "/placeholder.svg?height=80&width=80",
   "initialMove": "TRAMPA ROCAS",
   "tricks": [
-    {"detail": "Surf → Cambia a Poliwrath 6+2 // (Si entra Slowbro, cambia a Chandelure, Truco para encerrar en Escaldar, luego cambia a Poliwrath 6+2)", "variant": []},
-    {"detail": "Rayo → Cambia a Excadrill 6+2 // (Si entra Slowbro, cambia a Chandelure, Truco para encerrar en Escaldar, luego cambia a Poliwrath 6+2)", "variant": []},
-    {"detail": "Taladradora→ Cambia a Excadrill para poner Trampa Rocas, luego cambia a Chandelure para hacer Truco a Mantine, saca a Scrafty +2 // (A Mantine hay que golpearlo 2 veces) // Si te saca crítico usa Raíz Energía", "variant": []},
-    {"detail": "Hidrobomba → Usa Trampa Rocas, luego cambia a Poliwrath 2 Veces Tambor +Velocidad X.", "variant": [
-      {"detail": "(Si Metagross no aguanta el ataque y no puedes poner Trampa Rocas, dale Defensa X a Poliwrath y usa 2 tambores.)"},
-      {"detail": "Lucario te mata → Saca a Chandelure, Truco para encerrar en Triturar / Roca Afilada, saca a Scrafty +2"}
-    ]},
-    {"detail": "Nidoqueen → Observa el ítem intercambiado:", "variant": [
-      {"detail": "Vidasfera → Cambia a Excadrill 6+2 (Mata a Lapras con Terremoto)"},
-      {"detail": "Casco Dentado → Cambia a Excadrill Trampa Rocas, 4+2 (Terremoto para matar a Nido)"}
-    ]},
-   {"detail": "Nidoking → Cambia a Excadrill para colocar Trampa Rocas, luego cambia a Cloyster +6", "variant": []},
-    {"detail": "Slowbro → Cambia a Chandelure y utiliza Poder Oculto para bajarle vida a Dragonite, luego cambia a Excadrill", "variant": [
-      {"detail": "Si entra Lapras / Slowbro → Cambia a Poliwrath 6+2"},
-      {"detail": "Lucario → Cambia a Chandelure y utiliza Truco para encerrar en Triturar / Roca Afilada, luego cambia a Scrafty +2"} 
-      ]},
-    {"detail": "Blissey / Jigglypuff → Cambia a Chandelure y utiliza Truco para encerrar el Tierra Viva de Nidoking, luego cambia a Excadrill +6", "variant": []},
-    {"detail": "Magnezone → Cambia a Excadrill, utiliza Trampa Rocas luego Terremoto para matar a Magnezone // Si entra Lapras, cambia a Poliwrath 6+2", "variant": []},
-    {"detail": "Bronzong → Saca a Excadrill 6+2, luego pon Trampa Rocas", "variant": []}
+    {
+      "detail": "Surf → cambia a Poliwrath y ejecuta 6+2.",
+      "variant": [
+        {
+          "detail": "Si entra Slowbro: cambia a Chandelure, usa Truco para bloquear Escaldar y luego vuelve a Poliwrath 6+2."
+        }
+      ]
+    },
+    {
+      "detail": "Rayo → cambia a Excadrill y ejecuta 6+2.",
+      "variant": [
+        {
+          "detail": "Si entra Slowbro: cambia a Chandelure, usa Truco para bloquear Escaldar y luego vuelve a Poliwrath 6+2."
+        }
+      ]
+    },
+    {
+      "detail": "Taladradora → cambia a Excadrill y pon Trampa Rocas. Luego cambia a Chandelure, usa Truco sobre Mantine y saca a Scrafty +2.",
+      "variant": [
+        {
+          "detail": "Contra Mantine: necesitas golpearlo 2 veces. Si recibes un crítico y quedas en riesgo, usa Raíz Energía."
+        }
+      ]
+    },
+    {
+      "detail": "Hidrobomba → usa Trampa Rocas. Luego cambia a Poliwrath, usa Tambor 2 veces y usa Velocidad X.",
+      "variant": [
+        {
+          "detail": "Si Metagross no aguanta y no alcanza a poner Trampa Rocas: usa Defensa X en Poliwrath y luego usa 2 Tambores."
+        },
+        {
+          "detail": "Si Lucario debilita a Poliwrath: saca a Chandelure, usa Truco para bloquear Triturar o Roca Afilada, y luego saca a Scrafty +2."
+        }
+      ]
+    },
+    {
+      "detail": "Nidoqueen → revisa el objeto que recibió con Truco.",
+      "variant": [
+        {
+          "detail": "Vidasfera → cambia a Excadrill 6+2. Usa Terremoto para debilitar a Lapras cuando corresponda."
+        },
+        {
+          "detail": "Casco Dentado → cambia a Excadrill, pon Trampa Rocas y ejecuta 4+2. Usa Terremoto para debilitar a Nidoqueen."
+        }
+      ]
+    },
+    {
+      "detail": "Nidoking → cambia a Excadrill para poner Trampa Rocas. Luego cambia a Cloyster +6.",
+      "variant": []
+    },
+    {
+      "detail": "Slowbro → cambia a Chandelure y usa Poder Oculto para bajar la vida de Dragonite. Luego cambia a Excadrill.",
+      "variant": [
+        {
+          "detail": "Si después entra Lapras o Slowbro: cambia a Poliwrath y ejecuta 6+2."
+        },
+        {
+          "detail": "Si entra Lucario: cambia a Chandelure, usa Truco para bloquear Triturar o Roca Afilada, y luego cambia a Scrafty +2."
+        }
+      ]
+    },
+    {
+      "detail": "Blissey / Jigglypuff → cambia a Chandelure y usa Truco para bloquear Tierra Viva de Nidoking. Luego cambia a Excadrill +6.",
+      "variant": []
+    },
+    {
+      "detail": "Magnezone → cambia a Excadrill, pon Trampa Rocas y usa Terremoto para debilitar a Magnezone.",
+      "variant": [
+        {
+          "detail": "Si después entra Lapras: cambia a Poliwrath 6+2."
+        }
+      ]
+    },
+    {
+      "detail": "Bronzong → saca a Excadrill 6+2 y luego pon Trampa Rocas.",
+      "variant": []
+    }
   ]
 }
-        

--- a/src/data/kanto/lorelei/lucario.json
+++ b/src/data/kanto/lorelei/lucario.json
@@ -4,7 +4,24 @@
   "image": "/placeholder.svg?height=80&width=80",
   "initialMove": "CAMBIA A CHANDELURE",
   "tricks": [
-    {"detail": "Si cambia a Nidoking utiliza Truco con Chandelure para encerrar en movimiento tipo tierra, cambia a Cloyster +6 (Utiliza Carámbano contra Lucario) (Hay una pequeña posibilidad de que no mates a Lapras)", "variant": []},
-    {"detail": "Si se queda en Lucario, utiliza Truco para que encierres en Triturar / Roca Afilada, cambia a Scrafty +3 (Si Chandelure muere, utiliza 1 Danza Dragón extra)", "variant": []}
+    {
+      "detail": "Si Lucario cambia a Nidoking: usa Truco con Chandelure para bloquear un movimiento tipo Tierra. Luego cambia a Cloyster +6.",
+      "variant": [
+        {
+          "detail": "Cuando vuelva Lucario, usa Carámbano con Cloyster."
+        },
+        {
+          "detail": "Ten en cuenta que existe una pequeña posibilidad de no debilitar a Lapras."
+        }
+      ]
+    },
+    {
+      "detail": "Si Lucario se queda en campo: usa Truco con Chandelure para bloquear Triturar o Roca Afilada. Luego cambia a Scrafty +3.",
+      "variant": [
+        {
+          "detail": "Si Chandelure cae debilitado antes de terminar la ruta, usa 1 Danza Dragón extra con Scrafty."
+        }
+      ]
+    }
   ]
 }

--- a/src/data/kanto/lorelei/mantine.json
+++ b/src/data/kanto/lorelei/mantine.json
@@ -8,7 +8,7 @@
       "detail": "Si entra Lapras: cambia a Poliwrath. Si luego entra Slowbro y después sale Mantine, usa Bostezo.",
       "variant": [
         {
-          "detail": "Si frente a Mantine sale Magnezone: sacrifica a Poliwrath. Luego entra con Volcarona +1 y usa Ataque Especial X."
+          "detail": "Si frente a Mantine sale Magnezone: sacrifica a Poliwrath. Luego entra con Volcarona, usa Danza Aleteo +1 y usa Ataque Especial X."
         }
       ]
     },
@@ -16,7 +16,7 @@
       "detail": "Si entra Lucario: cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath +6."
+          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath y usa Tambor +6."
         }
       ]
     },
@@ -28,12 +28,12 @@
       "detail": "Si recibe un ataque tipo Psíquico o Tierra: cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath +6."
+          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath y usa Tambor +6."
         }
       ]
     },
     {
-      "detail": "Si usa Explosión y luego sale Chansey: saca a Politoed para sacrificarlo. Después entra con Poliwrath +6.",
+      "detail": "Si usa Explosión y luego sale Chansey: saca a Politoed para sacrificarlo. Después entra con Poliwrath y usa Tambor +6.",
       "variant": []
     },
     {
@@ -44,12 +44,12 @@
       "detail": "Si Mantine se queda en campo: usa Teletransporte hacia Slowbro y luego usa Bostezo.",
       "variant": [
         {
-          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath +6."
+          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath y usa Tambor +6."
         }
       ]
     },
     {
-      "detail": "Si sale Chansey: saca a Politoed para sacrificarlo. Después entra con Poliwrath +6.",
+      "detail": "Si sale Chansey: saca a Politoed para sacrificarlo. Después entra con Poliwrath y usa Tambor +6.",
       "variant": []
     },
     {
@@ -60,7 +60,7 @@
       "detail": "Si el rival se queda después de Golduck: cambia a Slowbro. Si luego sale Mantine, usa Bostezo.",
       "variant": [
         {
-          "detail": "Frente a Magnezone: sacrifica a Poliwrath. Luego entra con Volcarona +1 y usa Ataque Especial X."
+          "detail": "Frente a Magnezone: sacrifica a Poliwrath. Luego entra con Volcarona, usa Danza Aleteo +1 y usa Ataque Especial X."
         }
       ]
     },
@@ -68,7 +68,7 @@
       "detail": "Si sale Lapras después de Golduck: cambia a Slowbro y usa Bostezo frente a Magnezone.",
       "variant": [
         {
-          "detail": "Luego sacrifica a Poliwrath. Después entra con Volcarona +2 y usa Ataque Especial X."
+          "detail": "Luego sacrifica a Poliwrath. Después entra con Volcarona, usa Danza Aleteo +2 y usa Ataque Especial X."
         }
       ]
     }

--- a/src/data/kanto/lorelei/mantine.json
+++ b/src/data/kanto/lorelei/mantine.json
@@ -2,28 +2,75 @@
   "id": "mantine",
   "name": "Mantine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "UTILIZA PUÑO TRUENO (Si MANTINE NO CAMBIA SIGUE ATACANDO)",
+  "initialMove": "TRAMPA ROCAS",
   "tricks": [
-    {"detail": "Si cambia a Magnezone, saca a Excadrill y matalo con Terremoto, observa:", "variant": [
-      {"detail": "Si sale Mantine, saca a Chandelure y utiliza Truco para encerrar en Escaldar, saca a Scrafty + 1 Defensa Especial X + 2 Danza Dragón (Mantine necesita ser golpeado 2 veces)"},
-      {"detail": "Si sale Lapras, coloca Trampa Rocas, cambia a Poliwrath 6+2"}
-    ]},
-    {"detail": "Si cambia a Chansey, saca a Scrafty +1 luego utiliza Raíz Energía para recuperar PS y vuelva a usar Danza Dragón +1 (Utiliza Paliza para eliminar a Vileplume o Bronzong) // Mantine y Vileplume necesitan 2 Golpes // Curas con Lapras al final", "variant": [
-      {"detail": "Si mientras estás preparando el Scrafty sale Nidoking, cambia a Excadrill luego cambia a Chandelure y utiliza Truco para encerrar en Terremoto, vuelve con Excadrill, Trampa Rocas y +6"}
-    ]},
-    {"detail": "Si cambia a Nidoking, saca a Excadrill luego a Chandelure y observa el movimiento:", "variant": [
-      {"detail": "Roca Afilada, usa Truco y observa:", "variant": [
-        {"detail": "Si usa Tierra Viva, observa la vida de Mantine:", "variant": [
-          {"detail": "Si tiene Vida Completa, entra Excadrill + Trampa Rocas, luego cambia a Cloyster +6"},
-          {"detail": "No está Full Vida, entra Excadrill +6 +0"}
-        ]},
-        {"detail": "Si usa Rayo, saca a Excadrill, Trampa Rocas +6 +0 (Si Mantine no tiene full vida, puedes omitir las Trampa Rocas)"}
-      ]},
-      {"detail": "Rayo Hielo, usa Truco y bloquea el Tierra Viva, entra Excadrill, Trampa Rocas y cambias a Cloyster +6"},
-      {"detail": "Llamarada, usa Truco y bloquea el Tierra Viva, luego revisa la vida de Mantine:", "variant": [
-        {"detail": "Si tiene Vida Completa, entra Excadrill + Trampa Rocas + 6 + 0"},
-        {"detail": "Si No está Full Vida, entra Excadrill +4 +0"}
-      ]}
-    ]}
+    {
+      "detail": "Si entra Lapras: cambia a Poliwrath. Si luego entra Slowbro y después sale Mantine, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si frente a Mantine sale Magnezone: sacrifica a Poliwrath. Luego entra con Volcarona +1 y usa Ataque Especial X."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Lucario: cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath +6."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Bronzong: usa Encanto.",
+      "variant": []
+    },
+    {
+      "detail": "Si recibe un ataque tipo Psíquico o Tierra: cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath +6."
+        }
+      ]
+    },
+    {
+      "detail": "Si usa Explosión y luego sale Chansey: saca a Politoed para sacrificarlo. Después entra con Poliwrath +6.",
+      "variant": []
+    },
+    {
+      "detail": "Si usa Explosión y luego sale Nidoking: usa Amortiguador hasta quedar con PS al máximo.",
+      "variant": []
+    },
+    {
+      "detail": "Si Mantine se queda en campo: usa Teletransporte hacia Slowbro y luego usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath +6."
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Chansey: saca a Politoed para sacrificarlo. Después entra con Poliwrath +6.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Golduck: cambia a Gengar.",
+      "variant": []
+    },
+    {
+      "detail": "Si el rival se queda después de Golduck: cambia a Slowbro. Si luego sale Mantine, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Magnezone: sacrifica a Poliwrath. Luego entra con Volcarona +1 y usa Ataque Especial X."
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lapras después de Golduck: cambia a Slowbro y usa Bostezo frente a Magnezone.",
+      "variant": [
+        {
+          "detail": "Luego sacrifica a Poliwrath. Después entra con Volcarona +2 y usa Ataque Especial X."
+        }
+      ]
+    }
   ]
 }

--- a/src/data/kanto/lorelei/nidoqueen.json
+++ b/src/data/kanto/lorelei/nidoqueen.json
@@ -4,6 +4,13 @@
   "image": "/placeholder.svg?height=80&width=80",
   "initialMove": "TRUCO",
   "tricks": [
-    {"detail": "Cambia a Excadrill 6+2 (Terremoto para matar a Lapras) (Si Lapras aparece mientras te estas preparando, cambia a Poliwrath 6+2)", "variant": []}
+    {
+      "detail": "Después de Truco: cambia a Excadrill 6+2. Usa Terremoto para debilitar a Lapras cuando corresponda.",
+      "variant": [
+        {
+          "detail": "Si Lapras aparece mientras preparas a Excadrill: cambia a Poliwrath 6+2."
+        }
+      ]
+    }
   ]
 }

--- a/src/data/kanto/lorelei/raichu.json
+++ b/src/data/kanto/lorelei/raichu.json
@@ -4,6 +4,9 @@
   "image": "/placeholder.svg?height=80&width=80",
   "initialMove": "CAMBIA A CHANDELURE",
   "tricks": [
-    {"detail": "Utiliza Truco para encerrar Escaldar de Slowbro, entra Poliwrath 6+2", "variant": []}
+    {
+      "detail": "Con Chandelure: usa Truco para bloquear Escaldar de Slowbro. Luego cambia a Poliwrath 6+2.",
+      "variant": []
+    }
   ]
 }

--- a/src/data/kanto/lorelei/slowbro.json
+++ b/src/data/kanto/lorelei/slowbro.json
@@ -2,12 +2,18 @@
   "id": "slowbro",
   "name": "Slowbro",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "TRAMPA ROCAS",
   "tricks": [
-    {"detail": "SI UTILIZA LANZALLAMAS, usa Truco para encerrar en Escaldar, Poliwrath 6+2", "variant": []},
-    {"detail": "Si cambia a Dragonite usa Poder Oculto para bajar vida hasta que cambie:", "variant": [
-      {"detail": "LAPRAS: Poliwrath 6+2+6 (Aún no se que significa el último +6, me imagino que es otro Tambor para que se cure el Poliwrath) (Si te atacan con Rayo cambia a Excadrill 6+2)"},
-      {"detail": "LUCARIO: Cambia a Scrafty, vuelve a entrar Chandelure para usar Truco y encerrar en Triturar / Roca Afilada, vuelve a salir Scrafty +2"}
-    ]}
+    {
+      "detail": "Sale Lucario → cambia a Gengar, usa Otra Vez, usa Maquinación hasta +4 y luego usa Velocidad X para quedar +2 Velocidad.",
+      "variant": [
+        {
+          "detail": "Mantén Otra Vez cada vez que puedas para controlar al rival."
+        },
+        {
+          "detail": "Cuando Gengar esté listo, barre con Bola Sombra."
+        }
+      ]
+    }
   ]
 }

--- a/src/data/kanto/lorelei/togekiss.json
+++ b/src/data/kanto/lorelei/togekiss.json
@@ -4,8 +4,29 @@
   "image": "/placeholder.svg?height=80&width=80",
   "initialMove": "CAMBIA A CHANDELURE",
   "tricks": [
-    {"detail": "Nidoking / Nidoqueen, usa Truco para bloquear movimiento de tierra, entra Excadrill 6+2 (Usa terremoto para matar a Lapras)", "variant": []},
-    {"detail": "Hariyama, usa Truco para bloquear Roca Afilada, sale Scrafty +3 (Usa A Bocajarro para matar a Hariyama, Puño Drenaje para Lapras, Paliza para Nidoqueen)", "variant": []},
-    {"detail": "Si No Cambia usa Lanzallamas para bajar la vida a Togekiss, luego cambia a Scrafty y vuelve a cambiar Chandelure para usar Truco y encerrar el Roca Afilada, saca a Scrafty +3 (Usa A Bocajarro para matar a Conkeldurr, Puño Drenaje para Lapras, Paliza para Gliscor)", "variant": []}
+    {
+      "detail": "Si entra Nidoking o Nidoqueen: usa Truco con Chandelure para bloquear un movimiento tipo Tierra. Luego entra con Excadrill 6+2.",
+      "variant": [
+        {
+          "detail": "Usa Terremoto para debilitar a Lapras cuando corresponda."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Hariyama: usa Truco con Chandelure para bloquear Roca Afilada. Luego cambia a Scrafty +3.",
+      "variant": [
+        {
+          "detail": "Con Scrafty: usa A Bocajarro contra Hariyama, Puño Drenaje contra Lapras y Paliza contra Nidoqueen."
+        }
+      ]
+    },
+    {
+      "detail": "Si Togekiss no cambia: usa Lanzallamas para bajarle vida. Luego cambia a Scrafty y vuelve a Chandelure para usar Truco y bloquear Roca Afilada.",
+      "variant": [
+        {
+          "detail": "Después saca a Scrafty +3. Usa A Bocajarro contra Conkeldurr, Puño Drenaje contra Lapras y Paliza contra Gliscor."
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Improves Kanto Lorelei strategy text so each matchup is easier to follow turn by turn.
- Keeps the current JSON structure and battle logic.
- Splits long inline notes into variants for better readability.
- Removes unclear public-facing notes, especially the old Slowbro text that guessed what a boost meant.
- Clarifies the Slowbro route with Gengar: switch to Gengar, use Encore, use Nasty Plot to +4, use X Speed for +2 Speed, keep Encore active, then sweep with Shadow Ball.
- Replaces the old Mantine tree with the corrected route using Stealth Rock, Yawn, Teleport, sacrifice pivots, Poliwrath, and Volcarona setup.

## Updated matchups
- Articuno
- Claydol
- Dragonite
- Golurk
- Jynx
- Lapras
- Lucario
- Mantine
- Nidoqueen
- Raichu
- Slowbro
- Togekiss

## Notes
- This PR intentionally focuses only on Kanto / Lorelei to keep the changes reviewable.
- More leaders should be improved in separate branches.

Partially addresses #2.