### PR TITLE
Update Kanto Bruno strategies

### DIFF
--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -1,5 +1,6 @@
 import type { Pokemon } from '../interfaces/Pokemon'
 import type { Language, TranslationLabels } from '../i18n/translations'
+import { translateExactStrategyText } from '../utils/exactStrategyTranslations'
 import { formatStrategyText, translateStrategyText } from '../utils/strategyText'
 import { TrickItem } from './TrickItem'
 
@@ -10,7 +11,9 @@ interface PokemonDetailsProps {
 }
 
 export const PokemonDetails = ({ pokemon, language, labels }: PokemonDetailsProps) => {
-  const initialMove = formatStrategyText(translateStrategyText(pokemon.initialMove, language))
+  const initialMove = formatStrategyText(
+    translateStrategyText(translateExactStrategyText(pokemon.initialMove, language), language),
+  )
 
   return (
     <section className="animate-in slide-in-from-bottom duration-300 rounded-[2rem] border border-white/10 bg-slate-950/70 p-5 shadow-2xl shadow-black/30 backdrop-blur-xl sm:p-6">

--- a/src/components/TrickItem.tsx
+++ b/src/components/TrickItem.tsx
@@ -2,6 +2,7 @@ import { ChevronRight, ChevronDown } from "lucide-react"
 import { useState } from "react"
 import type { Language } from "../i18n/translations"
 import type { Tricks } from "../interfaces/Pokemon"
+import { translateExactStrategyText } from "../utils/exactStrategyTranslations"
 import { formatStrategyText, translateStrategyText } from "../utils/strategyText"
 
 interface TrickItemProps {
@@ -14,7 +15,9 @@ export function TrickItem({ trick, language, level = 0 }: TrickItemProps) {
   const variants = trick.variant || []
   const hasVariants = variants.length > 0
   const [isExpanded, setIsExpanded] = useState(level === 0)
-  const strategyText = formatStrategyText(translateStrategyText(trick.detail, language))
+  const strategyText = formatStrategyText(
+    translateStrategyText(translateExactStrategyText(trick.detail, language), language),
+  )
 
   const toggleExpand = () => {
     setIsExpanded(!isExpanded)

--- a/src/data/kanto/bruno/aggron.json
+++ b/src/data/kanto/bruno/aggron.json
@@ -2,11 +2,18 @@
   "id": "aggron",
   "name": "Aggron",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "Encanto",
   "tricks": [
     {
-      "detail": "Chandelure +4+0 con la vida curada al máximo, utiliza Lanzallamas para barrer todo el equipo. (Si Chandelure muere por Hitmonchan, saca a Cloyster +4)",
-      "variant": []
+      "detail": "Usa Encanto frente a Aggron. Luego toma una Max Poción y usa Amortiguador para mantener a Chansey sana.",
+      "variant": [
+        {
+          "detail": "Cuando salga Hitmonchan, entra con Gengar y usa Maquinación hasta +4. No es necesario usar Otra Vez."
+        },
+        {
+          "detail": "Cuando Gengar esté listo, barre con Bola Sombra."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/bruno/blastoise.json
+++ b/src/data/kanto/bruno/blastoise.json
@@ -2,15 +2,38 @@
   "id": "blastoise",
   "name": "Blastoise",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "USAR TRAMPA ROCAS",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "TORTERRA→ Cambia a Cloyster, luego a Metagross con Truco, bloquea Terremoto, Cloyster +4 + Especial X",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Machamp, cambia a Gengar y luego a Slowbro. Usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si entra Hitmonlee, cambia a Gengar y luego a Slowbro. Si Hitmonlee se queda, usa Bostezo."
+        },
+        {
+          "detail": "Si entra Electivire, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si entra Blastoise, entra con Volcarona y usa Danza Aleteo x1."
+        }
+      ]
     },
     {
-      "detail": "NO CAMBIA→ Poliwrath 6+2+6",
-      "variant": []
+      "detail": "Si entra Darmanitan, elige una de estas rutas.",
+      "variant": [
+        {
+          "detail": "Ruta ahorro: entra con Volcarona y usa Danza Aleteo x3. ⚠️ Cuidado con un Fuerza Bruta crítico: puede dejarte cerca de 51% PS."
+        },
+        {
+          "detail": "Ruta RNG: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Ruta estable: cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/bruno/darmanitan.json
+++ b/src/data/kanto/bruno/darmanitan.json
@@ -2,15 +2,21 @@
   "id": "darmanitan",
   "name": "Darmanitan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "Varias opciones",
   "tricks": [
     {
-      "detail": "Si quieres hacerlo rápido → Chandelure 4+0, Lanzallamas para barrer el equipo.",
-      "variant": []
-    },
-    {
-      "detail": "Si quieres ahorrar → Truco, cambia a Scrafty +3 ( A Bocajarro para matar a Machamp o Metagross)",
-      "variant": []
+      "detail": "Contra Darmanitan tienes tres rutas posibles. Elige según si quieres ahorrar recursos o jugar más estable.",
+      "variant": [
+        {
+          "detail": "Ruta ahorro: entra con Volcarona y usa Danza Aleteo x3. ⚠️ Cuidado con un Fuerza Bruta crítico: puede dejarte cerca de 51% PS."
+        },
+        {
+          "detail": "Ruta RNG: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Ruta estable: cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/bruno/eelektross.json
+++ b/src/data/kanto/bruno/eelektross.json
@@ -2,22 +2,35 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "Amortiguador",
   "tricks": [
     {
-      "detail": "Si Eelektross no se retira → Truco para ver qué movimiento usa",
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Si usa Voltio Cruel → Excadrill 6+2"
+          "detail": "Si entra Machamp, cambia a Gengar y luego a Slowbro. Usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
         },
         {
-          "detail": "Si usa Rayo → Excadrill 4+2"
+          "detail": "Si entra Infernape, usa Amortiguador para recibir A Bocajarro. Luego cambia a Gengar, usa Otra Vez y Maquinación hasta +4."
+        },
+        {
+          "detail": "Si entra Hitmonchan, entra con Gengar y usa Maquinación hasta +4. No es necesario usar Otra Vez."
         }
       ]
     },
     {
-      "detail": "Contra Torterra → Truco para encerrarlo en Terremoto, Cloyster +4 + Especial X",
-      "variant": []
+      "detail": "Si entra Darmanitan, elige una de estas rutas.",
+      "variant": [
+        {
+          "detail": "Ruta ahorro: entra con Volcarona y usa Danza Aleteo x3."
+        },
+        {
+          "detail": "Ruta RNG: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Ruta estable: cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/bruno/electivire.json
+++ b/src/data/kanto/bruno/electivire.json
@@ -2,44 +2,70 @@
   "id": "electivire",
   "name": "Electivire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Gengar + Otra Vez",
   "tricks": [
     {
-      "detail": "Si cambia por RHYPERIOR, saca a Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "Si cambia por STEELIX, saca a Cloyster +4 + Especial X",
-      "variant": []
-    },
-    {
-      "detail": "MACHAMP → cambia a Chandelure y analiza:",
+      "detail": "Cambia a Gengar, usa Otra Vez y luego cambia a Slowbro para revisar la ruta.",
       "variant": [
         {
-          "detail": "Si MACHAMP NO CAMBIA, utiliza Poder Oculto para bajar vida, luego cambia a Metagross ya que saldrá Blastoise, utiliza Trampa Rocas para luego cambiar a Poliwrath Tambor + Vel x"
+          "detail": "Si Electivire se queda, usa Bostezo. Si se vuelve a quedar, sacrifica a Politoed para recibir Voltio Cruel. Luego cambia a Chansey y coloca Trampa Rocas."
         },
         {
-          "detail": "GLISCOR → Truco con Chandelure, cambia a Cloyster +4 + Especial X / Carámbano para Hitmonlee"
+          "detail": "Si entra Staraptor, vuelve a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        },
+        {
+          "detail": "Si entra Machamp, usa Gengar con Otra Vez. Luego cambia a Chansey. Cuando salga Staraptor, vuelve a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
         }
       ]
     },
     {
-      "detail": "Si cambia a Metagross, utiliza Trampa Rocas y analiza:",
+      "detail": "Si entra Heracross, usa Protección y luego Bostezo.",
       "variant": [
         {
-          "detail": "Si Metagross no cambia, saca a Chandelure y utiliza 2 Especial X, luego usa lanzallamas para barrer."
-        },
-        {
-          "detail": "Si entra Machamp, cambia a Chandelure y utiliza Truco para encerrar en Roca Afilada, luego entra Excadrill 4+2. (Si al cambiar a Chandelure sale Gliscor igual utiliza Truco para encerrar en Terremoto, luego saca a Cloyster +4"
-        },
-        {
-          "detail": "Si entra Gliscor directamente, sacrifica a Metagross, Chandelure utiliza Truco para encerrar en Terremoto, saca a Cloyster +4"
+          "detail": "Cuando salga Salamence, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     },
     {
-      "detail": "Si Electivire utiliza Llamarada / Lanzallamas, cambia a Chandelure para utilizar Truco, luego entra Excadrill 4+2",
-      "variant": []
+      "detail": "Si entra Blastoise, cambia a Chansey y usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Cuando salga Hitmonlee, cambia a Gengar. Luego saca a Slowbro, usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Steelix, cambia a Chansey y usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Cuando salga Machamp, entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Metagross, sigue la ruta de Metagross.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo. Si usa Hierba Lazo, cambia a Chansey y usa Amortiguador. Cuando salga Hitmonlee, cambia a Gengar y luego a Slowbro para usar Bostezo."
+        },
+        {
+          "detail": "Si entra Electivire, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si entra Blastoise, entra con Volcarona y usa Danza Aleteo x1."
+        },
+        {
+          "detail": "Si entra Heracross, usa Protección y luego Bostezo. Cuando salga Salamence, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Rhyperior, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Cuando salga Heracross, usa Protección y luego Bostezo. Cuando salga Salamence, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/bruno/gliscor.json
+++ b/src/data/kanto/bruno/gliscor.json
@@ -2,11 +2,35 @@
   "id": "gliscor",
   "name": "Gliscor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Varias opciones",
   "tricks": [
     {
-      "detail": "Encierras en Terremoto, Cloyster +4 + Especial X / Carámbano contra Hitmonlee",
-      "variant": []
+      "detail": "Ruta rápida: coloca Trampa Rocas, recibe Acróbata y cambia a Slowbro para usar Bostezo.",
+      "variant": [
+        {
+          "detail": "Si entra Blastoise, entra con Volcarona y usa Danza Aleteo x1."
+        },
+        {
+          "detail": "Si entra Electivire, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    },
+    {
+      "detail": "Ruta ahorro: usa Amortiguador, recibe Acróbata y vuelve a usar Amortiguador.",
+      "variant": [
+        {
+          "detail": "Cuando salga Hitmonlee, cambia a Gengar, usa Otra Vez y luego cambia a Slowbro."
+        },
+        {
+          "detail": "Si Hitmonlee se queda, usa Bostezo."
+        },
+        {
+          "detail": "Si entra Blastoise, entra con Volcarona y usa Danza Aleteo x1."
+        },
+        {
+          "detail": "Si entra Electivire, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/bruno/heracross.json
+++ b/src/data/kanto/bruno/heracross.json
@@ -2,11 +2,18 @@
   "id": "heracross",
   "name": "Heracross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Amortiguador",
   "tricks": [
     {
-      "detail": "Cambia a Rhyperior, saca a Cloyster +4",
-      "variant": []
+      "detail": "Usa Amortiguador para recibir A Bocajarro.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Gengar, usa Otra Vez y Maquinación hasta +4."
+        },
+        {
+          "detail": "Usa Otra Vez nuevamente cuando sea necesario, porque Heracross tiene Banda Focus."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/bruno/hitmonchan.json
+++ b/src/data/kanto/bruno/hitmonchan.json
@@ -2,15 +2,18 @@
   "id": "hitmonchan",
   "name": "Hitmonchan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "UTILIZA ROCA AFILADA",
+  "initialMove": "Gengar +4",
   "tricks": [
     {
-      "detail": "Si utiliza Terremoto, cambia a Cloyster +6",
-      "variant": []
-    },
-    {
-      "detail": "Si utiliza A Bocajarro, cambia a Chandelure, Truco, Cloyster +6",
-      "variant": []
+      "detail": "Entra con Gengar y usa Maquinación hasta +4.",
+      "variant": [
+        {
+          "detail": "No es necesario usar Otra Vez."
+        },
+        {
+          "detail": "Cuando Gengar esté listo, barre con Bola Sombra."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/bruno/hitmonlee.json
+++ b/src/data/kanto/bruno/hitmonlee.json
@@ -2,22 +2,21 @@
   "id": "hitmonlee",
   "name": "Hitmonlee",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "UTILIZA TRAMPA ROCAS",
+  "initialMove": "Cambia a Gengar",
   "tricks": [
     {
-      "detail": "Si entra Machamp → Cambia a Chandelure y usa Truco",
+      "detail": "Cambia a Gengar y luego a Slowbro.",
       "variant": [
         {
-          "detail": "Si sale Blastoise → Poliwrath 6+2"
+          "detail": "Si Hitmonlee se queda, usa Bostezo."
         },
         {
-          "detail": "Si usa Roca Afilada → Excadrill 4+2"
+          "detail": "Si entra Electivire, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si entra Blastoise, entra con Volcarona y usa Danza Aleteo x1."
         }
       ]
-    },
-    {
-      "detail": "Si entra Metagross → Chandelure usa Lanzallamas para matarlo. Si luego sale Blastoise → Poliwrath 6+2",
-      "variant": []
     }
   ]
 }

--- a/src/data/kanto/bruno/hitmontop.json
+++ b/src/data/kanto/bruno/hitmontop.json
@@ -2,36 +2,13 @@
   "id": "hitmontop",
   "name": "Hitmontop",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE Y UTILIZA BOLA SOMBRA",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si lo matas y entra Staraptor → Cambia a Metagross y usa Truco → Enciérralo en Steelix → Entra Cloyster + 4 + Especial X",
-      "variant": []
-    },
-    {
-      "detail": "Si lo matas y entra Steelix → Cambia a Cloyster → Luego cambia a Metagross y usa Truco → Enciérralo en Terremoto → Cloyster + 4 + Especial X",
-      "variant": []
-    },
-    {
-      "detail": "Si lo matas y entra Machamp → Cambia a Metagross → Luego cambia a Chandelure y usa Truco → Enciérralo en Roca Afilada → Excadrill 4+2",
-      "variant": []
-    },
-    {
-      "detail": "Si cambia directo Machamp y lo alcanzas a golpear → Cambia a Metagross:",
+      "detail": "Coloca Trampa Rocas y cambia a Volcarona.",
       "variant": [
         {
-          "detail": "Contra Steelix o Staraptor: Usa Truco → Si usa Terremoto o entra Steelix → Cloyster + 6 + Defensa → (Si entra Slowbro mientras haces Truco, coloca Trampa Rocas, cambia a Chandelure y usa Especial X, barre todo con Lanzallamas"
-        },
-        {
-          "detail": "Si Machamp no se retira (Observa si bajo su defensa Especial)",
-          "variant": [
-            {
-              "detail": "NO BAJO SU DEFENSA : Utiliza Truco, Si sale Steelix, saca Cloyster +6 + Defensa X (Si entra Slowbro, pon Trampa Rocas y cambia a Chandelure + Especial X, con Lanzallamas barres todo."
-            },
-            {
-              "detail": "SI BAJO SU DEFENSA: Cambia a Chandelure y utiliza Truco, encierra el Roca Afilada, Excadrill 4+2"
-            }
-          ]
+          "detail": "Usa Danza Aleteo x1 y barre."
         }
       ]
     }

--- a/src/data/kanto/bruno/infernape.json
+++ b/src/data/kanto/bruno/infernape.json
@@ -2,15 +2,15 @@
   "id": "infernape",
   "name": "Infernape",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "Amortiguador",
   "tricks": [
     {
-      "detail": "Si NO SE RETIRA, usa Truco. para encerrar Puño Trueno, cambia a Excadrill 4+2",
-      "variant": []
-    },
-    {
-      "detail": "Si cambia a SEISMITOAD, usa Truco para encerrarlo en Terremoto, cambia a Cloyster +4",
-      "variant": []
+      "detail": "Usa Amortiguador para recibir A Bocajarro.",
+      "variant": [
+        {
+          "detail": "Luego usa Teletransporte hacia Gengar, usa Otra Vez y Maquinación hasta +4."
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/bruno/krookodile.json
+++ b/src/data/kanto/bruno/krookodile.json
@@ -2,11 +2,18 @@
   "id": "krookodile",
   "name": "Krookodile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Enciérralo en Terremoto, Cloyster + 4. (Usa Carámbano para matar a Lucario.)",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Cuando salga Metagross, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Cuando salga Salamence, usa Teletransporte hacia Volcarona."
+        },
+        {
+          "detail": "Con Volcarona, usa Danza Aleteo x1 y continúa la ruta."
+        }
+      ]
     }
   ]
 }

--- a/src/utils/exactStrategyTranslations.ts
+++ b/src/utils/exactStrategyTranslations.ts
@@ -1,0 +1,64 @@
+import type { Language } from '../i18n/translations'
+
+const exactTranslations: Record<string, string> = {
+  Encanto: 'Charm',
+  '🥚 Amortiguador 🥚': '🥚 Soft-Boiled 🥚',
+  'Varias opciones': 'Multiple options',
+  Amortiguador: 'Soft-Boiled',
+  'Gengar +4': 'Gengar +4',
+  'Cambia a Gengar': 'Switch to Gengar',
+
+  'Usa Encanto frente a Aggron. Luego toma una Max Poción y usa Amortiguador para mantener a Chansey sana.': 'Use Charm against Aggron. Then take a Max Potion and use Soft-Boiled to keep Chansey healthy.',
+  'Cuando salga Hitmonchan, entra con Gengar y usa Maquinación hasta +4. No es necesario usar Otra Vez.': 'When Hitmonchan comes in, bring in Gengar and use Nasty Plot to +4. Encore is not needed.',
+  'Cuando Gengar esté listo, barre con Bola Sombra.': 'When Gengar is ready, sweep with Shadow Ball.',
+  'Usa Amortiguador y revisa qué Pokémon entra después.': 'Use Soft-Boiled and check which Pokémon comes in next.',
+  'Si entra Machamp, cambia a Gengar y luego a Slowbro. Usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.': 'If Machamp comes in, switch to Gengar and then to Slowbro. Use Yawn, sacrifice Politoed, and bring in Poliwrath to use Belly Drum and reach +6 Attack.',
+  'Si entra Hitmonlee, cambia a Gengar y luego a Slowbro. Si Hitmonlee se queda, usa Bostezo.': 'If Hitmonlee comes in, switch to Gengar and then to Slowbro. If Hitmonlee stays in, use Yawn.',
+  'Si entra Electivire, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.': 'If Electivire comes in, sacrifice Politoed and bring in Poliwrath to use Belly Drum and reach +6 Attack.',
+  'Si entra Blastoise, entra con Volcarona y usa Danza Aleteo x1.': 'If Blastoise comes in, bring in Volcarona and use Quiver Dance x1.',
+  'Si entra Darmanitan, elige una de estas rutas.': 'If Darmanitan comes in, choose one of these routes.',
+  'Ruta ahorro: entra con Volcarona y usa Danza Aleteo x3. ⚠️ Cuidado con un Fuerza Bruta crítico: puede dejarte cerca de 51% PS.': 'Budget route: bring in Volcarona and use Quiver Dance x3. ⚠️ Be careful with a critical Superpower: it can leave you near 51% HP.',
+  'Ruta RNG: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.': 'RNG route: sacrifice Politoed and bring in Poliwrath to use Belly Drum and reach +6 Attack.',
+  'Ruta estable: cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.': 'Stable route: switch to Slowbro, use Yawn, sacrifice Politoed, and bring in Poliwrath to use Belly Drum and reach +6 Attack.',
+  'Contra Darmanitan tienes tres rutas posibles. Elige según si quieres ahorrar recursos o jugar más estable.': 'Against Darmanitan, you have three possible routes. Choose based on whether you want to save resources or play more safely.',
+  'Ruta ahorro: entra con Volcarona y usa Danza Aleteo x3.': 'Budget route: bring in Volcarona and use Quiver Dance x3.',
+  'Si entra Infernape, usa Amortiguador para recibir A Bocajarro. Luego cambia a Gengar, usa Otra Vez y Maquinación hasta +4.': 'If Infernape comes in, use Soft-Boiled to take Close Combat. Then switch to Gengar, use Encore, and use Nasty Plot to +4.',
+  'Si entra Hitmonchan, entra con Gengar y usa Maquinación hasta +4. No es necesario usar Otra Vez.': 'If Hitmonchan comes in, bring in Gengar and use Nasty Plot to +4. Encore is not needed.',
+  'Cambia a Gengar, usa Otra Vez y luego cambia a Slowbro para revisar la ruta.': 'Switch to Gengar, use Encore, and then switch to Slowbro to check the route.',
+  'Si Electivire se queda, usa Bostezo. Si se vuelve a quedar, sacrifica a Politoed para recibir Voltio Cruel. Luego cambia a Chansey y coloca Trampa Rocas.': 'If Electivire stays in, use Yawn. If it stays in again, sacrifice Politoed to take Wild Charge. Then switch to Chansey and set up Stealth Rock.',
+  'Si entra Staraptor, vuelve a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.': 'If Staraptor comes in, go back to Gengar, use Encore, use Nasty Plot to +2, and use X Accuracy.',
+  'Si entra Machamp, usa Gengar con Otra Vez. Luego cambia a Chansey. Cuando salga Staraptor, vuelve a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.': 'If Machamp comes in, use Gengar with Encore. Then switch to Chansey. When Staraptor comes in, go back to Gengar, use Encore, use Nasty Plot to +2, and use X Accuracy.',
+  'Si entra Heracross, usa Protección y luego Bostezo.': 'If Heracross comes in, use Protect and then Yawn.',
+  'Cuando salga Salamence, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.': 'When Salamence comes in, sacrifice Politoed and bring in Poliwrath to use Belly Drum and reach +6 Attack.',
+  'Si entra Blastoise, cambia a Chansey y usa Amortiguador.': 'If Blastoise comes in, switch to Chansey and use Soft-Boiled.',
+  'Cuando salga Hitmonlee, cambia a Gengar. Luego saca a Slowbro, usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1.': 'When Hitmonlee comes in, switch to Gengar. Then send out Slowbro, use Teleport, and bring in Volcarona to use Quiver Dance x1.',
+  'Si entra Steelix, cambia a Chansey y usa Amortiguador.': 'If Steelix comes in, switch to Chansey and use Soft-Boiled.',
+  'Cuando salga Machamp, entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.': 'When Machamp comes in, bring in Gengar, use Encore, use Nasty Plot to +2, and use X Accuracy.',
+  'Si entra Metagross, sigue la ruta de Metagross.': 'If Metagross comes in, follow the Metagross route.',
+  'Usa Bostezo. Si usa Hierba Lazo, cambia a Chansey y usa Amortiguador. Cuando salga Hitmonlee, cambia a Gengar y luego a Slowbro para usar Bostezo.': 'Use Yawn. If it uses Grass Knot, switch to Chansey and use Soft-Boiled. When Hitmonlee comes in, switch to Gengar and then to Slowbro to use Yawn.',
+  'Si entra Heracross, usa Protección y luego Bostezo. Cuando salga Salamence, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.': 'If Heracross comes in, use Protect and then Yawn. When Salamence comes in, sacrifice Politoed and bring in Poliwrath to use Belly Drum and reach +6 Attack.',
+  'Si entra Rhyperior, usa Bostezo.': 'If Rhyperior comes in, use Yawn.',
+  'Cuando salga Heracross, usa Protección y luego Bostezo. Cuando salga Salamence, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.': 'When Heracross comes in, use Protect and then Yawn. When Salamence comes in, sacrifice Politoed and bring in Poliwrath to use Belly Drum and reach +6 Attack.',
+  'Ruta rápida: coloca Trampa Rocas, recibe Acróbata y cambia a Slowbro para usar Bostezo.': 'Fast route: set up Stealth Rock, take Acrobatics, and switch to Slowbro to use Yawn.',
+  'Ruta ahorro: usa Amortiguador, recibe Acróbata y vuelve a usar Amortiguador.': 'Budget route: use Soft-Boiled, take Acrobatics, and use Soft-Boiled again.',
+  'Cuando salga Hitmonlee, cambia a Gengar, usa Otra Vez y luego cambia a Slowbro.': 'When Hitmonlee comes in, switch to Gengar, use Encore, and then switch to Slowbro.',
+  'Si Hitmonlee se queda, usa Bostezo.': 'If Hitmonlee stays in, use Yawn.',
+  'Usa Amortiguador para recibir A Bocajarro.': 'Use Soft-Boiled to take Close Combat.',
+  'Luego cambia a Gengar, usa Otra Vez y Maquinación hasta +4.': 'Then switch to Gengar, use Encore, and use Nasty Plot to +4.',
+  'Usa Otra Vez nuevamente cuando sea necesario, porque Heracross tiene Banda Focus.': 'Use Encore again when needed because Heracross has Focus Sash.',
+  'Entra con Gengar y usa Maquinación hasta +4.': 'Bring in Gengar and use Nasty Plot to +4.',
+  'No es necesario usar Otra Vez.': 'Encore is not needed.',
+  'Cambia a Gengar y luego a Slowbro.': 'Switch to Gengar and then to Slowbro.',
+  'Coloca Trampa Rocas y cambia a Volcarona.': 'Set up Stealth Rock and switch to Volcarona.',
+  'Usa Danza Aleteo x1 y barre.': 'Use Quiver Dance x1 and sweep.',
+  'Luego usa Teletransporte hacia Gengar, usa Otra Vez y Maquinación hasta +4.': 'Then use Teleport into Gengar, use Encore, and use Nasty Plot to +4.',
+  'Coloca Trampa Rocas. Cuando salga Metagross, cambia a Slowbro y usa Bostezo.': 'Set up Stealth Rock. When Metagross comes in, switch to Slowbro and use Yawn.',
+  'Cuando salga Salamence, usa Teletransporte hacia Volcarona.': 'When Salamence comes in, use Teleport into Volcarona.',
+  'Con Volcarona, usa Danza Aleteo x1 y continúa la ruta.': 'With Volcarona, use Quiver Dance x1 and continue the route.'
+}
+
+export const translateExactStrategyText = (text: string, language: Language) => {
+  if (language === 'es') return text
+
+  return exactTranslations[text] || text
+}


### PR DESCRIPTION
## Summary
- Updates Kanto Bruno strategy routes for the Pokémon provided in this batch.
- Rewrites the routes with clearer, shorter step-by-step instructions.
- Keeps boost wording consistent:
  - Gengar uses Nasty Plot as +2/+4 without repeating Special Attack.
  - Poliwrath uses Belly Drum to +6 Attack.
  - Volcarona uses Quiver Dance x1/x3.
  - X Accuracy remains explicit where needed.
- Adds exact English strategy translations to avoid Spanglish for the updated Bruno text.

## Updated matchups
- Aggron
- Blastoise
- Darmanitan
- Eelektross
- Electivire
- Gliscor
- Heracross
- Hitmonchan
- Hitmonlee
- Hitmontop
- Infernape
- Krookodile

## Notes
- This PR targets `develop`.
- No visual assets are changed.
- No release to `main` is included yet.

Refs #16
Refs #32