### PR TITLE
Add Pokémon HOME sprite fallbacks

### DIFF
--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -4,6 +4,7 @@ import {
   getLocalPokemonSpriteUrl,
   getPokemonAnimatedSpriteUrl,
   getPokemonDbGen9SpriteUrl,
+  getPokemonDbHomeSpriteUrl,
   getPokemonGen8SpriteUrl,
 } from '../utils/pokemonSprites'
 
@@ -26,18 +27,24 @@ export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) 
   const handleSpriteError = () => {
     if (fallbackStep === 0) {
       setFallbackStep(1)
-      setSpriteSrc(getPokemonGen8SpriteUrl(pokemon.name))
+      setSpriteSrc(getPokemonDbHomeSpriteUrl(pokemon.name))
       return
     }
 
     if (fallbackStep === 1) {
       setFallbackStep(2)
-      setSpriteSrc(getPokemonAnimatedSpriteUrl(pokemon.name))
+      setSpriteSrc(getPokemonGen8SpriteUrl(pokemon.name))
       return
     }
 
     if (fallbackStep === 2) {
       setFallbackStep(3)
+      setSpriteSrc(getPokemonAnimatedSpriteUrl(pokemon.name))
+      return
+    }
+
+    if (fallbackStep === 3) {
+      setFallbackStep(4)
       setSpriteSrc(getLocalPokemonSpriteUrl(pokemon.name))
     }
   }

--- a/src/utils/pokemonSprites.ts
+++ b/src/utils/pokemonSprites.ts
@@ -1,14 +1,18 @@
 const GEN_8_SPRITE_BASE_URL = 'https://play.pokemonshowdown.com/sprites/gen8'
 const ANIMATED_SPRITE_BASE_URL = 'https://play.pokemonshowdown.com/sprites/ani'
 const POKEMON_DB_GEN_9_SPRITE_BASE_URL = 'https://img.pokemondb.net/sprites/scarlet-violet/normal'
+const POKEMON_DB_HOME_SPRITE_BASE_URL = 'https://img.pokemondb.net/sprites/home/normal/1x'
 
 const specialSpriteSlugs: Record<string, string> = {
+  'rotom agua': 'rotom-wash',
+  'rotom lavadora': 'rotom-wash',
+  'rotom wash': 'rotom-wash',
   'rotom hielo': 'rotom-frost',
   'rotom-hielo': 'rotom-frost',
   'rotom calor': 'rotom-heat',
-  'rotom lavadora': 'rotom-wash',
   'rotom corte': 'rotom-mow',
   'rotom ventilador': 'rotom-fan',
+  'rotom abanico': 'rotom-fan',
   'nidoran macho': 'nidoran-m',
   'nidoran hembra': 'nidoran-f',
   'mime jr': 'mime-jr',
@@ -34,6 +38,10 @@ export const getPokemonGen8SpriteUrl = (name: string) => {
 
 export const getPokemonDbGen9SpriteUrl = (name: string) => {
   return `${POKEMON_DB_GEN_9_SPRITE_BASE_URL}/${getPokemonSpriteSlug(name)}.png`
+}
+
+export const getPokemonDbHomeSpriteUrl = (name: string) => {
+  return `${POKEMON_DB_HOME_SPRITE_BASE_URL}/${getPokemonSpriteSlug(name)}.png`
 }
 
 export const getPokemonAnimatedSpriteUrl = (name: string) => {


### PR DESCRIPTION
## Summary
- Adds Pokémon HOME sprites as the first fallback after Scarlet/Violet sprites.
- Updates the fallback chain to: Scarlet/Violet → HOME → Gen 8 → animated → local.
- Adds extra slug mappings for Rotom forms, including Rotom Agua / Wash Rotom.

## Why
Some Pokémon do not have Scarlet/Violet sprites on PokémonDB, so they were falling back directly to older sprites. This should improve Pokémon such as Claydol, Jynx, Mantine, Nidoking, Togekiss, Aggron, Darmanitan, Machamp, Seismitoad, Steelix, Alakazam, Crobat, Marowak, Rotom-Wash, Aerodactyl, Pidgeot, Absol, Xatu, Ferrothorn, Nidoqueen, Parasect, Sharpedo, Starmie, Stunfisk, Tangrowth, and Kangaskhan.

## Notes
- No strategy data changes are included.