### PR TITLE
Complete Kanto Lorelei strategies

### DIFF
--- a/src/data/kanto/lorelei/exeggutor.json
+++ b/src/data/kanto/lorelei/exeggutor.json
@@ -1,10 +1,41 @@
 {
-    "id": "exeggutor",
-    "name": "Exeggutor",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "TRUCO",
-    "tricks": [
-        {"detail": "MAGNEZONE → Excadrill coloca Trampa Rocas, luego Terremoto lo mata. / Frente a Lapras, Poliwrath +6+2 (no necesita Puño Hielo)", "variant": []},
-        {"detail": "NIDOKING → Excadrill coloca Trampa Rocas, luego Cloyster +6", "variant": []}
-    ]
+  "id": "exeggutor",
+  "name": "Exeggutor",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas. 🔔 Si Exeggutor no cambia, usa Amortiguador para mantener a Chansey sana. 🔔",
+      "variant": [
+        {
+          "detail": "Si entra Lapras, cambia a Politoed. Luego cambia a Slowbro cuando salga Mantine."
+        },
+        {
+          "detail": "Con Slowbro frente a Mantine, usa Bostezo. Cuando salga Magnezone, sacrifica a Poliwrath para darle entrada segura a Volcarona."
+        },
+        {
+          "detail": "Con Volcarona, usa Danza Aleteo x1 y Especial X. 🔔 Usa Psíquico contra Mantine. 🔔"
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Golduck, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Si Golduck se queda, cambia a Slowbro cuando salga Mantine. Usa Bostezo frente a Magnezone, sacrifica a Poliwrath y entra con Volcarona."
+        },
+        {
+          "detail": "Con Volcarona, usa Danza Aleteo x1 y Especial X. 🔔 Usa Psíquico contra Mantine. 🔔"
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Lapras directamente, cambia a Slowbro y usa Bostezo frente a Magnezone.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Poliwrath y entra con Volcarona. Usa Danza Aleteo x2 y Especial X. 🔔 Usa Psíquico contra Mantine. 🔔"
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/kanto/lorelei/golduck.json
+++ b/src/data/kanto/lorelei/golduck.json
@@ -2,9 +2,21 @@
   "id": "golduck",
   "name": "Golduck",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
-    {"detail": "Si cambia a Magneton / Magnezone, cambia a Excadrill,trampa rocas y matalo con Terremoto, debería de salir Lapras, cambia a Poliwrath 6+2", "variant": []},
-    {"detail": "Si cambia a Nidoking, cambia a Cloyster +6", "variant": []}
+    {
+      "detail": "Coloca Trampa Rocas y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro cuando entre Mantine. Usa Bostezo frente a Magnezone y sacrifica a Poliwrath para darle entrada segura a Volcarona."
+        },
+        {
+          "detail": "Con Volcarona, usa Danza Aleteo x1 y Especial X. 🔔 Usa Psíquico contra Mantine. 🔔"
+        },
+        {
+          "detail": "Después de Mantine, usa Revivir Hierba en Poliwrath, una Medicina Pequeña y continúa la ruta."
+        }
+      ]
+    }
   ]
 }

--- a/src/data/kanto/lorelei/golurk.json
+++ b/src/data/kanto/lorelei/golurk.json
@@ -2,18 +2,10 @@
   "id": "golurk",
   "name": "Golurk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "👀",
   "tricks": [
     {
-      "detail": "Si cambia a Magneton o Magnezone: cambia a Excadrill y debilítalo con Terremoto.",
-      "variant": [
-        {
-          "detail": "Después debería entrar Lapras: cambia a Poliwrath 6+2."
-        }
-      ]
-    },
-    {
-      "detail": "Si cambia a Nidoking: cambia a Cloyster +6.",
+      "detail": "U cant see me",
       "variant": []
     }
   ]

