### PR TITLE
Test Gen 9 sprites for Lorelei

### DIFF
--- a/src/components/LeaderCard.tsx
+++ b/src/components/LeaderCard.tsx
@@ -4,9 +4,10 @@ interface LeaderCardProps {
   leader: ConfigLeader
   isExpanded: boolean
   onClick: (leaderId: string) => void
+  trimWhiteFrame?: boolean
 }
 
-export const LeaderCard = ({ leader, isExpanded, onClick }: LeaderCardProps) => {
+export const LeaderCard = ({ leader, isExpanded, onClick, trimWhiteFrame = false }: LeaderCardProps) => {
   const leaderImage = `${import.meta.env.BASE_URL}images/lideres/${leader.name.toLowerCase().replace(/ /g, '_')}.png`
 
   return (
@@ -20,11 +21,15 @@ export const LeaderCard = ({ leader, isExpanded, onClick }: LeaderCardProps) => 
       onClick={() => onClick(leader.id)}
     >
       <div className="absolute inset-0 bg-gradient-to-br from-rose-400/15 via-transparent to-cyan-300/10 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-      <div className="relative flex h-24 items-center justify-center sm:h-28">
+      <div className="relative flex h-24 items-center justify-center overflow-hidden rounded-2xl sm:h-28">
         <img
           src={leaderImage}
           alt={leader.name}
-          className="max-h-24 w-full object-contain drop-shadow-lg transition-transform duration-300 group-hover:scale-105 sm:max-h-28"
+          className={`max-h-24 w-full object-contain drop-shadow-lg transition-transform duration-300 sm:max-h-28 ${
+            trimWhiteFrame
+              ? 'scale-[1.1] group-hover:scale-[1.16]'
+              : 'group-hover:scale-105'
+          }`}
           loading="lazy"
         />
       </div>

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { Pokemon } from '../interfaces/Pokemon'
 import {
   getLocalPokemonSpriteUrl,
   getPokemonAnimatedSpriteUrl,
+  getPokemonDbGen9SpriteUrl,
   getPokemonGen8SpriteUrl,
 } from '../utils/pokemonSprites'
 
@@ -10,21 +11,34 @@ interface PokemonCardProps {
   pokemon: Pokemon
   isSelected: boolean
   onClick: (pokemon: Pokemon) => void
+  useGen9Sprite?: boolean
 }
 
-export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) => {
-  const [spriteSrc, setSpriteSrc] = useState(getPokemonGen8SpriteUrl(pokemon.name))
+export const PokemonCard = ({ pokemon, isSelected, onClick, useGen9Sprite = false }: PokemonCardProps) => {
+  const getInitialSprite = () => useGen9Sprite ? getPokemonDbGen9SpriteUrl(pokemon.name) : getPokemonGen8SpriteUrl(pokemon.name)
+  const [spriteSrc, setSpriteSrc] = useState(getInitialSprite)
   const [fallbackStep, setFallbackStep] = useState(0)
 
+  useEffect(() => {
+    setSpriteSrc(getInitialSprite())
+    setFallbackStep(0)
+  }, [pokemon.name, useGen9Sprite])
+
   const handleSpriteError = () => {
-    if (fallbackStep === 0) {
+    if (useGen9Sprite && fallbackStep === 0) {
       setFallbackStep(1)
+      setSpriteSrc(getPokemonGen8SpriteUrl(pokemon.name))
+      return
+    }
+
+    if (fallbackStep <= 1) {
+      setFallbackStep(2)
       setSpriteSrc(getPokemonAnimatedSpriteUrl(pokemon.name))
       return
     }
 
-    if (fallbackStep === 1) {
-      setFallbackStep(2)
+    if (fallbackStep === 2) {
+      setFallbackStep(3)
       setSpriteSrc(getLocalPokemonSpriteUrl(pokemon.name))
     }
   }
@@ -40,11 +54,11 @@ export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) 
       onClick={() => onClick(pokemon)}
     >
       <div className="absolute inset-0 bg-gradient-to-b from-cyan-300/10 via-transparent to-rose-400/10 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-      <div className="relative flex h-20 items-center justify-center sm:h-24">
+      <div className="relative flex h-24 items-center justify-center sm:h-28">
         <img
           src={spriteSrc}
           alt={pokemon.name}
-          className="max-h-20 w-full object-contain drop-shadow-lg transition-transform duration-300 group-hover:scale-110 sm:max-h-24"
+          className="max-h-24 w-full object-contain drop-shadow-lg transition-transform duration-300 group-hover:scale-110 sm:max-h-28"
           loading="lazy"
           onError={handleSpriteError}
         />

--- a/src/components/PokemonGuide.tsx
+++ b/src/components/PokemonGuide.tsx
@@ -120,7 +120,8 @@ export default function PokemonGuide() {
   const currentRegion = regions.find((region) => region.id === expandedRegion)
   const currentLeader = currentRegion?.leaders.find((leader) => leader.id === expandedLeader)
   const currentLeaderPokemons = currentLeader?.pokemons || []
-  const useLoreleiGen9Sprites = currentRegion?.id === 'kanto' && currentLeader?.id === 'lorelei'
+  const isKantoRegion = currentRegion?.id === 'kanto'
+  const useLoreleiGen9Sprites = isKantoRegion && currentLeader?.id === 'lorelei'
 
   return (
     <div className="min-h-screen overflow-hidden bg-[#0b1020] text-slate-50">
@@ -236,6 +237,7 @@ export default function PokemonGuide() {
                   leader={leader}
                   isExpanded={expandedLeader === leader.id}
                   onClick={handleLeaderClick}
+                  trimWhiteFrame={isKantoRegion}
                 />
               ))}
             </div>

--- a/src/components/PokemonGuide.tsx
+++ b/src/components/PokemonGuide.tsx
@@ -120,6 +120,7 @@ export default function PokemonGuide() {
   const currentRegion = regions.find((region) => region.id === expandedRegion)
   const currentLeader = currentRegion?.leaders.find((leader) => leader.id === expandedLeader)
   const currentLeaderPokemons = currentLeader?.pokemons || []
+  const useLoreleiGen9Sprites = currentRegion?.id === 'kanto' && currentLeader?.id === 'lorelei'
 
   return (
     <div className="min-h-screen overflow-hidden bg-[#0b1020] text-slate-50">
@@ -251,6 +252,7 @@ export default function PokemonGuide() {
                   pokemon={pokemon}
                   isSelected={selectedPokemon?.id === pokemon.id}
                   onClick={handlePokemonClick}
+                  useGen9Sprite={useLoreleiGen9Sprites}
                 />
               ))}
             </div>

--- a/src/utils/pokemonSprites.ts
+++ b/src/utils/pokemonSprites.ts
@@ -1,5 +1,6 @@
 const GEN_8_SPRITE_BASE_URL = 'https://play.pokemonshowdown.com/sprites/gen8'
 const ANIMATED_SPRITE_BASE_URL = 'https://play.pokemonshowdown.com/sprites/ani'
+const POKEMON_DB_GEN_9_SPRITE_BASE_URL = 'https://img.pokemondb.net/sprites/scarlet-violet/normal'
 
 const specialSpriteSlugs: Record<string, string> = {
   'rotom hielo': 'rotom-frost',
@@ -29,6 +30,10 @@ export const getPokemonSpriteSlug = (name: string) => {
 
 export const getPokemonGen8SpriteUrl = (name: string) => {
   return `${GEN_8_SPRITE_BASE_URL}/${getPokemonSpriteSlug(name)}.png`
+}
+
+export const getPokemonDbGen9SpriteUrl = (name: string) => {
+  return `${POKEMON_DB_GEN_9_SPRITE_BASE_URL}/${getPokemonSpriteSlug(name)}.png`
 }
 
 export const getPokemonAnimatedSpriteUrl = (name: string) => {


### PR DESCRIPTION
## Summary
- Adds a backup branch before the sprite experiment: `backup/pre-lorelei-gen9-sprites`.
- Adds PokémonDB Gen 9 sprite support.
- Uses Gen 9 sprites only for Kanto / Lorelei matchups.
- Keeps safe fallbacks: Gen 9 → Gen 8 → animated → local sprite.
- Increases Pokémon card sprite height slightly so the new renders look cleaner.
- Crops Kanto trainer sprites visually to reduce the white frame without editing the original PNG assets.

## Notes
- This is an experimental visual PR.
- If the Gen 9 sprites do not look good, we can close/revert this PR and keep the backup branch untouched.
- No strategy data was changed in this PR.