### PR TITLE
Release favicon path fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
       name="description"
       content="Guía visual para farmear las Ligas de PokeMMO con rutas, líderes y estrategias por Pokémon."
     />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
     <title>Farm Liga PokeMMO</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Releases the favicon base path fix from `develop` into `main`.
- Forces a new GitHub Pages deployment.

## Notes
- `develop` remains active.
- No strategy data changes are included.