### PR TITLE
Update Kanto Lorelei strategies

### DIFF
--- a/src/data/kanto/lorelei/articuno.json
+++ b/src/data/kanto/lorelei/articuno.json
@@ -2,16 +2,16 @@
   "id": "articuno",
   "name": "Articuno",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "PANTALLA LUZ",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si entra Nidoking: cambia a Cloyster y luego cambia a Metagross.",
+      "detail": "Coloca Trampa Rocas frente a Lucario. Cuando entre Lapras, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Con Metagross: usa Truco."
+          "detail": "Después saca a Politoed y deja que caiga para darle entrada segura a Poliwrath."
         },
         {
-          "detail": "Después vuelve a Cloyster +6. Si aparece Lucario, usa Carámbano."
+          "detail": "Con Poliwrath en campo, usa Tambor para quedar en +6 Ataque y comienza a barrer. 🐸"
         }
       ]
     }

--- a/src/data/kanto/lorelei/bronzong.json
+++ b/src/data/kanto/lorelei/bronzong.json
@@ -2,20 +2,66 @@
   "id": "bronzong",
   "name": "Bronzong",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
-    {"detail": "NIDOQUEEN, saca a Excadrill 6+2", "variant": []},
-    {"detail": "GIRO BOLA, usa Trampa Rocas. Cambiará a Nidoking y tu cambia a Excadrill 4+0", "variant": []},
-    {"detail": "TERREMOTO, cambia a Excadrill 6+2 y luego Trampa Rocas", "variant": []},
-    {"detail": "SLOWBRO, cambia a Chandelure ya que el cambiara a Dragonite, utiliza Poder Oculto para bajarle vida y luego cambia a Excadrill 6+2",
-    "variant": [
-        {"detail": "Si Slowbro cambia a Lucario utiliza Truco con Chandelure para encerrar en Roca Afilada / Triturar, luego cambia a Scrafty +2"},
-        {"detail": "Si cambia a Lapras o Slowbro se queda, cambia a Poliwrath 6+2 (Slowbro muere de 2 TERREMOTOS) (Usar A BOCAJARRO contra Bronzong)", "variant": []}
-    ]},
-    {"detail": "DRAGONITE, saca a Chandelure y utiliza Poder Oculto para ver que hace:", "variant": [
-        {"detail": "Si entra Lapras cambia a Poliwrath 6 + 2"},
-        {"detail": "Si entra Lucario cambia a Scrafty para cambiar a Chandelure inmediatamente utiliza Truco para encerrar en Roca Afilada o Triturar, vuelve Scrafty +2", "variant": []}
-    ]},
-    {"detail": "LUCARIO, Chandelure utiliza Truco para luego cambiar a Scrafty +3", "variant": []}
+    {
+      "detail": "Coloca Trampa Rocas y revisa qué hace Bronzong antes de elegir la ruta.",
+      "variant": [
+        {
+          "detail": "Si Bronzong se queda en campo, revisa su movimiento."
+        },
+        {
+          "detail": "Si usa Giro Bola, cambia a Volcarona, usa Especial X y barre con ataques súper efectivos. 🔔 Si Bronzong se quema, puedes usar Danza Aleteo x2 antes de atacar."
+        },
+        {
+          "detail": "Si usa Autodestrucción y entra Chansey, saca a Politoed y deja que caiga. Luego entra Poliwrath, usa Tambor para quedar en +6 Ataque y barre."
+        },
+        {
+          "detail": "Si usa Cabezazo Zen o Terremoto, cambia a Slowbro. Frente a Nidoking, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Autodestrucción y entra Nidoking, usa Amortiguador con Chansey hasta quedar con PS al máximo."
+        },
+        {
+          "detail": "Si después de curarte el rival se queda, usa Teletransporte. Entra Slowbro, usa Bostezo, sacrifica a Politoed y termina con Poliwrath usando Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si cambia a Chansey, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Hariyama, revisa su objeto antes de decidir.",
+      "variant": [
+        {
+          "detail": "Si tiene Llamasfera, cambia a Slowbro. Luego cambia a Gengar, usa Otra Vez y usa Maquinación hasta +4 Ataque Especial más Velocidad X para quedar en +2 Velocidad. 🔔 Barre con Bola Sombra."
+        },
+        {
+          "detail": "Si no tiene Llamasfera, cambia a Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🔔 Usa Puño Drenaje contra Jynx."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Walrein o Dewgong, usa la ruta de Gengar con Otra Vez.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Otra Vez y luego Maquinación hasta +2 Ataque Especial."
+        },
+        {
+          "detail": "Si el rival se queda encerrado, sube con Maquinación hasta +6 Ataque Especial. 🔔 Barre con Bola Sombra."
+        },
+        {
+          "detail": "Si cambia a Lapras, sigue atacando hasta llegar a Bronzong. Frente a Bronzong, entra Volcarona y usa Danza Aleteo x1 antes de barrer."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Lucario, usa la ruta de Gengar.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez y luego Maquinación hasta +4 Ataque Especial más Velocidad X para quedar en +2 Velocidad. 🔔 Barre con Bola Sombra."
+        }
+      ]
+    }
   ]
 }

