### PR TITLE
Add security baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://noisgit.github.io/EliteFourPokeMMO/
 - Spanish as the primary in-app language, with an English UI option.
 - Dynamic strategy loading from JSON files grouped by region and trainer.
 - Redesigned cards for regions, trainers, Pokémon, and strategy steps.
-- Gen 8-style Pokémon sprites with animated and local fallbacks.
+- Pokémon HOME sprites with Scarlet/Violet, Gen 8, animated, and local fallbacks.
 - Context-aware boost notes for common setup routes.
 - GitHub Pages deployment from the `main` branch.
 
@@ -72,6 +72,16 @@ The production build is generated in:
 ```text
 dist/
 ```
+
+## Security checks
+
+Run the dependency audit before merging dependency updates:
+
+```bash
+npm run security:audit
+```
+
+See [`SECURITY.md`](./SECURITY.md) for the project security policy.
 
 ## GitHub Pages deployment
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported version
+
+This project is a static frontend deployed with GitHub Pages. Security updates apply to the `main` branch.
+
+## Reporting a vulnerability
+
+If you find a security issue, please open a private report through GitHub Security Advisories when available, or contact the repository owner directly.
+
+Please include:
+
+- affected file or feature;
+- clear reproduction steps;
+- expected impact;
+- suggested fix, if known.
+
+## Project security notes
+
+- Do not commit API keys, tokens, secrets, cookies, or private credentials.
+- Do not add secrets to frontend code. Anything shipped in this app is public.
+- Keep GitHub Actions permissions minimal.
+- Run dependency audits before merging dependency updates:
+
+```bash
+npm run security:audit
+```
+
+- Prefer small pull requests so changes are easy to review.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "farmeof4",
+  "name": "elitefour-pokemmo",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "security:audit": "npm audit --audit-level=high"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- Adds a security policy with basic reporting and project security notes.
- Adds a dependency audit script: `npm run security:audit`.
- Adds Dependabot configuration for npm and GitHub Actions.
- Documents security checks in the README.
- Renames the package from `farmeof4` to `elitefour-pokemmo`.

## Notes
- No runtime security logic was added to UI components.
- The deploy workflow already uses minimal permissions for GitHub Pages.
- The audit script is not blocking deploy yet to avoid breaking Pages on devDependency-only advisories.

Closes #11.