### PR TITLE
Recover GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build
         run: npm run build
@@ -46,10 +46,8 @@ jobs:
     name: Deploy to GitHub Pages
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Deploy to GitHub Pages
-        id: deployment
         uses: actions/deploy-pages@v5

--- a/package.json
+++ b/package.json
@@ -12,23 +12,23 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^19.2.5",
+    "react-dom": "^18.2.0",
     "lucide-react": "^0.292.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.45",
-    "@types/react-dom": "^19.2.3",
-    "@typescript-eslint/eslint-plugin": "^8.59.1",
+    "@types/react-dom": "^18.2.18",
+    "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "@vitejs/plugin-react": "^4.2.1",
-    "autoprefixer": "^10.5.0",
+    "autoprefixer": "^10.4.21",
     "eslint": "^8.54.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint-plugin-react-refresh": "^0.4.5",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5",
     "typescript": "^5.2.2",
-    "vite": "^8.0.10"
+    "vite": "^5.0.11"
   }
 }


### PR DESCRIPTION
## Summary
- Aligns React and React DOM dependencies back to React 18.
- Aligns React DOM types with React 18.
- Uses a stable Vite 5 version instead of the broken Vite 8 range.
- Switches the Pages workflow install step from `npm ci` to `npm install` so the deploy can recover even while the lockfile is out of sync.

## Notes
- This PR targets `main` directly because the public deploy is currently broken.
- After the deploy is recovered, we can clean up the lockfile properly in a separate PR.