--- a/src/data/kanto/lorelei/bronzong.json
+++ b/src/data/kanto/lorelei/bronzong.json
@@ -34,7 +34,7 @@
       "detail": "Si entra Hariyama, revisa su objeto antes de decidir.",
       "variant": [
         {
-          "detail": "Si tiene Llamasfera, cambia a Slowbro. Luego cambia a Gengar, usa Otra Vez y usa Maquinación hasta +4 Ataque Especial más Velocidad X para quedar en +2 Velocidad. 🔔 Barre con Bola Sombra."
+          "detail": "Si tiene Llamasfera, cambia a Slowbro. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para quedar en +2 Velocidad. 🔔 Barre con Bola Sombra."
         },
         {
           "detail": "Si no tiene Llamasfera, cambia a Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🔔 Usa Puño Drenaje contra Jynx."
@@ -45,10 +45,10 @@
       "detail": "Si entra Walrein o Dewgong, usa la ruta de Gengar con Otra Vez.",
       "variant": [
         {
-          "detail": "Entra con Gengar, usa Otra Vez y luego Maquinación hasta +2 Ataque Especial."
+          "detail": "Entra con Gengar, usa Otra Vez y luego Maquinación hasta +2."
         },
         {
-          "detail": "Si el rival se queda encerrado, sube con Maquinación hasta +6 Ataque Especial. 🔔 Barre con Bola Sombra."
+          "detail": "Si el rival se queda encerrado, sube con Maquinación hasta +6. 🔔 Barre con Bola Sombra."
         },
         {
           "detail": "Si cambia a Lapras, sigue atacando hasta llegar a Bronzong. Frente a Bronzong, entra Volcarona y usa Danza Aleteo x1 antes de barrer."
@@ -59,7 +59,7 @@
       "detail": "Si entra Lucario, usa la ruta de Gengar.",
       "variant": [
         {
-          "detail": "Cambia a Gengar, usa Otra Vez y luego Maquinación hasta +4 Ataque Especial más Velocidad X para quedar en +2 Velocidad. 🔔 Barre con Bola Sombra."
+          "detail": "Cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para quedar en +2 Velocidad. 🔔 Barre con Bola Sombra."
         }
       ]
     }

--- a/src/data/kanto/lorelei/chansey.json
+++ b/src/data/kanto/lorelei/chansey.json
@@ -2,9 +2,27 @@
   "id": "chansey",
   "name": "Chansey",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
-    {"detail": "Si utiliza MOV. SÍSMICO cambia a Scrafty, utiliza +1 luego + Raíz Energía para recuperar salud y boostea +1 (Paliza para Vileplume y Bronzong)", "variant": []},
-    {"detail": "Si sale NIDOKING cambia a Excadrill +6 + 0", "variant": []}
+    {
+      "detail": "Coloca Trampa Rocas frente a Bronzong y luego usa Encanto para bajar su Ataque. ❤️",
+      "variant": [
+        {
+          "detail": "Si Bronzong usa Cabezazo Zen o Terremoto, cambia a Slowbro. Frente a Nidoking, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Autodestrucción y entra Chansey, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Autodestrucción y entra Nidoking, usa Amortiguador hasta recuperar los PS al máximo."
+        },
+        {
+          "detail": "Si después de curarte el rival se queda, usa Teletransporte. Entra Slowbro, usa Bostezo, sacrifica a Politoed y termina con Poliwrath usando Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si cambia a Chansey, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    }
   ]
 }

--- a/src/data/kanto/lorelei/claydol.json
+++ b/src/data/kanto/lorelei/claydol.json
@@ -2,13 +2,16 @@
   "id": "claydol",
   "name": "Claydol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRAMPA ROCAS",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Después de poner Trampa Rocas: cambia a Cloyster y luego a Metagross.",
+      "detail": "Coloca Trampa Rocas frente a Lucario. Cuando entre Lapras, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Contra Lapras: usa Truco para bloquear Hidrobomba y luego cambia a Poliwrath +6 +2."
+          "detail": "Después saca a Politoed y deja que caiga para darle entrada segura a Poliwrath."
+        },
+        {
+          "detail": "Con Poliwrath en campo, usa Tambor para quedar en +6 Ataque y comienza a barrer. 🐸"
         }
       ]
     }

--- a/src/data/kanto/lorelei/dragonite.json
+++ b/src/data/kanto/lorelei/dragonite.json
@@ -2,22 +2,18 @@
   "id": "dragonite",
   "name": "Dragonite",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si Dragonite NO cambia: usa Poder Oculto con Chandelure. Repite Poder Oculto mientras Dragonite siga en campo.",
+      "detail": "Coloca Trampa Rocas frente a Lucario. Cuando entre Lapras, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Si luego entra Lapras: cambia a Poliwrath. Ejecuta la secuencia 6+2 indicada para Poliwrath. Si Lapras usa Rayo de forma inesperada, cambia a Excadrill y ejecuta 6+2."
+          "detail": "Después saca a Politoed y deja que caiga para darle entrada segura a Poliwrath."
         },
         {
-          "detail": "Si luego entra Lucario: cambia a Scrafty. Después vuelve a Chandelure, usa Truco para bloquear Triturar o Roca Afilada, y vuelve a sacar a Scrafty +2."
+          "detail": "Con Poliwrath en campo, usa Tambor para quedar en +6 Ataque y comienza a barrer. 🐸"
         }
       ]
