### PR TITLE
Polish responsive layout

### DIFF
--- a/src/components/LeaderCard.tsx
+++ b/src/components/LeaderCard.tsx
@@ -14,13 +14,13 @@ export const LeaderCard = ({ leader, isExpanded, onClick }: LeaderCardProps) => 
       type="button"
       className={`group relative min-w-0 overflow-hidden rounded-3xl border bg-slate-950/60 p-3 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 hover:border-rose-200/40 hover:bg-slate-900/90 ${
         isExpanded
-          ? 'scale-[1.03] border-rose-200/70 ring-2 ring-rose-300/70'
+          ? 'scale-[1.02] border-rose-200/70 ring-2 ring-rose-300/70 sm:scale-[1.03]'
           : 'border-white/10'
       }`}
       onClick={() => onClick(leader.id)}
     >
       <div className="absolute inset-0 bg-gradient-to-br from-rose-400/15 via-transparent to-cyan-300/10 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-      <div className="relative flex h-28 items-center justify-center overflow-hidden rounded-2xl sm:h-32">
+      <div className="relative flex h-24 items-center justify-center overflow-hidden rounded-2xl min-[420px]:h-28 sm:h-32">
         <img
           src={leaderImage}
           alt={leader.name}

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -54,13 +54,13 @@ export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) 
       type="button"
       className={`group relative min-w-0 cursor-pointer overflow-hidden rounded-2xl border bg-slate-950/60 p-2 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 hover:border-cyan-200/40 hover:bg-slate-900/90 ${
         isSelected
-          ? 'scale-[1.03] border-cyan-200/70 ring-2 ring-cyan-300/70'
+          ? 'scale-[1.02] border-cyan-200/70 ring-2 ring-cyan-300/70 sm:scale-[1.03]'
           : 'border-white/10'
       }`}
       onClick={() => onClick(pokemon)}
     >
       <div className="absolute inset-0 bg-gradient-to-b from-cyan-300/10 via-transparent to-rose-400/10 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-      <div className="relative flex h-24 items-center justify-center sm:h-28">
+      <div className="relative flex h-20 items-center justify-center min-[380px]:h-24 sm:h-28">
         <img
           src={spriteSrc}
           alt={pokemon.name}

