### PR TITLE
Use Pokémon HOME sprites by default

### DIFF
--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -15,7 +15,7 @@ interface PokemonCardProps {
 }
 
 export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) => {
-  const getInitialSprite = () => getPokemonDbGen9SpriteUrl(pokemon.name)
+  const getInitialSprite = () => getPokemonDbHomeSpriteUrl(pokemon.name)
   const [spriteSrc, setSpriteSrc] = useState(getInitialSprite)
   const [fallbackStep, setFallbackStep] = useState(0)
 
@@ -27,7 +27,7 @@ export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) 
   const handleSpriteError = () => {
     if (fallbackStep === 0) {
       setFallbackStep(1)
-      setSpriteSrc(getPokemonDbHomeSpriteUrl(pokemon.name))
+      setSpriteSrc(getPokemonDbGen9SpriteUrl(pokemon.name))
       return
     }
 


### PR DESCRIPTION
## Summary
- Uses Pokémon HOME sprites as the default source for every Pokémon card.
- Keeps Scarlet/Violet sprites as the first fallback.
- Keeps the complete fallback chain: HOME → Scarlet/Violet → Gen 8 → animated → local.

## Why
Pokémon HOME sprites look more consistent across the full guide, especially for Pokémon that do not have Scarlet/Violet sprites available.