-    },
-    {
-      "detail": "Si Dragonite cambia a Slowbro: usa Truco con Chandelure para bloquear Escaldar. Luego cambia a Poliwrath y ejecuta 6+2.",
-      "variant": []
     }
   ]
 }

--- a/src/utils/strategyText.ts
+++ b/src/utils/strategyText.ts
@@ -3,6 +3,8 @@ import type { Language } from '../i18n/translations'
 const moveTranslations: Array<[RegExp, string]> = [
   [/\bTRUCO\b/gi, 'Trick'],
   [/\bTruco\b/g, 'Trick'],
+  [/\bTRAMPA ROCAS\b/gi, 'Stealth Rock'],
+  [/\bTrampa Rocas\b/gi, 'Stealth Rock'],
   [/\bOTRA VEZ\b/gi, 'Encore'],
   [/\bOtra vez\b/gi, 'Encore'],
   [/\bMaquinaci[oó]n\b/gi, 'Nasty Plot'],
@@ -10,35 +12,66 @@ const moveTranslations: Array<[RegExp, string]> = [
   [/\bDanza Aleteo\b/gi, 'Quiver Dance'],
   [/\bVelocidad X\b/gi, 'X Speed'],
   [/\bPrecisi[oó]n X\b/gi, 'X Accuracy'],
+  [/\bEspecial X\b/gi, 'X Sp. Atk'],
   [/\bSurf\b/gi, 'Surf'],
   [/\bCar[aá]mbano\b/gi, 'Icicle Spear'],
   [/\bRoca Afilada\b/gi, 'Stone Edge'],
   [/\bTriturar\b/gi, 'Crunch'],
   [/\bTerremoto\b/gi, 'Earthquake'],
+  [/\bCabezazo Zen\b/gi, 'Zen Headbutt'],
+  [/\bGiro Bola\b/gi, 'Gyro Ball'],
+  [/\bAutodestrucci[oó]n\b/gi, 'Self-Destruct'],
   [/\bHuesomerang\b/gi, 'Bonemerang'],
   [/\bEscaldar\b/gi, 'Scald'],
   [/\bRayo\b/gi, 'Thunderbolt'],
   [/\bPoder Oculto\b/gi, 'Hidden Power'],
+  [/\bBostezo\b/gi, 'Yawn'],
+  [/\bAmortiguador\b/gi, 'Soft-Boiled'],
+  [/\bTeletransporte\b/gi, 'Teleport'],
+  [/\bPuño Drenaje\b/gi, 'Drain Punch'],
+  [/\bBola Sombra\b/gi, 'Shadow Ball'],
+  [/\bEncanto\b/gi, 'Charm'],
+]
+
+const itemTranslations: Array<[RegExp, string]> = [
+  [/\bLlamasfera\b/gi, 'Flame Orb'],
 ]
 
 const phraseTranslations: Array<[RegExp, string]> = [
   [/\bNO CAMBIA\b/g, 'DOES NOT SWITCH'],
   [/\bNo cambia\b/g, 'Does not switch'],
   [/\bSi utiliza\b/gi, 'If it uses'],
+  [/\bSi usa\b/gi, 'If it uses'],
   [/\bSi cambia a\b/gi, 'If it switches to'],
+  [/\bSi entra\b/gi, 'If it comes in'],
+  [/\bSi tiene\b/gi, 'If it has'],
+  [/\bSi no tiene\b/gi, 'If it does not have'],
   [/\bcambia a\b/gi, 'switch to'],
+  [/\bCambia a\b/g, 'Switch to'],
   [/\bsaca a\b/gi, 'send out'],
+  [/\bSacrifica a\b/g, 'Sacrifice'],
   [/\bsacrifica a\b/gi, 'sacrifice'],
   [/\bsacrificar a\b/gi, 'sacrifice'],
   [/\bsacrifica\b/gi, 'sacrifice'],
-  [/\butiliza\b/gi, 'use'],
+  [/\bdeja que caiga\b/gi, 'let it faint'],
   [/\busa\b/gi, 'use'],
+  [/\bUsa\b/g, 'Use'],
+  [/\butiliza\b/gi, 'use'],
+  [/\bpara quedar en\b/gi, 'to reach'],
+  [/\bAtaque Especial\b/gi, 'Special Attack'],
+  [/\bAtaque\b/gi, 'Attack'],
+  [/\bVelocidad\b/gi, 'Speed'],
+  [/\bPS al máximo\b/gi, 'full HP'],
+  [/\bPS\b/g, 'HP'],
+  [/\bbarrer\b/gi, 'sweep'],
+  [/\bbarre\b/gi, 'sweep'],
   [/\bpara luego volver con\b/gi, 'then go back to'],
   [/\bsi a[uú]n sigue en el campo y no cambia\b/gi, 'if it is still on the field and does not switch'],
   [/\bsi sorpresivamente utiliza\b/gi, 'if it unexpectedly uses'],
   [/\bsi .* esta bloqueado usa\b/gi, 'if the locked move is unavailable, use'],
   [/\bencerrar en\b/gi, 'lock into'],
   [/\bcontra\b/gi, 'against'],
+  [/\bfrente a\b/gi, 'against'],
 ]
 
 const regionTranslations: Array<[RegExp, string]> = [
@@ -48,7 +81,7 @@ const regionTranslations: Array<[RegExp, string]> = [
 export const translateStrategyText = (text: string, language: Language) => {
   if (language === 'es') return text
 
-  return [...moveTranslations, ...phraseTranslations, ...regionTranslations]
+  return [...moveTranslations, ...itemTranslations, ...phraseTranslations, ...regionTranslations]
     .reduce((currentText, [pattern, replacement]) => currentText.replace(pattern, replacement), text)
 }
 


### PR DESCRIPTION
## Summary
- Updates Lorelei strategy text for Articuno, Bronzong, Chansey, Claydol, and Dragonite.
- Makes the routes more explicit and easier to follow turn by turn.
- Expands contextual boost wording:
  - Poliwrath +6 = Belly Drum to +6 Attack.
  - Gengar 4+2 = Nasty Plot to +4 Special Attack plus X Speed to +2 Speed.
  - Volcarona +1/+2 = Quiver Dance x1/x2.
- Adds Spanish-to-English strategy translations for the new move and item terms.

## Notes
- This PR targets `develop`.
- No visual assets are changed in this PR.
- No deploy to `main` is included yet, so the strategies can be reviewed first.

Refs #16
Refs #32