### PR TITLE
Fix GitHub Pages deployment permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary
- Adds `actions: read` permission to the GitHub Pages deploy workflow.

## Why
- GitHub Pages deploy jobs can fail or not publish correctly when artifact access permissions are incomplete.
- This should make the deployment path more explicit and reliable after the Kanto release.

## Notes
- No app code or strategy data changes.