### PR TITLE
Fix favicon base path

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
       name="description"
       content="Guía visual para farmear las Ligas de PokeMMO con rutas, líderes y estrategias por Pokémon."
     />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
     <title>Farm Liga PokeMMO</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Uses Vite `%BASE_URL%` for the favicon path.
- Makes the favicon resolve correctly under the GitHub Pages base path.

## Notes
- Targets `develop` following the current workflow.
- No strategy data changes are included.