### PR TITLE
Use Gen 9 sprites across the guide

### DIFF
--- a/src/components/LeaderCard.tsx
+++ b/src/components/LeaderCard.tsx
@@ -4,17 +4,10 @@ interface LeaderCardProps {
   leader: ConfigLeader
   isExpanded: boolean
   onClick: (leaderId: string) => void
-  trimWhiteFrame?: boolean
 }
 
-const leaderFrameFixes: Record<string, string> = {
-  bruno: 'scale-[1.18] group-hover:scale-[1.24] contrast-[1.04] saturate-[1.08]',
-}
-
-export const LeaderCard = ({ leader, isExpanded, onClick, trimWhiteFrame = false }: LeaderCardProps) => {
+export const LeaderCard = ({ leader, isExpanded, onClick }: LeaderCardProps) => {
   const leaderImage = `${import.meta.env.BASE_URL}images/lideres/${leader.name.toLowerCase().replace(/ /g, '_')}.png`
-  const leaderKey = leader.name.toLowerCase().replace(/ /g, '_')
-  const frameFixClass = leaderFrameFixes[leaderKey]
 
   return (
     <button
@@ -31,11 +24,7 @@ export const LeaderCard = ({ leader, isExpanded, onClick, trimWhiteFrame = false
         <img
           src={leaderImage}
           alt={leader.name}
-          className={`h-full w-full object-contain transition-transform duration-300 ${
-            frameFixClass || (trimWhiteFrame
-              ? 'scale-[1.12] group-hover:scale-[1.18]'
-              : 'group-hover:scale-105')
-          }`}
+          className="h-full w-full object-contain transition-transform duration-300 group-hover:scale-105"
           loading="lazy"
         />
       </div>

--- a/src/components/LeaderCard.tsx
+++ b/src/components/LeaderCard.tsx
@@ -7,8 +7,14 @@ interface LeaderCardProps {
   trimWhiteFrame?: boolean
 }
 
+const leaderFrameFixes: Record<string, string> = {
+  bruno: 'scale-[1.18] group-hover:scale-[1.24] contrast-[1.04] saturate-[1.08]',
+}
+
 export const LeaderCard = ({ leader, isExpanded, onClick, trimWhiteFrame = false }: LeaderCardProps) => {
   const leaderImage = `${import.meta.env.BASE_URL}images/lideres/${leader.name.toLowerCase().replace(/ /g, '_')}.png`
+  const leaderKey = leader.name.toLowerCase().replace(/ /g, '_')
+  const frameFixClass = leaderFrameFixes[leaderKey]
 
   return (
     <button
@@ -21,14 +27,14 @@ export const LeaderCard = ({ leader, isExpanded, onClick, trimWhiteFrame = false
       onClick={() => onClick(leader.id)}
     >
       <div className="absolute inset-0 bg-gradient-to-br from-rose-400/15 via-transparent to-cyan-300/10 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-      <div className="relative flex h-24 items-center justify-center overflow-hidden rounded-2xl sm:h-28">
+      <div className="relative flex h-28 items-center justify-center overflow-hidden rounded-2xl sm:h-32">
         <img
           src={leaderImage}
           alt={leader.name}
-          className={`max-h-24 w-full object-contain drop-shadow-lg transition-transform duration-300 sm:max-h-28 ${
-            trimWhiteFrame
-              ? 'scale-[1.1] group-hover:scale-[1.16]'
-              : 'group-hover:scale-105'
+          className={`h-full w-full object-contain transition-transform duration-300 ${
+            frameFixClass || (trimWhiteFrame
+              ? 'scale-[1.12] group-hover:scale-[1.18]'
+              : 'group-hover:scale-105')
           }`}
           loading="lazy"
         />

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -11,27 +11,26 @@ interface PokemonCardProps {
   pokemon: Pokemon
   isSelected: boolean
   onClick: (pokemon: Pokemon) => void
-  useGen9Sprite?: boolean
 }
 
-export const PokemonCard = ({ pokemon, isSelected, onClick, useGen9Sprite = false }: PokemonCardProps) => {
-  const getInitialSprite = () => useGen9Sprite ? getPokemonDbGen9SpriteUrl(pokemon.name) : getPokemonGen8SpriteUrl(pokemon.name)
+export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) => {
+  const getInitialSprite = () => getPokemonDbGen9SpriteUrl(pokemon.name)
   const [spriteSrc, setSpriteSrc] = useState(getInitialSprite)
   const [fallbackStep, setFallbackStep] = useState(0)
 
   useEffect(() => {
     setSpriteSrc(getInitialSprite())
     setFallbackStep(0)
-  }, [pokemon.name, useGen9Sprite])
+  }, [pokemon.name])
 
   const handleSpriteError = () => {
-    if (useGen9Sprite && fallbackStep === 0) {
+    if (fallbackStep === 0) {
       setFallbackStep(1)
       setSpriteSrc(getPokemonGen8SpriteUrl(pokemon.name))
       return
     }
 
-    if (fallbackStep <= 1) {
+    if (fallbackStep === 1) {
       setFallbackStep(2)
       setSpriteSrc(getPokemonAnimatedSpriteUrl(pokemon.name))
       return
@@ -58,7 +57,7 @@ export const PokemonCard = ({ pokemon, isSelected, onClick, useGen9Sprite = fals
         <img
           src={spriteSrc}
           alt={pokemon.name}
-          className="max-h-24 w-full object-contain drop-shadow-lg transition-transform duration-300 group-hover:scale-110 sm:max-h-28"
+          className="h-full w-full object-contain drop-shadow-lg transition-transform duration-300 group-hover:scale-105"
           loading="lazy"
           onError={handleSpriteError}
         />

--- a/src/components/PokemonGuide.tsx
+++ b/src/components/PokemonGuide.tsx
@@ -122,7 +122,6 @@ export default function PokemonGuide() {
   const currentRegion = regions.find((region) => region.id === expandedRegion)
   const currentLeader = currentRegion?.leaders.find((leader) => leader.id === expandedLeader)
   const currentLeaderPokemons = currentLeader?.pokemons || []
-  const isKantoRegion = currentRegion?.id === 'kanto'
 
   return (
     <div className="min-h-screen overflow-hidden bg-[#0b1020] text-slate-50">
@@ -252,7 +251,6 @@ export default function PokemonGuide() {
                   leader={leader}
                   isExpanded={expandedLeader === leader.id}
                   onClick={handleLeaderClick}
-                  trimWhiteFrame={isKantoRegion}
                 />
               ))}
             </div>

--- a/src/components/PokemonGuide.tsx
+++ b/src/components/PokemonGuide.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { ChevronDown, ChevronUp } from "lucide-react"
+import { ChevronDown, ChevronUp, ExternalLink } from "lucide-react"
 
 import type { Pokemon } from "../interfaces/Pokemon"
 import type { Region } from "../interfaces/Region"
@@ -11,6 +11,8 @@ import { RegionCard } from "./RegionCard"
 import { LeaderCard } from "./LeaderCard"
 import { PokemonCard } from "./PokemonCard"
 import { PokemonDetails } from "./PokemonDetails"
+
+const TEAM_PASTE_URL = 'https://pokepast.es/e356ee22f26cf6dc'
 
 export default function PokemonGuide() {
   const [expandedRegion, setExpandedRegion] = useState<string | null>(null)
@@ -121,7 +123,6 @@ export default function PokemonGuide() {
   const currentLeader = currentRegion?.leaders.find((leader) => leader.id === expandedLeader)
   const currentLeaderPokemons = currentLeader?.pokemons || []
   const isKantoRegion = currentRegion?.id === 'kanto'
-  const useLoreleiGen9Sprites = isKantoRegion && currentLeader?.id === 'lorelei'
 
   return (
     <div className="min-h-screen overflow-hidden bg-[#0b1020] text-slate-50">
@@ -168,9 +169,23 @@ export default function PokemonGuide() {
               <p className="text-xs font-bold uppercase tracking-[0.2em] text-cyan-200">{t.routeLabel}</p>
               <p className="mt-2 text-lg font-black text-white">{t.route}</p>
             </div>
-            <div className="rounded-2xl border border-amber-300/20 bg-amber-300/10 p-4">
-              <p className="text-xs font-bold uppercase tracking-[0.2em] text-amber-100">{t.boostLegendTitle}</p>
-              <p className="mt-2 text-sm leading-6 text-amber-50">{t.boostLegend[0]}</p>
+            <div className="rounded-2xl border border-rose-300/20 bg-rose-300/10 p-4">
+              <p className="text-xs font-bold uppercase tracking-[0.2em] text-rose-100">{t.teamLabel}</p>
+              <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-lg font-black text-white">{t.teamTitle}</p>
+                  <p className="mt-1 text-sm leading-5 text-rose-50/80">{t.teamDescription}</p>
+                </div>
+                <a
+                  href={TEAM_PASTE_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex flex-none items-center justify-center gap-2 rounded-xl bg-rose-300 px-4 py-2 text-sm font-black text-slate-950 transition-all duration-300 hover:bg-rose-200"
+                >
+                  {t.teamButton}
+                  <ExternalLink className="h-4 w-4" />
+                </a>
+              </div>
             </div>
           </div>
         </section>
@@ -254,7 +269,6 @@ export default function PokemonGuide() {
                   pokemon={pokemon}
                   isSelected={selectedPokemon?.id === pokemon.id}
                   onClick={handlePokemonClick}
-                  useGen9Sprite={useLoreleiGen9Sprites}
                 />
               ))}
             </div>

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -5,6 +5,10 @@ export interface TranslationLabels {
   subtitle: string
   routeLabel: string
   route: string
+  teamLabel: string
+  teamTitle: string
+  teamDescription: string
+  teamButton: string
   languageLabel: string
   tipsTitle: string
   tipsBadge: string
@@ -29,6 +33,10 @@ export const translations: Record<Language, TranslationLabels> = {
     subtitle: 'Guía visual para farmear la Liga con rutas, líderes y respuestas por Pokémon.',
     routeLabel: 'Ruta recomendada',
     route: 'Teselia → Hoenn → Sinnoh → Kanto → Johto',
+    teamLabel: 'Equipo recomendado',
+    teamTitle: 'PokePaste del team',
+    teamDescription: 'Consulta naturaleza, movimientos, objetos y spreads del equipo usado por la guía.',
+    teamButton: 'Ver equipo',
     languageLabel: 'Idioma',
     tipsTitle: 'Recomendaciones antes de empezar',
     tipsBadge: 'Equipo + tips',
@@ -58,6 +66,10 @@ export const translations: Record<Language, TranslationLabels> = {
     subtitle: 'Visual guide for League farming with routes, trainers, and matchup-specific answers.',
     routeLabel: 'Recommended route',
     route: 'Unova → Hoenn → Sinnoh → Kanto → Johto',
+    teamLabel: 'Recommended team',
+    teamTitle: 'Team PokePaste',
+    teamDescription: 'Check the nature, moves, items, and spreads used by this guide.',
+    teamButton: 'View team',
     languageLabel: 'Language',
     tipsTitle: 'Before you start',
     tipsBadge: 'Team + tips',


### PR DESCRIPTION
## Summary
- Uses PokémonDB Gen 9 sprites for every Pokémon card across the guide.
- Keeps the existing fallback chain: Gen 9 → Gen 8 → animated → local sprite.
- Normalizes Pokémon sprite sizing so cards feel more consistent.
- Adds the recommended team PokePaste link to the header.
- Adds Spanish and English copy for the team link card.
- Normalizes trainer sprite rendering across regions so Kanto and Johto leaders use the same display rules.

## Notes
- No strategy data changes are included.
- The team link points to: https://pokepast.es/e356ee22f26cf6dc