--- a/src/components/PokemonGuide.tsx
+++ b/src/components/PokemonGuide.tsx
@@ -127,17 +127,17 @@ export default function PokemonGuide() {
   const currentLeaderPokemons = currentLeader?.pokemons || []
 
   return (
-    <div className="min-h-screen overflow-hidden bg-[#0b1020] text-slate-50">
+    <div className="min-h-screen overflow-x-hidden bg-[#0b1020] text-slate-50">
       <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(244,63,94,0.22),_transparent_32%),radial-gradient(circle_at_top_right,_rgba(59,130,246,0.2),_transparent_28%),linear-gradient(135deg,_#0b1020_0%,_#111827_45%,_#1e1b4b_100%)]" />
 
-      <main className="relative mx-auto min-h-screen w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-        <section className="mb-8 rounded-[2rem] border border-white/10 bg-white/[0.08] p-5 shadow-2xl shadow-black/30 backdrop-blur-xl sm:p-8">
-          <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
-            <div className="max-w-3xl">
-              <span className="mb-3 inline-flex rounded-full border border-rose-300/30 bg-rose-400/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.24em] text-rose-100">
+      <main className="relative mx-auto min-h-screen w-full max-w-7xl px-3 py-4 sm:px-6 sm:py-6 lg:px-8">
+        <section className="mb-6 rounded-[1.5rem] border border-white/10 bg-white/[0.08] p-4 shadow-2xl shadow-black/30 backdrop-blur-xl sm:mb-8 sm:rounded-[2rem] sm:p-8">
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0 max-w-3xl">
+              <span className="mb-3 inline-flex rounded-full border border-rose-300/30 bg-rose-400/10 px-3 py-1 text-[0.65rem] font-bold uppercase tracking-[0.2em] text-rose-100 sm:text-xs sm:tracking-[0.24em]">
                 PokeMMO Elite Four
               </span>
-              <h1 className="text-4xl font-black tracking-tight text-white sm:text-5xl lg:text-6xl">
+              <h1 className="text-3xl font-black tracking-tight text-white sm:text-5xl lg:text-6xl">
                 {t.title}
               </h1>
               <p className="mt-4 max-w-2xl text-sm leading-6 text-slate-300 sm:text-base">
@@ -145,7 +145,7 @@ export default function PokemonGuide() {
               </p>
             </div>
 
-            <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-3">
+            <div className="flex w-full flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-3 sm:w-auto sm:min-w-48">
               <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">{t.languageLabel}</span>
               <div className="grid grid-cols-2 gap-2">
                 {(Object.keys(languages) as Language[]).map((currentLanguage) => (
@@ -166,23 +166,23 @@ export default function PokemonGuide() {
             </div>
           </div>
 
-          <div className="mt-6 grid gap-3 md:grid-cols-[1.4fr_1fr]">
+          <div className="mt-6 grid gap-3 lg:grid-cols-[1.1fr_1fr]">
             <div className="rounded-2xl border border-cyan-300/20 bg-cyan-300/10 p-4">
               <p className="text-xs font-bold uppercase tracking-[0.2em] text-cyan-200">{t.routeLabel}</p>
-              <p className="mt-2 text-lg font-black text-white">{t.route}</p>
+              <p className="mt-2 text-base font-black text-white sm:text-lg">{t.route}</p>
             </div>
             <div className="rounded-2xl border border-rose-300/20 bg-rose-300/10 p-4">
               <p className="text-xs font-bold uppercase tracking-[0.2em] text-rose-100">{t.teamLabel}</p>
               <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <p className="text-lg font-black text-white">{t.teamTitle}</p>
+                <div className="min-w-0">
+                  <p className="text-base font-black text-white sm:text-lg">{t.teamTitle}</p>
                   <p className="mt-1 text-sm leading-5 text-rose-50/80">{t.teamDescription}</p>
                 </div>
                 <a
                   href={TEAM_PASTE_URL}
                   target="_blank"
                   rel="noreferrer"
-                  className="inline-flex flex-none items-center justify-center gap-2 rounded-xl bg-rose-300 px-4 py-2 text-sm font-black text-slate-950 transition-all duration-300 hover:bg-rose-200"
+                  className="inline-flex w-full flex-none items-center justify-center gap-2 rounded-xl bg-rose-300 px-4 py-2 text-sm font-black text-slate-950 transition-all duration-300 hover:bg-rose-200 sm:w-auto"
                 >
                   {t.teamButton}
                   <ExternalLink className="h-4 w-4" />
@@ -192,17 +192,17 @@ export default function PokemonGuide() {
           </div>
         </section>
 
-        <section className="mb-6 rounded-3xl border border-white/10 bg-slate-950/45 p-4 backdrop-blur-xl">
+        <section className="mb-6 rounded-3xl border border-white/10 bg-slate-950/45 p-3 backdrop-blur-xl sm:p-4">
           <button
             type="button"
             onClick={() => setShowTips(!showTips)}
             className="flex w-full items-center justify-between gap-3 rounded-2xl px-2 py-2 text-left transition-colors hover:bg-white/5"
           >
-            <span>
+            <span className="min-w-0">
               <span className="block text-sm font-black uppercase tracking-[0.18em] text-rose-100">{t.tipsTitle}</span>
               <span className="mt-1 block text-xs font-bold uppercase tracking-[0.16em] text-slate-400">{t.tipsBadge}</span>
             </span>
-            {showTips ? <ChevronUp className="h-5 w-5 text-rose-200" /> : <ChevronDown className="h-5 w-5 text-rose-200" />}
+            {showTips ? <ChevronUp className="h-5 w-5 flex-none text-rose-200" /> : <ChevronDown className="h-5 w-5 flex-none text-rose-200" />}
           </button>
 
           {showTips && (
@@ -211,7 +211,7 @@ export default function PokemonGuide() {
                 {t.tips.map((tip) => (
                   <li key={tip} className="flex gap-3">
                     <span className="mt-2 h-2 w-2 flex-none rounded-full bg-rose-300" />
-                    <span>{tip}</span>
+                    <span className="min-w-0 break-words">{tip}</span>
                   </li>
                 ))}
               </ul>
@@ -220,7 +220,7 @@ export default function PokemonGuide() {
                 <h2 className="mb-3 text-sm font-black uppercase tracking-[0.18em] text-amber-100">{t.boostLegendTitle}</h2>
                 <ul className="space-y-2 text-sm leading-6 text-amber-50">
                   {t.boostLegend.map((item) => (
-                    <li key={item}>{item}</li>
+                    <li key={item} className="break-words">{item}</li>
                   ))}
                 </ul>
               </div>
@@ -232,7 +232,7 @@ export default function PokemonGuide() {
           <div className="mb-3 flex items-center justify-between">
             <h2 className="text-xs font-black uppercase tracking-[0.22em] text-slate-400">{t.selectRegion}</h2>
           </div>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+          <div className="grid grid-cols-1 gap-3 min-[420px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
             {regions.map((region) => (
               <RegionCard
                 key={region.id}
@@ -247,7 +247,7 @@ export default function PokemonGuide() {
         {expandedRegion && currentRegion && currentRegion.leaders.length > 0 && (
           <section className="mb-6 animate-in slide-in-from-top duration-300">
             <h2 className="mb-3 text-xs font-black uppercase tracking-[0.22em] text-slate-400">{t.selectLeader}</h2>
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+            <div className="grid grid-cols-1 gap-3 min-[420px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
               {currentRegion.leaders.map((leader) => (
                 <LeaderCard
                   key={leader.id}
@@ -263,7 +263,7 @@ export default function PokemonGuide() {
         {expandedLeader && (
           <section className="mb-6 animate-in slide-in-from-top duration-300">
             <h2 className="mb-3 text-xs font-black uppercase tracking-[0.22em] text-slate-400">{t.selectPokemon}</h2>
-            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10">
+            <div className="grid grid-cols-2 gap-2 min-[380px]:grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10">
               {currentLeaderPokemons.map((pokemon) => (
                 <PokemonCard
                   key={pokemon.id || pokemon.name}

--- a/src/components/RegionCard.tsx
+++ b/src/components/RegionCard.tsx
@@ -26,10 +26,10 @@ export const RegionCard = ({ region, isExpanded, onClick }: RegionCardProps) => 
       onClick={() => onClick(region.id)}
     >
       <div className={`absolute inset-0 bg-gradient-to-br ${regionAccent[region.id] || 'from-cyan-300/20 to-rose-400/10'} opacity-80`} />
-      <div className="relative flex h-20 items-end sm:h-24">
-        <div>
+      <div className="relative flex h-16 items-end sm:h-24">
+        <div className="min-w-0">
           <span className="mb-2 block h-1 w-10 rounded-full bg-cyan-200 transition-all duration-300 group-hover:w-16" />
-          <span className="block text-xl font-black text-white sm:text-2xl">{region.name}</span>
+          <span className="block truncate text-xl font-black text-white sm:text-2xl">{region.name}</span>
         </div>
       </div>
     </button>


### PR DESCRIPTION
## Summary
- Improves mobile spacing in the main header.
- Makes the language switcher and team card fit better on small screens.
- Improves region, leader, and Pokémon grids for narrow widths.
- Reduces selected card scaling on mobile to avoid layout pressure.
- Adds safer text wrapping for long tips and boost notes.

## Notes
- This PR targets `develop` following the new workflow.
- No strategy data changes are included.

Closes #5.