--- a/src/data/kanto/lorelei/hariyama.json
+++ b/src/data/kanto/lorelei/hariyama.json
@@ -2,21 +2,16 @@
   "id": "hariyama",
   "name": "Hariyama",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🐌 Cambia a Slowbro",
   "tricks": [
     {
-      "detail": "SI NO CAMBIA utiliza Truco para encerrar en Roca Afilada, cambia a Scrafty +3 (Utiliza A Bocajarro contra Hariyama y Gliscor)(Puño Drenaje contra Lapras)",
+      "detail": "Cambia a Slowbro y usa Bostezo para dormir la amenaza.",
       "variant": [
         {
-          "detail": "Si Entra Nidoking, cambia a Excadrill y luego cambia a Chandelure para usar Truco y encerrar Tierra viva, vuelve a Excadrill 4+2"
-        }
-      ]
-    },
-    {
-      "detail": "NIDOKING, utiliza Truco para encerrar en Tierra Viva, cambia a Excadrill 4+2 (Utiliza Terremoto para acabar con Lapras)",
-      "variant": [
+          "detail": "Después saca a Politoed y deja que caiga para darle entrada segura a Poliwrath."
+        },
         {
-          "detail": "Si entra Lapras mientras te preparas, cambia a Poliwrath 6+2"
+          "detail": "Con Poliwrath, usa Tambor para quedar en +6 Ataque. 🐸 Usa Puño Drenaje contra Jynx."
         }
       ]
     }

--- a/src/data/kanto/lorelei/jynx.json
+++ b/src/data/kanto/lorelei/jynx.json
@@ -2,11 +2,18 @@
   "id": "jynx",
   "name": "Jynx",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A SCRAFTY +2",
