### PR TITLE
Add global strategy data validation

### DIFF
--- a/src/components/PokemonGuide.tsx
+++ b/src/components/PokemonGuide.tsx
@@ -6,6 +6,7 @@ import type { Region } from "../interfaces/Region"
 import type { Language } from "../i18n/translations"
 
 import { languages, translations } from "../i18n/translations"
+import { validatePokemonStrategy } from "../utils/strategyValidation"
 import { useDynamicImports } from "../hooks/useDynamicImports"
 import { RegionCard } from "./RegionCard"
 import { LeaderCard } from "./LeaderCard"
@@ -56,10 +57,12 @@ export default function PokemonGuide() {
               try {
                 const module = await import(`../data/${region.id}/${leader.id}/${file.replace('.json', '')}.json`)
                 const data = module.default || module
-                pokemons.push({
-                  ...data,
-                  id: data.id || data.name?.toLowerCase() || file.replace('.json', ''),
-                })
+
+                pokemons.push(validatePokemonStrategy(data, {
+                  regionId: region.id,
+                  leaderId: leader.id,
+                  fileName: file,
+                }))
               } catch (error) {
                 console.error(`Error importing ${file}:`, error)
               }

--- a/src/utils/strategyValidation.ts
+++ b/src/utils/strategyValidation.ts
@@ -1,0 +1,79 @@
+import type { Pokemon, Tricks } from '../interfaces/Pokemon'
+
+type ValidationContext = {
+  regionId: string
+  leaderId: string
+  fileName: string
+}
+
+const createFallbackPokemon = (context: ValidationContext): Pokemon => ({
+  id: context.fileName.replace('.json', ''),
+  name: context.fileName.replace('.json', ''),
+  initialMove: 'SIN ESTRATEGIA DEFINIDA',
+  tricks: [],
+})
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const normalizeText = (value: unknown) => {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+const validateTricks = (value: unknown, contextLabel: string): Tricks[] => {
+  if (!Array.isArray(value)) {
+    console.warn(`[strategy-validation] ${contextLabel}: tricks must be an array.`)
+    return []
+  }
+
+  return value
+    .map((item, index): Tricks | null => {
+      if (!isRecord(item)) {
+        console.warn(`[strategy-validation] ${contextLabel}: trick #${index + 1} is not valid.`)
+        return null
+      }
+
+      const detail = normalizeText(item.detail)
+
+      if (!detail) {
+        console.warn(`[strategy-validation] ${contextLabel}: trick #${index + 1} is missing detail.`)
+        return null
+      }
+
+      return {
+        detail,
+        variant: validateTricks(item.variant ?? [], `${contextLabel} > trick #${index + 1}`),
+      }
+    })
+    .filter((item): item is Tricks => item !== null)
+}
+
+export const validatePokemonStrategy = (value: unknown, context: ValidationContext): Pokemon => {
+  const contextLabel = `${context.regionId}/${context.leaderId}/${context.fileName}`
+
+  if (!isRecord(value)) {
+    console.warn(`[strategy-validation] ${contextLabel}: file is not a valid object.`)
+    return createFallbackPokemon(context)
+  }
+
+  const name = normalizeText(value.name)
+  const initialMove = normalizeText(value.initialMove)
+  const id = normalizeText(value.id) || name.toLowerCase() || context.fileName.replace('.json', '')
+
+  if (!name) {
+    console.warn(`[strategy-validation] ${contextLabel}: missing name.`)
+  }
+
+  if (!initialMove) {
+    console.warn(`[strategy-validation] ${contextLabel}: missing initialMove.`)
+  }
+
+  return {
+    id,
+    name: name || context.fileName.replace('.json', ''),
+    image: normalizeText(value.image) || undefined,
+    initialMove: initialMove || 'SIN ESTRATEGIA DEFINIDA',
+    tricks: validateTricks(value.tricks, contextLabel),
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a single global validation helper for strategy JSON files.
- Validates Pokémon strategy data when each JSON file is loaded.
- Normalizes missing fields with safe fallbacks instead of letting the UI break.
- Logs clear development warnings for invalid strategy files.
- Keeps validation out of UI components to avoid duplicate checks.

## Validation rules
- `name` and `initialMove` are normalized as strings.
- `tricks` must be an array.
- each trick must have a valid `detail`.
- nested `variant` entries are validated recursively.

## Notes
- No strategy text changes are included.
- This keeps the app safer while preserving the current JSON structure.

Closes #10.