### PR TITLE
Update Johto Will strategies

### DIFF
--- a/src/data/johto/will/absol.json
+++ b/src/data/johto/will/absol.json
@@ -1,29 +1,19 @@
 {
-    "id": "absol",
-    "name": "Absol",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "CAMBIA A CHANDELURE",
-    "tricks": [
-      {
-        "detail": "TAJO UMBRÍO → Entrar con Scrafty → Scrafty +3 → Bronzong necesita dos Puño Drenaje para ser derrotado",
-        "variant": []
-      },
-      {
-        "detail": "A BOCAJARRO → Chandelure usa Truco para intercambiar objetos → Luego entrar con Scrafty → Scrafty +2 → Bronzong necesita dos Puño Drenaje para ser derrotado",
-        "variant": []
-      },
-      {
-        "detail": "BRONZONG → Chandelure usa Lanzallamas para debilitar:",
-        "variant": [
-          {
-            "detail": "Si entra Absol → Scrafty +2",
-            "variant": []
-          },
-          {
-            "detail": "Si entra Empoleon → Poliwrath +6 +2 / Si te congela, descongela con Cura Total o una Baya dependiendo de tus Ps",
-            "variant": []
-          }
-        ]
-      }
-    ]
-  }
+  "id": "absol",
+  "name": "Absol",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "👻 Gengar +4 + Precisión X 👻",
+  "tricks": [
+    {
+      "detail": "Entra con Gengar, usa Maquinación hasta +4 y luego Precisión X.",
+      "variant": [
+        {
+          "detail": "No uses Otra Vez en esta ruta."
+        },
+        {
+          "detail": "Cuando Gengar esté listo, barre con la cobertura correspondiente."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/altaria.json
+++ b/src/data/johto/will/altaria.json
@@ -1,34 +1,38 @@
 {
-    "id": "altaria",
-    "name": "Altaria",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "TRUCO",
-    "tricks": [
-      {
-        "detail": "LLAMARADA: Cambia Scrafty +Def. Esp X + 2 +Raiz Energia Si estas en rojo. + 1 Danza Dragón. (Crítico de Llamarada baja 46.2%)",
-        "variant": [
-          {
-            "detail": "Si Altaria mata a Scrafty Por Criticó Cambia Chandelure usa una vez Lanzallamas, luego entra Poliwrath frente a Empoleon, cambia a Chandelure y usa Truco para Encerrar en Cascada,cambia Poliwrath 2 Veces tambor + Velocidad X. / Puño Hielo para matar a Alakazam.",
-            "variant": []
-          }
-        ]
-      },
-      {
-        "detail": "LANZALLAMAS Es [Zorua Disfrazado] : Cambia a Chandelure usa Truco para cambiar el ítem, luego cambia Scrafty +4.(Si Metagross murió o está quemado, haz otra Danza Dragón Extra.)",
-        "variant": []
-      },
-      {
-        "detail": "CLEFABLE: cambia a Chandelure.",
-        "variant": [
-          {
-            "detail": "Lucario o Gardevoir, usa Truco para Encerrar en Triturar, Pulso Umbrío o Bola Sombra, Scrafty +2.",
-            "variant": []
-          },
-          {
-            "detail": "Si Clefable no se va, Scrafty 1 + usa Raíz Energía para curar y boostear otra vez.",
-            "variant": []
-          }
-        ]
-      }
-    ]
-  }
+  "id": "altaria",
+  "name": "Altaria",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🥚 Amortiguador 🥚",
+  "tricks": [
+    {
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Stantler, cambia a Gengar y usa Otra Vez. Cuando salga Alakazam, elige ruta estable o ruta RNG."
+        },
+        {
+          "detail": "Ruta estable: cambia a Chansey, usa Teletransporte y entra con Slowbro. Usa Bostezo, luego Protección para dormir a Alakazam. Después usa Bostezo frente a Roserade, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Ruta RNG: entra con Slowbro, usa Bostezo y luego Protección. Cuando salga Roserade, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Lucario, cambia a Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Usa Maquinación hasta +6 y Precisión X. Mantén Otra Vez cuando sea necesario."
+        }
+      ]
+    },
+    {
+      "detail": "Si Lucario usa un movimiento de fuego, probablemente es Zoroark.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez sobre el movimiento de fuego y luego entra con Poliwrath para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/bronzong.json
+++ b/src/data/johto/will/bronzong.json
@@ -1,16 +1,30 @@
 {
-    "id": "bronzong",
-    "name": "Bronzong",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "Chandelure usa Lanzallamas para debilitar y revelar al Pokémon rival",
-    "tricks": [
-      {
-        "detail": "ABSOL: cambia a Scrafty +2",
-        "variant": []
-      },
-      {
-        "detail": "EMPOLEON: cambia a Poliwrath 6+2",
-        "variant": []
-      }
-    ]
-  }
+  "id": "bronzong",
+  "name": "Bronzong",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🥚 Amortiguador 🥚",
+  "tricks": [
+    {
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Absol, entra con Gengar, usa Maquinación hasta +4 y Precisión X. 🔔 Absol tiene Pañuelo Elegido. 🔔"
+        },
+        {
+          "detail": "Si entra Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2."
+        }
+      ]
+    },
+    {
+      "detail": "Si Flareon se queda, derrota a Flareon y revisa el siguiente cambio.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, usa Bola Sombra y luego sacrifica a Politoed. Entra con Poliwrath para usar Tambor hasta +6 Ataque. 🔔 Absol tiene Pañuelo Elegido. 🔔"
+        },
+        {
+          "detail": "Si vuelve Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🔔 Usa Cascada contra Bronzong. 🔔"
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/chansey.json
+++ b/src/data/johto/will/chansey.json
@@ -1,12 +1,16 @@
 {
-    "id": "chansey",
-    "name": "Chansey",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "CAMBIA A SCRAFTY",
-    "tricks": [
-      {
-        "detail": "Scrafty +1 → 2 Puño drenaje para derrotar a chansey",
-        "variant": []
-      }
-    ]
-  }
+  "id": "chansey",
+  "name": "Chansey",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/claydol.json
+++ b/src/data/johto/will/claydol.json
@@ -1,7 +1,22 @@
 {
-    "id": "claydol",
-    "name": "Claydol",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "Excadrill y usas Trampa Rocas, entra Mantine, cambia a Chandelure y usa Truco, lo deja bloqueado en Escaldar, cambia a Poliwrath 6+2",
-    "tricks": []
-  }
+  "id": "claydol",
+  "name": "Claydol",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas. Si Claydol se queda, aguanta con Defensa Especial X y usa Amortiguador frente a Girafarig.",
+      "variant": [
+        {
+          "detail": "Cuando entre Girafarig, cambia a Gengar y usa Otra Vez."
+        },
+        {
+          "detail": "Luego cambia a Slowbro frente a Mantine y usa Bostezo frente a Magnezone."
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/clefable.json
+++ b/src/data/johto/will/clefable.json
@@ -1,28 +1,25 @@
 {
-    "id": "clefable",
-    "name": "Clefable",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "CAMBIA A CHANDELURE",
-    "tricks": [
-      {
-        "detail": "MOV. SÍSMICO O EL SEGUNDO CLEFABLE→ Entra Scrafty +2. / Si está envenenado, primero curar el estado. Mov. Sísmico hace siempre 100 PS de daño; si te deja con más de 100, puedes curarte con Raíz Energía y seguir potenciando.",
-        "variant": []
-      },
-      {
-        "detail": "LLAMARADA → Usar Truco para bloquear a Umbreon o a Clefable con Hierba Lazo, luego entra Scrafty +2.",
-        "variant": []
-      },
-      {
-        "detail": "Lanzallamas [Zoroark disfrazado] → Usar Truco para bloquear Pulso Noche, luego entra Scrafty +2 (Si Chandelure Murió Un Danza Dragón extra)",
-        "variant": []
-      },
-      {
-        "detail": "CLEFABLE SE QUEDA saca a Scrafty y a +2.",
-        "variant": []
-      },
-      {
-        "detail": "GOLURK → Truco para bloquear en Terremoto, Excadrill 4+2, usa Terremoto para derrotar a Drowzee.",
-        "variant": []
-      }
-    ]
-  }
+  "id": "clefable",
+  "name": "Clefable",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🥚 Amortiguador 🥚",
+  "tricks": [
+    {
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +6 y Precisión X. Mantén Otra Vez cada vez que puedas."
+        },
+        {
+          "detail": "Si el movimiento principal no sirve contra Xatu, usa la cobertura especial dos veces."
+        },
+        {
+          "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X. Mantén Otra Vez cada vez que puedas."
+        },
+        {
+          "detail": "Si Lucario revela que es Zoroark, usa Otra Vez sobre su movimiento y entra con Poliwrath para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/electivire.json
+++ b/src/data/johto/will/electivire.json
@@ -1,20 +1,30 @@
 {
-    "id": "electivire",
-    "name": "Electivire",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "USA TRAMPA ROCAS",
-    "tricks": [
-      {
-        "detail": "BLISSEY / CHANSEY → Scrafty +1 / Dos Puño drenaje para derrotar a Blissey/Chansey",
-        "variant": []
-      },
-      {
-        "detail": "UMBREON → Scrafty +2",
-        "variant": []
-      },
-      {
-        "detail": "LANZALLAMAS → Chandelure usa Truco para cambiar objeto, Excadrill 4+2 / Terremoto para derrotar a Umbreon",
-        "variant": []
-      }
-    ]
-  }
+  "id": "electivire",
+  "name": "Electivire",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas. Si Electivire se queda, revisa su objeto y si el golpe fue crítico.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidasfera y el golpe no fue crítico, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        },
+        {
+          "detail": "Si tiene Vidasfera y el golpe fue crítico, toma una Max Poción. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        },
+        {
+          "detail": "Si no tiene Vidasfera, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. No es necesario usar Otra Vez."
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lucario durante la ruta de Gengar, alterna Poliwrath y Gengar para reposicionar.",
+      "variant": [
+        {
+          "detail": "Después entra con Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/empoleon.json
+++ b/src/data/johto/will/empoleon.json
@@ -1,42 +1,33 @@
 {
-    "id": "empoleon",
-    "name": "Empoleon",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "TRUCO",
-    "tricks": [
-      {
-        "detail": "GOLURK → Excadrill 4+2",
-        "variant": []
-      },
-      {
-        "detail": "BLISSEY / CHANSEY → Scrafty +1 / a bocajarro para matar a Blissey // Paliza vs Jynx",
-        "variant": []
-      },
-      {
-        "detail": "BRONZONG → Chandelure",
-        "variant": [
-          {
-            "detail": "Contra Empoleon → Truco para bloquear Escaldar, Poliwrath 6+2,",
-            "variant": []
-          },
-          {
-            "detail": "Contra Tropius → Truco para bloquear Poder Oculto, Scrafty +2",
-            "variant": []
-          }
-        ]
-      },
-      {
-        "detail": "VIDASFERA → Poliwrath 2 defensa especial x +2 +6, lo mata Mismagius con Encanto,",
-        "variant": [
-          {
-            "detail": "Hydreigon → Chandelure usa Truco para bloquear Poder Oculto, Scrafty +2",
-            "variant": []
-          }
-        ]
-      },
-      {
-        "detail": "GAFAS ELEGIDAS → Poliwrath 6+2 / A bocajarro para matar a Umbreon",
-        "variant": []
-      }
-    ]
-  }
+  "id": "empoleon",
+  "name": "Empoleon",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas. Si Empoleon se queda, revisa su ataque.",
+      "variant": [
+        {
+          "detail": "Si usa Surf, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Hidrobomba, usa Teletransporte hacia Slowbro. Usa Bostezo, luego Protección; cuando salga Clefable, vuelve a usar Bostezo. Después sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🔔 Usa Cascada contra Hypno. 🔔"
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No es necesario usar Otra Vez."
+    },
+    {
+      "detail": "Si entra Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
+    },
+    {
+      "detail": "Si entra Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
+      "variant": [
+        {
+          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol o Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/espeon.json
+++ b/src/data/johto/will/espeon.json
@@ -1,12 +1,19 @@
 {
-    "id": "espeon",
-    "name": "Espeon",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "USA TRAMPA ROCAS",
-    "tricks": [
-      {
-        "detail": "Umbreon → Scrafty +2",
-        "variant": []
-      }
-    ]
-  }
+  "id": "espeon",
+  "name": "Espeon",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "Slowbro + Bostezo",
+  "tricks": [
+    {
+      "detail": "Entra con Slowbro y usa Bostezo para presionar el cambio.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Chansey y coloca Trampa Rocas. Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        },
+        {
+          "detail": "Si mientras colocas Trampa Rocas el rival no cambia, usa Amortiguador hasta que cambie. Después sigue la ruta anterior."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/exeggutor.json
+++ b/src/data/johto/will/exeggutor.json
@@ -2,11 +2,29 @@
   "id": "exeggutor",
   "name": "Exeggutor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CLOYSTER",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Bronzong, luego cambia a Poliwrath contra Empoleon, Poliwrath 6+2",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No es necesario usar Otra Vez."
+        },
+        {
+          "detail": "Si entra Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2."
+        }
+      ]
+    },
+    {
+      "detail": "Si Flareon se queda, derrótalo y revisa el siguiente cambio.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/flareon.json
+++ b/src/data/johto/will/flareon.json
@@ -2,31 +2,16 @@
   "id": "flareon",
   "name": "Flareon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "Cambia a Gengar +2",
   "tricks": [
     {
-      "detail": "ENVITE ÍGNEO → Usa Truco",
+      "detail": "Cambia a Gengar y usa Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Drapion, Scrafty +2",
-          "variant": []
+          "detail": "Si Flareon se queda, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X."
         },
         {
-          "detail": "Empoleon, Poliwrath 6+2",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "BRONZONG → Usa Llamarada para eliminarlo",
-      "variant": [
-        {
-          "detail": "Drapion, Scrafty +2",
-          "variant": []
-        },
-        {
-          "detail": "Empoleon, Poliwrath +6+2",
-          "variant": []
+          "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     }

--- a/src/data/johto/will/gardevoir.json
+++ b/src/data/johto/will/gardevoir.json
@@ -2,26 +2,16 @@
   "id": "gardevoir",
   "name": "Gardevoir",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "LANZALLAMAS [Zoroark disfrazado] → Truco para bloquear en Pulso Umbrío, Scrafty +2",
-      "variant": []
-    },
-    {
-      "detail": "CLEFABLE → Cambia a Scrafty y observa el movimiento",
+      "detail": "Usa Amortiguador y revisa si entra Lucario.",
       "variant": [
         {
-          "detail": "Si no es Pulso Umbrío → Scrafty +2 / Si está envenenado, cura primero.",
-          "variant": []
+          "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +6 y Precisión X."
         },
         {
-          "detail": "Ataques físicos te hacen 100 de daño fijo, si tienes menos de 100 PS usa Raíz Energía y sigue subiendo stats",
-          "variant": []
-        },
-        {
-          "detail": "Si es Pulso Umbrío [poca probabilidad] → Cambia a Chandelure y usa Truco para bloquear en Pulso Umbrío, Scrafty +2",
-          "variant": []
+          "detail": "Si la cobertura principal queda limitada, usa Onda Certera para cubrir a Xatu."
         }
       ]
     }

--- a/src/data/johto/will/girafarig.json
+++ b/src/data/johto/will/girafarig.json
@@ -2,24 +2,18 @@
   "id": "girafarig",
   "name": "Girafarig",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "CLAYDOL CON TERREMOTO / PSÍQUICO → Excadrill lanza Trampa Rocas (entra Mantine), cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2",
+      "detail": "Coloca Trampa Rocas y cambia a Gengar para usar Otra Vez.",
       "variant": [
         {
-          "detail": "Opción 1: Si aparece Claydol mientras te boosteas cambia a Excadrill 4+2, si vuelve a cambiar a Mantine vuelve con Poliwrath 6+2 (Experimental, falta testear)",
-          "variant": []
+          "detail": "Luego cambia a Slowbro y usa Bostezo. Cuando salga Mantine, vuelve a usar Bostezo."
         },
         {
-          "detail": "Opción 2: Si aparece Claydol mientras te boosteas cambia a Scrafty +3 (Experimental, falta testear)",
-          "variant": []
+          "detail": "Cuando salga Magnezone, deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
-    },
-    {
-      "detail": "MAGNEZONE → Excadrill lo derrota, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/will/golduck.json
+++ b/src/data/johto/will/golduck.json
@@ -2,11 +2,21 @@
   "id": "golduck",
   "name": "Golduck",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "USA TRAMPA ROCAS",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "entra Umbreon → Scrafty +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si Golduck usa Tajo Cruzado.",
+      "variant": [
+        {
+          "detail": "Si usa Tajo Cruzado, usa Teletransporte. Si Golduck se queda, entra con Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        },
+        {
+          "detail": "Si entra Lucario, puedes pasar por Poliwrath y luego volver a Gengar. Usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        },
+        {
+          "detail": "Si Lucario entra directo, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/golurk.json
+++ b/src/data/johto/will/golurk.json
@@ -2,15 +2,18 @@
   "id": "golurk",
   "name": "Golurk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "RESTOS → Excadrill 4+2 / Hypno Terremoto",
-      "variant": []
-    },
-    {
-      "detail": "CINTA XPERTA → Excadrill 4+2 y vuelve a lanzar Trampa Rocas, entra Slowbro, cambia a Poliwrath, luego cambia a Scrafty +1 Defensa Especial X +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa el porcentaje de daño recibido.",
+      "variant": [
+        {
+          "detail": "Si el daño ronda 50%, y el crítico ronda 75%, toma una Max Poción. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad."
+        },
+        {
+          "detail": "Si el daño ronda 35%, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/grumpig.json
+++ b/src/data/johto/will/grumpig.json
@@ -2,11 +2,15 @@
   "id": "grumpig",
   "name": "Grumpig",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Entra Blissey, Scrafty +1, A bocajarro para matar a Blissey",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si entra Electivire.",
+      "variant": [
+        {
+          "detail": "Si entra Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/hypno.json
+++ b/src/data/johto/will/hypno.json
@@ -2,15 +2,18 @@
   "id": "hypno",
   "name": "Hypno",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Politoed cae",
   "tricks": [
     {
-      "detail": "GOLURK, Excadrill 4+2, Terremoto para matar a Drowzee / Musharna",
-      "variant": []
-    },
-    {
-      "detail": "HYPNO NO CAMBIA Y SE QUEDA ENCERRADO EN MOV. SÍSMICO. Saca a chandelure usa bola sombra y debilitarlo luego cambia a metagross y sacrifica para entrar con chandelure y truco. Improvisa xD",
-      "variant": []
+      "detail": "Deja caer a Politoed y entra con Poliwrath.",
+      "variant": [
+        {
+          "detail": "Usa Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "🔔 Usa Cascada contra Hypno. 🔔"
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/jolteon.json
+++ b/src/data/johto/will/jolteon.json
@@ -2,19 +2,18 @@
   "id": "jolteon",
   "name": "Jolteon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO PARA BLOQUEAR EN RAYO, LUEGO CAMBIA EXCADRILL",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "NO CAMBIA: Trampa Rocas con Excadrill y 4+2",
-      "variant": []
-    },
-    {
-      "detail": "GOLURK: cambia a Chandelure, usa Truco para bloquear en Terremoto, entra Excadrill con +2 de Ataque y lanza Trampa Rocas. // Si luego entra Slowbro, cambia a Poliwrath, luego cambia a Scrafty con +2 en Defensa Especial y usa Danza Dragón (+2).",
-      "variant": []
-    },
-    {
-      "detail": "FALLA TRUCO POR PARÁLISIS: se sacrifica, entra Chandelure, usa Truco para bloquear en Rayo, luego entra Excadrill con Trampa Rocas y +2 de Ataque.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si entra Golurk.",
+      "variant": [
+        {
+          "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad."
+        },
+        {
+          "detail": "Barre con Bola Sombra."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/jynx.json
+++ b/src/data/johto/will/jynx.json
@@ -2,11 +2,15 @@
   "id": "jynx",
   "name": "Jynx",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "CHANSEY → Scrafty +1, A bocajarro para matar a Chansey, Luego Puño Drenaje para recuperar vida",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si entra Electivire.",
+      "variant": [
+        {
+          "detail": "Si entra Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/liepard.json
+++ b/src/data/johto/will/liepard.json
@@ -2,11 +2,18 @@
   "id": "liepard",
   "name": "Liepard",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "bloquear a Golurk, Excadrill 4+2 y lanza Trampa Rocas, Si entra Slowbro, cambia a Poliwrath, luego a Scrafty +2(SpD)+2.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si entra Golurk.",
+      "variant": [
+        {
+          "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad."
+        },
+        {
+          "detail": "Barre con Bola Sombra."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/lucario.json
+++ b/src/data/johto/will/lucario.json
@@ -2,11 +2,30 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Chandelure y Truco",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si Lucario no cambia y utiliza Triturar / Roca Afilada / Otro movimiento al que Scrafty sea resistente cambia a Scrafty +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Lucario usa A Bocajarro, revisa el objeto y si lograste poner las rocas.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidasfera y colocaste Trampa Rocas, usa Teletransporte. Si usa Triturar o Puño Bala, pasa por Poliwrath y luego entra con Gengar. Usa Otra Vez, Maquinación hasta +4 y Precisión X."
+        },
+        {
+          "detail": "Si tiene Vidasfera y usa A Bocajarro o Velocidad Extrema, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
+        },
+        {
+          "detail": "Si tiene Vidasfera y no colocaste Trampa Rocas, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
+        },
+        {
+          "detail": "Si no tiene Vidasfera, usa Teletransporte. Luego entra con Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra."
+    },
+    {
+      "detail": "Si aparece un segundo Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
     }
   ]
 }

--- a/src/data/johto/will/magnezone.json
+++ b/src/data/johto/will/magnezone.json
@@ -2,11 +2,26 @@
   "id": "magnezone",
   "name": "Magnezone",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A EXCADRILL",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Excadrill derrota a Magnezone, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Magnezone se queda, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Si aún se queda, cambia a Slowbro y usa Bostezo. Slowbro aguanta Rayo por la Banda Focus."
+        },
+        {
+          "detail": "Entra con Volcarona, usa Danza Aleteo x1 y derrota a Magnezone con Psíquico o Lanzallamas. Luego, frente a Typhlosion, deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Girafarig, cambia a Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro frente a Mantine y usa Bostezo frente a Magnezone. Deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/mantine.json
+++ b/src/data/johto/will/mantine.json
@@ -2,19 +2,21 @@
   "id": "mantine",
   "name": "Mantine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "USA TRAMPA ROCAS",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "NO CAMBIA → Cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2",
-      "variant": []
-    },
-    {
-      "detail": "MAGNEZONE → Excadrill lo derrota, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2",
-      "variant": []
-    },
-    {
-      "detail": "GOLURK→ Cambia a Excadrill y luego a Chandelure, contra Mantine usa Truco para bloquear Escaldar, Poliwrath 6+2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Mantine se queda, usa Amortiguador para mantener a Chansey sana.",
+      "variant": [
+        {
+          "detail": "Si entra Girafarig, cambia a Gengar y usa Otra Vez."
+        },
+        {
+          "detail": "Luego cambia a Slowbro frente a Mantine y usa Bostezo frente a Magnezone."
+        },
+        {
+          "detail": "Deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/slowbro.json
+++ b/src/data/johto/will/slowbro.json
@@ -2,24 +2,21 @@
   "id": "slowbro",
   "name": "Slowbro",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "LANZALLAMAS → Chandelure 2+2 / Lanzallamas para avanzar en el equipo",
+      "detail": "Coloca Trampa Rocas y revisa si entra Golurk.",
       "variant": [
         {
-          "detail": "Si el rival cambia a Golurk, usa Truco, luego entra Excadrill +4 +2 y vuelve a colocar Trampa Rocas.",
-          "variant": []
+          "detail": "Si entra Golurk, cambia a Gengar y usa Otra Vez."
         },
         {
-          "detail": "Si el rival cambia a Slowbro, entra Scrafty +1 en Defensa Especial + 1 Danza Dragón + Raíz Energía + 1 Danza Dragón / Liepard tiene banda Focus pero no te mata",
-          "variant": []
+          "detail": "Usa Maquinación hasta +4 y Velocidad X para +2 Velocidad."
+        },
+        {
+          "detail": "Continúa atacando con Bola Sombra."
         }
       ]
-    },
-    {
-      "detail": "GOLURK → Excadrill 4+2 y lanza Trampa Rocas, (si entra Drowzee), cambia a Poliwrath, luego a Scrafty 2(SpD)+2",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/will/typhlosion.json
+++ b/src/data/johto/will/typhlosion.json
@@ -2,19 +2,15 @@
   "id": "typhlosion",
   "name": "Typhlosion",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE, LUEGO SACA A METAGROSS, COLOCA ROCAS Y OBSERVA",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "MANTINE NO SE RETIRA → Chandelure usa Truco para bloquearlo con Escaldar, luego entra Poliwrath +6 At. +2 Vel. // Si cambia a Claydol después de Tambor, matalo con Puño Hielo, saldrá Magnezone, cambia a Excadrill y matalo con terremoto, luego saldrá Mantine, cambia a Poliwrath y boostea +6+2",
-      "variant": []
-    },
-    {
-      "detail": "MAGNEZONE → Excadrill lo derrota, luego entra Mantine, cambia a Chandelure y usa Truco para bloquear con Escaldar, luego entra Poliwrath +6 At. +2 Vel.",
-      "variant": []
-    },
-    {
-      "detail": "CLAYDOL → Cambia a Excadrill, luego a Chandelure, te enfrentas a Mantine, usa Truco para bloquear Escaldar, luego entra Poliwrath +6 At. +2 Vel.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y prepara la entrada segura de Poliwrath.",
+      "variant": [
+        {
+          "detail": "Entra con Poliwrath y usa Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/umbreon.json
+++ b/src/data/johto/will/umbreon.json
@@ -2,11 +2,21 @@
   "id": "umbreon",
   "name": "Umbreon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRAMPA ROCAS",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Sale Scrafty +2",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X."
+        },
+        {
+          "detail": "Si entra Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. 🔔 Lucario tiene Banda Focus. 🔔"
+        },
+        {
+          "detail": "Si Umbreon se queda, cambia a Slowbro y usa Bostezo. Luego deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/xatu.json
+++ b/src/data/johto/will/xatu.json
@@ -2,126 +2,49 @@
   "id": "xatu",
   "name": "Xatu",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "CLAYDOL CON PSÍQUICO → Excadrill coloca Trampa Rocas, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath +6+2",
-      "variant": []
-    },
-    {
-      "detail": "GOLURK→ Revisa el objeto",
+      "detail": "Coloca Trampa Rocas. Si Xatu se queda, revisa su objeto.",
       "variant": [
         {
-          "detail": "RESTOS → Excadrill 4+2 / Terremoto para matar a Hypno",
-          "variant": []
+          "detail": "Si tiene Llamasfera, usa Amortiguador hasta que salga Golurk. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
         },
         {
-          "detail": "CINTA XPERTO → Excadrill +4+2 y vuelve a poner Trampa Rocas, Si cambia a Slowbro mientras te boosteas, entra Poliwrath, luego cambia a Scrafty con +2 en Defensa Especial.",
-          "variant": []
+          "detail": "Si no tiene Llamasfera, cambia a Slowbro y usa Bostezo. Cuando salga Magnezone, usa Protección y cambia a Chansey. Cuando salga Girafarig, coloca Trampa Rocas. Luego usa Gengar con Otra Vez, cambia a Slowbro frente a Mantine y usa Bostezo. Después entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     },
     {
-      "detail": "MAGNEZONE → Excadrill lo derrota, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2.",
-      "variant": []
-    },
-    {
-      "detail": "BRONZONG → Cambia a Chandelure",
+      "detail": "Si entra Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Contra Empoleon → Truco para bloquear Escaldar, Poliwrath 6+2,",
-          "variant": []
-        },
-        {
-          "detail": "Contra Tropius → Truco para bloquear Poder Oculto, Scrafty +2 (Bronzong necesita dos golpes)",
-          "variant": []
+          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol o Bronzong, entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     },
     {
-      "detail": "UMBREON → Lanza Trampa Rocas, Scrafty +2",
-      "variant": []
+      "detail": "Si entra Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No es necesario usar Otra Vez."
     },
     {
-      "detail": "CLEFABLE → Cambia a Chandelure, según la situación 👇🏻",
+      "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Mantén Otra Vez cuando sea necesario."
+    },
+    {
+      "detail": "Si entra Lucario, usa Teletransporte y revisa su objeto.",
       "variant": [
         {
-          "detail": "Mov. sísmico → Scrafty +1, cura con Raíz Energía y sube otro +1",
-          "variant": []
+          "detail": "Si tiene Vidasfera, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X. Mantén Otra Vez cuando sea necesario."
         },
         {
-          "detail": "Lanzallamas [Zoroark disfrazado] → Truco para cambiar objeto, Scrafty +2",
-          "variant": []
+          "detail": "Si no tiene Vidasfera, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Mantén Otra Vez cuando sea necesario."
         },
         {
-          "detail": "Contra LUCARIO / GARDEVOIR → Truco para bloquear Triturar/Pulso Umbrío, Scrafty +2",
-          "variant": []
+          "detail": "Si revela que es Zoroark por un movimiento de tipo Fuego, usa Otra Vez y entra con Poliwrath para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad."
         }
       ]
     },
     {
-      "detail": "BLISSEY O CHANSEY → Scrafty +1 / A bocajarro para matar a Blissey o Chansey // Luego cura con Puño Drenaje",
-      "variant": []
-    },
-    {
-      "detail": "VIDASFERA + ONDA ÍGNEA → Chandelure usa Bola Sombra para debilitar",
-      "variant": [
-        {
-          "detail": "Si sale Umbreon → Cambia a Metagross y lanza Trampa Rocas, Scrafty +2, Si no puede poner Trampa Rocas con Metagross, usa Excadrill para ponerlas",
-          "variant": []
-        },
-        {
-          "detail": "Si sale Lucario → Cambia a Scrafty, luego a Chandelure con Truco para bloquear Triturar, Scrafty +2",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "RESTOS + ONDA ÍGNEA → Scrafty +2 / 2 puño drenaje para matar a Kecleon / Clefeable",
-      "variant": []
-    },
-    {
-      "detail": "GAFAS ELEGIDAS + ONDA ÍGNEA → Cambia a Chandelure",
-      "variant": [
-        {
-          "detail": "Si no cambia → Bola Sombra para debilitar o matar, entra Hydreigon, Scrafty +2 // (Bronzong necesita dos golpes)",
-          "variant": []
-        },
-        {
-          "detail": "Contra Bronzong → lanzallamas para debilitar o matar:",
-          "variant": [
-            {
-              "detail": "Si sale Hydreigon, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Si sale Empoleon, Poliwrath 6+2",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "CHALECO ASALTO + ONDA ÍGNEA → Cambia a Scrafty",
-      "variant": [
-        {
-          "detail": "No se retira → Scrafty usa Defensa Especial X luego +4 / Usa Puño Drenaje para eliminar Magnezone / Si Metagross está quemado, ayudar a eliminar la quemadura / Si Onda Ígnea baja mucha vida curar con Raíz Energía",
-          "variant": []
-        },
-        {
-          "detail": "Magnezone → Excadrill usa Terremoto para eliminarlo, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath +6+4",
-          "variant": []
-        },
-        {
-          "detail": "Claydol → Excadrill coloca Trampa Rocas, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath +6+4 // Si claydol no se retira, Scrafty +3",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "LANZALLAMAS [disfraz de Zoroark] → Chandelure usa Truco para intercambiar objeto, Scrafty +2 (requiere pruebas)",
-      "variant": []
+      "detail": "Si entra Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Mantén Otra Vez cuando sea necesario."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Updates Johto Will strategy routes using the new Kanto-style structure.
- Replaces old strategy references and old team flow in Will files.
- Rewrites boosts into clearer language:
  - Gengar uses Nasty Plot as +2/+4/+6.
  - X Speed is written as +2 Speed.
  - Poliwrath uses Belly Drum to +6 Attack.
  - X Accuracy remains explicit.
- Cleans old shorthand like `6+2`, `4+2`, and `2+2` in Will strategy files.

## Updated matchups
- Absol
- Altaria
- Bronzong
- Chansey
- Claydol
- Clefable
- Electivire
- Empoleon
- Espeon
- Exeggutor
- Flareon
- Gardevoir
- Girafarig
- Golduck
- Golurk
- Grumpig
- Hypno
- Jolteon
- Jynx
- Liepard
- Lucario
- Magnezone
- Mantine
- Slowbro
- Typhlosion
- Umbreon
- Xatu

## Notes
- This PR targets `develop`.
- No visual assets are changed.
- No release to `main` is included yet.