+  "initialMove": "Cambia a Slowbro",
   "tricks": [
     {
-      "detail": "Con Scrafty preparado: usa A Bocajarro contra Hariyama, Paliza contra Togekiss y Puño Drenaje contra Lapras.",
-      "variant": []
+      "detail": "Cambia a Slowbro. Cuando salga Hariyama, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Después saca a Politoed y deja que caiga para darle entrada segura a Poliwrath."
+        },
+        {
+          "detail": "Con Poliwrath, usa Tambor para quedar en +6 Ataque. 🐸 Usa Puño Drenaje contra Jynx."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/lorelei/lapras.json
+++ b/src/data/kanto/lorelei/lapras.json
@@ -2,84 +2,96 @@
   "id": "lapras",
   "name": "Lapras",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRAMPA ROCAS",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Surf → cambia a Poliwrath y ejecuta 6+2.",
+      "detail": "Coloca Trampa Rocas. Si Lapras se queda en campo, revisa su movimiento.",
       "variant": [
         {
-          "detail": "Si entra Slowbro: cambia a Chandelure, usa Truco para bloquear Escaldar y luego vuelve a Poliwrath 6+2."
-        }
-      ]
-    },
-    {
-      "detail": "Rayo → cambia a Excadrill y ejecuta 6+2.",
-      "variant": [
-        {
-          "detail": "Si entra Slowbro: cambia a Chandelure, usa Truco para bloquear Escaldar y luego vuelve a Poliwrath 6+2."
-        }
-      ]
-    },
-    {
-      "detail": "Taladradora → cambia a Excadrill y pon Trampa Rocas. Luego cambia a Chandelure, usa Truco sobre Mantine y saca a Scrafty +2.",
-      "variant": [
-        {
-          "detail": "Contra Mantine: necesitas golpearlo 2 veces. Si recibes un crítico y quedas en riesgo, usa Raíz Energía."
-        }
-      ]
-    },
-    {
-      "detail": "Hidrobomba → usa Trampa Rocas. Luego cambia a Poliwrath, usa Tambor 2 veces y usa Velocidad X.",
-      "variant": [
-        {
-          "detail": "Si Metagross no aguanta y no alcanza a poner Trampa Rocas: usa Defensa X en Poliwrath y luego usa 2 Tambores."
+          "detail": "Si usa Rayo Hielo, sacrifica a Politoed. Luego entra con Poliwrath, usa Tambor para quedar en +6 Ataque y usa Cascada contra Banette. 🔔 Si un Rayo Hielo crítico debilita a Poliwrath, cambia de estrategia. 🔔"
         },
         {
-          "detail": "Si Lucario debilita a Poliwrath: saca a Chandelure, usa Truco para bloquear Triturar o Roca Afilada, y luego saca a Scrafty +2."
-        }
-      ]
-    },
-    {
-      "detail": "Nidoqueen → revisa el objeto que recibió con Truco.",
-      "variant": [
-        {
-          "detail": "Vidasfera → cambia a Excadrill 6+2. Usa Terremoto para debilitar a Lapras cuando corresponda."
+          "detail": "Si usa Acua Cola, cambia a Politoed. Luego cambia a Slowbro y espera a Mantine. Usa Bostezo frente a Magnezone, sacrifica a Poliwrath y entra con Volcarona."
         },
         {
-          "detail": "Casco Dentado → cambia a Excadrill, pon Trampa Rocas y ejecuta 4+2. Usa Terremoto para debilitar a Nidoqueen."
+          "detail": "Con Volcarona, usa Danza Aleteo x1 y Especial X. 🔔 Usa Psíquico contra Mantine. 🔔"
         }
       ]
     },
     {
-      "detail": "Nidoking → cambia a Excadrill para poner Trampa Rocas. Luego cambia a Cloyster +6.",
-      "variant": []
-    },
-    {
-      "detail": "Slowbro → cambia a Chandelure y usa Poder Oculto para bajar la vida de Dragonite. Luego cambia a Excadrill.",
+      "detail": "Si entra Golduck, cambia a Gengar.",
       "variant": [
         {
-          "detail": "Si después entra Lapras o Slowbro: cambia a Poliwrath y ejecuta 6+2."
+          "detail": "Si Golduck se queda, cambia a Slowbro y espera a Mantine. Usa Bostezo frente a Magnezone, sacrifica a Poliwrath y entra con Volcarona."
         },
         {
-          "detail": "Si entra Lucario: cambia a Chandelure, usa Truco para bloquear Triturar o Roca Afilada, y luego cambia a Scrafty +2."
+          "detail": "Con Volcarona, usa Danza Aleteo x1 y Especial X. 🔔 Usa Psíquico contra Mantine, da Revivir Hierba a Poliwrath, usa una Medicina Pequeña y continúa. 🔔"
         }
       ]
     },
     {
-      "detail": "Blissey / Jigglypuff → cambia a Chandelure y usa Truco para bloquear Tierra Viva de Nidoking. Luego cambia a Excadrill +6.",
-      "variant": []
-    },
-    {
-      "detail": "Magnezone → cambia a Excadrill, pon Trampa Rocas y usa Terremoto para debilitar a Magnezone.",
+      "detail": "Si entra Lapras, cambia a Slowbro y usa Bostezo frente a Magnezone.",
       "variant": [
         {
-          "detail": "Si después entra Lapras: cambia a Poliwrath 6+2."
+          "detail": "Sacrifica a Poliwrath y entra con Volcarona. Usa Danza Aleteo x2 y Especial X. 🔔 Usa Psíquico contra Mantine, da Revivir Hierba a Poliwrath, usa una Medicina Pequeña y continúa. 🔔"
         }
       ]
     },
     {
-      "detail": "Bronzong → saca a Excadrill 6+2 y luego pon Trampa Rocas.",
-      "variant": []
+      "detail": "Si entra Hariyama, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si después entra Nidoking, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🔔 Usa Puño Drenaje contra Jynx. 🔔"
+        },
+        {
+          "detail": "Si después entra Jynx, entra con Volcarona y usa Danza Aleteo x2."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Lucario, elige la ruta según su objeto.",
+      "variant": [
+        {
+          "detail": "Ruta rápida: usa Teletransporte para revisar el objeto."
+        },
+        {
+          "detail": "Si tiene Vidasfera, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para quedar en +2 Velocidad. Barre con Bola Sombra."
+        },
+        {
+          "detail": "Si no tiene Vidasfera, envía a Slowbro y usa Bostezo frente a Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si quieres ahorrar dinero, entra con Gengar, usa Otra Vez y Maquinación hasta +2. Si Lucario se queda, sube con Maquinación hasta +4 y usa Velocidad X para quedar en +2 Velocidad. Barre con Bola Sombra."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Mantine, cambia a Chansey y usa Amortiguador frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Luego entra con Gengar, usa Maquinación hasta +4 y Velocidad X para quedar en +2 Velocidad. 🔔 Barre con Bola Sombra. 🔔"
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Bronzong, usa Encanto con Chansey.",
+      "variant": [
+        {
+          "detail": "Si usa un ataque Psíquico o de tipo Tierra, cambia a Slowbro y usa Bostezo frente a Nidoking. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Autodestrucción y entra Chansey, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Autodestrucción y entra Nidoking, usa Amortiguador con Chansey hasta quedar con PS al máximo."
+        },
+        {
+          "detail": "Si Bronzong se queda, usa Teletransporte. Entra Slowbro, usa Bostezo, sacrifica a Politoed y termina con Poliwrath usando Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si entra Chansey, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/lorelei/lucario.json
+++ b/src/data/kanto/lorelei/lucario.json
@@ -2,24 +2,22 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "Gengar + Otra Vez",
   "tricks": [
     {
-      "detail": "Si Lucario cambia a Nidoking: usa Truco con Chandelure para bloquear un movimiento tipo Tierra. Luego cambia a Cloyster +6.",
+      "detail": "Entra con Gengar, usa Otra Vez y luego cambia a Slowbro para revisar el objeto de Lucario.",
       "variant": [
         {
-          "detail": "Cuando vuelva Lucario, usa Carámbano con Cloyster."
+          "detail": "Si tiene Vidasfera, cambia a Chansey. Cuando salga Lapras, coloca Trampa Rocas. Cuando vuelva Lucario, cambia a Slowbro y usa Bostezo."
         },
         {
-          "detail": "Ten en cuenta que existe una pequeña posibilidad de no debilitar a Lapras."
-        }
-      ]
-    },
-    {
-      "detail": "Si Lucario se queda en campo: usa Truco con Chandelure para bloquear Triturar o Roca Afilada. Luego cambia a Scrafty +3.",
-      "variant": [
+          "detail": "Si Lucario se queda, usa Teletransporte hacia Volcarona. Usa Danza Aleteo x1, derrótalo y cuando salga Dragonite usa Especial X. Mantén los PS sobre 35%."
+        },
         {
-          "detail": "Si Chandelure cae debilitado antes de terminar la ruta, usa 1 Danza Dragón extra con Scrafty."
+          "detail": "Si después sale Lapras, usa Volcarona con Danza Aleteo x2. Mantén los PS sobre 46%."
+        },
+        {
+          "detail": "Si no tiene Vidasfera, cambia a Chansey y coloca Trampa Rocas. Luego cambia a Slowbro y usa Bostezo. Cuando salga Lapras, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     }

--- a/src/data/kanto/lorelei/magnezone.json
+++ b/src/data/kanto/lorelei/magnezone.json
@@ -2,10 +2,29 @@
   "id": "magnezone",
   "name": "Magnezone",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRAMPA ROCAS",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
-    {"detail": "Lapras → Dragonite +3 (No encares)", "variant": []},
-    {"detail": "Golduck → Gengar encara y +6", "variant": []
+    {
+      "detail": "Coloca Trampa Rocas y mantén Amortiguador hasta que el rival cambie.",
+      "variant": [
+        {
+          "detail": "Si entra Golduck, cambia a Gengar."
+        },
+        {
+          "detail": "Si Golduck se queda, cambia a Slowbro. Cuando salga Mantine, usa Bostezo. Frente a Magnezone, sacrifica a Poliwrath y entra con Volcarona."
+        },
+        {
+          "detail": "Con Volcarona, usa Danza Aleteo x1 y Especial X. 🔔 Usa Psíquico contra Mantine. 🔔"
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Lapras, cambia a Slowbro y usa Bostezo frente a Magnezone.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Poliwrath y entra con Volcarona. Usa Danza Aleteo x2 y Especial X. 🔔 Usa Psíquico contra Mantine. 🔔"
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/lorelei/mantine.json
+++ b/src/data/kanto/lorelei/mantine.json
@@ -2,73 +2,60 @@
   "id": "mantine",
   "name": "Mantine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRAMPA ROCAS",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si entra Lapras: cambia a Poliwrath. Si luego entra Slowbro y después sale Mantine, usa Bostezo.",
+      "detail": "Si entra Lapras, cambia a Poliwrath y luego cambia a Slowbro. Cuando salga Mantine, usa Bostezo.",
       "variant": [
         {
-          "detail": "Si frente a Mantine sale Magnezone: sacrifica a Poliwrath. Luego entra con Volcarona, usa Danza Aleteo +1 y usa Ataque Especial X."
+          "detail": "Cuando salga Magnezone, sacrifica a Poliwrath y entra con Volcarona. Usa Danza Aleteo x1 y Especial X."
         }
       ]
     },
     {
-      "detail": "Si entra Lucario: cambia a Slowbro y usa Bostezo.",
+      "detail": "Si entra Lucario, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath y usa Tambor +6."
+          "detail": "Después saca a Politoed y deja que caiga. Entra con Poliwrath y usa Tambor hasta +6 Ataque."
         }
       ]
     },
     {
-      "detail": "Si entra Bronzong: usa Encanto.",
-      "variant": []
-    },
-    {
-      "detail": "Si recibe un ataque tipo Psíquico o Tierra: cambia a Slowbro y usa Bostezo.",
+      "detail": "Si entra Bronzong, usa Encanto con Chansey.",
       "variant": [
         {
-          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath y usa Tambor +6."
+          "detail": "Si Bronzong usa un ataque Psíquico o de tipo Tierra, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Explosión y entra Chansey, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Explosión y entra Nidoking, usa Amortiguador con Chansey hasta quedar con PS al máximo."
+        },
+        {
+          "detail": "Si Bronzong se queda, usa Teletransporte hacia Slowbro. Usa Bostezo, sacrifica a Politoed y termina con Poliwrath usando Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si entra Chansey, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     },
     {
-      "detail": "Si usa Explosión y luego sale Chansey: saca a Politoed para sacrificarlo. Después entra con Poliwrath y usa Tambor +6.",
-      "variant": []
-    },
-    {
-      "detail": "Si usa Explosión y luego sale Nidoking: usa Amortiguador hasta quedar con PS al máximo.",
-      "variant": []
-    },
-    {
-      "detail": "Si Mantine se queda en campo: usa Teletransporte hacia Slowbro y luego usa Bostezo.",
+      "detail": "Si entra Golduck, cambia a Gengar.",
       "variant": [
         {
-          "detail": "Luego saca a Politoed para sacrificarlo. Después entra con Poliwrath y usa Tambor +6."
+          "detail": "Si Golduck se queda, cambia a Slowbro cuando salga Mantine. Usa Bostezo frente a Magnezone, sacrifica a Poliwrath y entra con Volcarona."
+        },
+        {
+          "detail": "Con Volcarona, usa Danza Aleteo x1 y Especial X."
         }
       ]
     },
     {
-      "detail": "Si sale Chansey: saca a Politoed para sacrificarlo. Después entra con Poliwrath y usa Tambor +6.",
-      "variant": []
-    },
-    {
-      "detail": "Si sale Golduck: cambia a Gengar.",
-      "variant": []
-    },
-    {
-      "detail": "Si el rival se queda después de Golduck: cambia a Slowbro. Si luego sale Mantine, usa Bostezo.",
+      "detail": "Si entra Lapras después de Golduck, cambia a Slowbro y usa Bostezo frente a Magnezone.",
       "variant": [
         {
-          "detail": "Frente a Magnezone: sacrifica a Poliwrath. Luego entra con Volcarona, usa Danza Aleteo +1 y usa Ataque Especial X."
-        }
-      ]
-    },
-    {
-      "detail": "Si sale Lapras después de Golduck: cambia a Slowbro y usa Bostezo frente a Magnezone.",
-      "variant": [
-        {
-          "detail": "Luego sacrifica a Poliwrath. Después entra con Volcarona, usa Danza Aleteo +2 y usa Ataque Especial X."
+          "detail": "Sacrifica a Poliwrath y entra con Volcarona. Usa Danza Aleteo x2 y Especial X."
         }
       ]
     }

--- a/src/data/kanto/lorelei/nidoking.json
+++ b/src/data/kanto/lorelei/nidoking.json
@@ -2,8 +2,62 @@
   "id": "nidoking",
   "name": "Nidoking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
-    {"detail": "Cambia a Excadrill y utiliza Trampa Rocas, luego cambia a Cloyster +6", "variant": []}
+    {
+      "detail": "Si entra Lapras, cambia a Poliwrath y luego cambia a Slowbro. Cuando salga Mantine, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Cuando salga Magnezone, sacrifica a Poliwrath y entra con Volcarona. Usa Danza Aleteo x1 y Especial X."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Golduck, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Si Golduck se queda, cambia a Slowbro cuando salga Mantine. Usa Bostezo frente a Magnezone, sacrifica a Poliwrath y entra con Volcarona."
+        },
+        {
+          "detail": "Con Volcarona, usa Danza Aleteo x1 y Especial X."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Lapras después de Golduck, cambia a Slowbro y usa Bostezo frente a Magnezone.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Poliwrath y entra con Volcarona. Usa Danza Aleteo x2 y Especial X."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Bronzong, usa Encanto con Chansey.",
+      "variant": [
+        {
+          "detail": "Si Bronzong usa un ataque Psíquico o de tipo Tierra, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Explosión y entra Chansey, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Explosión y entra Nidoking, usa Amortiguador con Chansey hasta quedar con PS al máximo."
+        },
+        {
+          "detail": "Si Bronzong se queda, usa Teletransporte hacia Slowbro. Usa Bostezo, sacrifica a Politoed y termina con Poliwrath usando Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si entra Chansey, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Lucario, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Después saca a Politoed y deja que caiga. Entra con Poliwrath y usa Tambor hasta +6 Ataque."
+        }
+      ]
+    }
   ]
 }

--- a/src/data/kanto/lorelei/nidoqueen.json
+++ b/src/data/kanto/lorelei/nidoqueen.json
@@ -2,13 +2,16 @@
   "id": "nidoqueen",
   "name": "Nidoqueen",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Cambia a Slowbro",
   "tricks": [
     {
-      "detail": "Después de Truco: cambia a Excadrill 6+2. Usa Terremoto para debilitar a Lapras cuando corresponda.",
+      "detail": "Cambia a Slowbro. Cuando salga Hariyama, usa Bostezo.",
       "variant": [
         {
-          "detail": "Si Lapras aparece mientras preparas a Excadrill: cambia a Poliwrath 6+2."
+          "detail": "Si entra Nidoking, saca a Politoed y deja que caiga. Luego entra con Poliwrath y usa Tambor hasta +6 Ataque. 🔔 Usa Piel Seca contra Jynx. 🔔"
+        },
+        {
+          "detail": "Si entra Jynx, entra con Volcarona y usa Danza Aleteo x3."
         }
       ]
     }

--- a/src/data/kanto/lorelei/raichu.json
+++ b/src/data/kanto/lorelei/raichu.json
@@ -2,11 +2,18 @@
   "id": "raichu",
   "name": "Raichu",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Con Chandelure: usa Truco para bloquear Escaldar de Slowbro. Luego cambia a Poliwrath 6+2.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Cuando salga Lucario, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para quedar en +2 Velocidad."
+        },
+        {
+          "detail": "Mantén Otra Vez cada vez que puedas para controlar al rival. Cuando Gengar esté listo, barre con Bola Sombra."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/lorelei/togekiss.json
+++ b/src/data/kanto/lorelei/togekiss.json
@@ -2,29 +2,16 @@
   "id": "togekiss",
   "name": "Togekiss",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "Cambia a Slowbro",
   "tricks": [
     {
-      "detail": "Si entra Nidoking o Nidoqueen: usa Truco con Chandelure para bloquear un movimiento tipo Tierra. Luego entra con Excadrill 6+2.",
+      "detail": "Cambia a Slowbro. Cuando salga Hariyama, usa Bostezo.",
       "variant": [
         {
-          "detail": "Usa Terremoto para debilitar a Lapras cuando corresponda."
-        }
-      ]
-    },
-    {
-      "detail": "Si entra Hariyama: usa Truco con Chandelure para bloquear Roca Afilada. Luego cambia a Scrafty +3.",
-      "variant": [
+          "detail": "Después saca a Politoed y deja que caiga. Entra con Poliwrath y usa Tambor hasta +6 Ataque."
+        },
         {
-          "detail": "Con Scrafty: usa A Bocajarro contra Hariyama, Puño Drenaje contra Lapras y Paliza contra Nidoqueen."
-        }
-      ]
-    },
-    {
-      "detail": "Si Togekiss no cambia: usa Lanzallamas para bajarle vida. Luego cambia a Scrafty y vuelve a Chandelure para usar Truco y bloquear Roca Afilada.",
-      "variant": [
-        {
-          "detail": "Después saca a Scrafty +3. Usa A Bocajarro contra Conkeldurr, Puño Drenaje contra Lapras y Paliza contra Gliscor."
+          "detail": "🔔 Usa Piel Seca contra Jynx. 🔔"
         }
       ]
     }

--- a/src/data/kanto/lorelei/vileplume.json
+++ b/src/data/kanto/lorelei/vileplume.json
@@ -2,8 +2,27 @@
   "id": "vileplume",
   "name": "Vileplume",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
-    {"detail": "Utiliza Lanzallamas para derrotar, saldrá Bronzong así que cambia a Excadrill 6+2 y Trampa Rocas", "variant": []}
+    {
+      "detail": "Coloca Trampa Rocas. Cuando salga Bronzong, usa Encanto con Chansey.",
+      "variant": [
+        {
+          "detail": "Si Bronzong usa un ataque Psíquico o Terremoto, cambia a Slowbro y usa Bostezo. Cuando salga Nidoking, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Explosión y entra Chansey, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Explosión y entra Nidoking, usa Amortiguador con Chansey hasta quedar con PS al máximo."
+        },
+        {
+          "detail": "Si Bronzong se queda, usa Teletransporte hacia Slowbro. Usa Bostezo, sacrifica a Politoed y termina con Poliwrath usando Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si entra Chansey, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    }
   ]
 }

--- a/src/utils/strategyText.ts
+++ b/src/utils/strategyText.ts
@@ -21,9 +21,13 @@ const moveTranslations: Array<[RegExp, string]> = [
   [/\bCabezazo Zen\b/gi, 'Zen Headbutt'],
   [/\bGiro Bola\b/gi, 'Gyro Ball'],
   [/\bAutodestrucci[oó]n\b/gi, 'Self-Destruct'],
+  [/\bExplosi[oó]n\b/gi, 'Explosion'],
   [/\bHuesomerang\b/gi, 'Bonemerang'],
   [/\bEscaldar\b/gi, 'Scald'],
+  [/\bRayo Hielo\b/gi, 'Ice Beam'],
   [/\bRayo\b/gi, 'Thunderbolt'],
+  [/\bAcua Cola\b/gi, 'Aqua Tail'],
+  [/\bCascada\b/gi, 'Waterfall'],
   [/\bPoder Oculto\b/gi, 'Hidden Power'],
   [/\bBostezo\b/gi, 'Yawn'],
   [/\bAmortiguador\b/gi, 'Soft-Boiled'],
@@ -31,10 +35,18 @@ const moveTranslations: Array<[RegExp, string]> = [
   [/\bPuño Drenaje\b/gi, 'Drain Punch'],
   [/\bBola Sombra\b/gi, 'Shadow Ball'],
   [/\bEncanto\b/gi, 'Charm'],
+  [/\bPs[ií]quico\b/gi, 'Psychic'],
 ]
 
 const itemTranslations: Array<[RegExp, string]> = [
   [/\bLlamasfera\b/gi, 'Flame Orb'],
+  [/\bVidasfera\b/gi, 'Life Orb'],
+  [/\bRevivir Hierba\b/gi, 'Revival Herb'],
+  [/\bMedicina Pequeña\b/gi, 'Small Medicine'],
+]
+
+const abilityTranslations: Array<[RegExp, string]> = [
+  [/\bPiel Seca\b/gi, 'Dry Skin'],
 ]
 
 const phraseTranslations: Array<[RegExp, string]> = [
@@ -72,6 +84,7 @@ const phraseTranslations: Array<[RegExp, string]> = [
   [/\bencerrar en\b/gi, 'lock into'],
   [/\bcontra\b/gi, 'against'],
   [/\bfrente a\b/gi, 'against'],
+  [/\btipo Tierra\b/gi, 'Ground-type'],
 ]
 
 const regionTranslations: Array<[RegExp, string]> = [
@@ -81,7 +94,7 @@ const regionTranslations: Array<[RegExp, string]> = [
 export const translateStrategyText = (text: string, language: Language) => {
   if (language === 'es') return text
 
-  return [...moveTranslations, ...itemTranslations, ...phraseTranslations, ...regionTranslations]
+  return [...moveTranslations, ...itemTranslations, ...abilityTranslations, ...phraseTranslations, ...regionTranslations]
     .reduce((currentText, [pattern, replacement]) => currentText.replace(pattern, replacement), text)
 }
 


### PR DESCRIPTION
## Summary
- Completes the remaining Kanto Lorelei strategy files.
- Updates Exeggutor, Golduck, Golurk, Hariyama, Jynx, Lapras, Lucario, Magnezone, Mantine, Nidoking, Nidoqueen, Raichu, Togekiss, and Vileplume.
- Keeps the boost wording consistent:
  - Gengar uses Nasty Plot as `+2`, `+4`, or `+6` without repeating Special Attack.
  - X Speed remains explicit as `+2 Speed`.
  - Poliwrath uses Belly Drum to `+6 Attack`.
  - Volcarona uses Quiver Dance x1/x2/x3.
- Adds the remaining Spanish-to-English translations needed by the new Lorelei text.

## Notes
- This PR targets `develop`.
- No visual assets are changed in this PR.
- No release to `main` is included yet.

Refs #16
Refs #32