### PR TITLE
Update Johto Koga strategies

### DIFF
--- a/src/data/johto/koga/ariados.json
+++ b/src/data/johto/koga/ariados.json
@@ -2,11 +2,24 @@
   "id": "ariados",
   "name": "Ariados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear Rhyperior, Cloyster +4. / Carámbano para todo",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Ariados no cambia, usa Amortiguador y revisa si entra Tangrowth.",
+      "variant": [
+        {
+          "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y luego Bostezo. Observa si Tangrowth acierta su ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth acierta, usa Teletransporte hacia Poliwrath. Usa Tambor hasta +6 Ataque, Puño Drenaje contra Tangrowth y, frente a Sharpedo, usa Velocidad X para +2 Velocidad y Puño Drenaje. 🔔 Sharpedo tiene Banda Focus. 🔔",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth falla, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/bisharp.json
+++ b/src/data/johto/koga/bisharp.json
@@ -2,15 +2,20 @@
   "id": "bisharp",
   "name": "Bisharp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Patada baja → Chandelure usa lanzallamas para debilitar o matar, entra Lapras, Poliwrath 6+2.",
-      "variant": []
-    },
-    {
-      "detail": "RHYPERIOR → Excadrill 6+2 y luego pon Trampa Rocas. Usa Terremoto para matar a Gengar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si entra Crobat.",
+      "variant": [
+        {
+          "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Gengar o Lapras.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/crobat.json
+++ b/src/data/johto/koga/crobat.json
@@ -2,96 +2,84 @@
   "id": "crobat",
   "name": "Crobat",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "ONDA ÍGNEA + BANDA FOCUS → Cambia a Chandelure y usa Truco",
+      "detail": "Coloca Trampa Rocas. Si Crobat se queda, observa qué ataque usa.",
       "variant": [
         {
-          "detail": "Crobat no se retira, entra Excadrill con +6 de Ataque y +2 de Velocidad. / Usa Terremoto para derrotar a Skuntank",
+          "detail": "Si usa Superdiente, cambia a Slowbro.",
           "variant": []
         },
         {
-          "detail": "Ampharos, entra Poliwrath +6 en Ataque y +4 en Velocidad",
+          "detail": "Si después sale Magmortar, usa Bostezo, sacrifica a Politoed y entra con Poliwrath. Usa Ataque X y empieza a barrer. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rhyperior, Slowbro usa Bostezo y recibe Megacuerno. Luego usa Protección y Bostezo hasta quedar frente a Gengar o Lapras. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Onda Ígnea + Vidasfera → Cambia a Chandelure // Si Crobat cambia directamente a Rhyperior o Stunfisk utiliza Truco, cambia a Cloyster+6 (Carámbano para Sharpedo)",
+      "detail": "Si Crobat usa Puya Nociva o Pájaro Osado, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Onda Ígnea acierta (Se activa el Abs. Fuego) // Usa Lanzallamas y observa qué Pokémon entra:",
-          "variant": [
-            {
-              "detail": "Rhyperior: cambia a Excadrill, luego a Chandelure y usa Truco para bloquear en Terremoto, luego entra Cloyster con +6. / Usa Carámbano para eliminar a Sharpedo",
-              "variant": []
-            },
-            {
-              "detail": "Tentacruel: cambia a Poliwrath, luego a Metagross para colocar Trampa Rocas, Poliwrath 6+2. / Usa primero la medicina de Velocidad. / Si queda congelado, descongela pues huevón! xd / Si crobat no a muerto utiliza otra velocidad X / A Bocajarro contra Skarmory",
-              "variant": []
-            },
-            {
-              "detail": "Electrode: cambia a Excadrill, luego a Chandelure, espera a que se autodestruya (entra Tentacruel), luego cambia a Metagross para colocar Trampa Rocas, Poliwrath 6+2. / Usa primero la medicina de Velocidad. Si Crobat no ha muerto, usar otra medicina de Velocidad",
-              "variant": []
-            },
-            {
-              "detail": "Floatzel: cambia a Poliwrath, luego a Chandelure y usa Truco",
-              "variant": [
-                {
-                  "detail": "Triturar, entra Scrafty con +3. / Usa Puño Drenaje + A Bocajarro para vencer a Scizor",
-                  "variant": []
-                },
-                {
-                  "detail": "Hidrobomba, entra Poliwrath 6+2",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Stunfisk: Excadrill +4 y +2",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Onda Ígnea falla (no se activa Absorbe Fuego) → Usar Truco:",
-          "variant": [
-            {
-              "detail": "Rhyperior o Stunfisk → entra Cloyster +6. / Usar Carámbano para eliminar a Sharpedo",
-              "variant": []
-            },
-            {
-              "detail": "Tentacruel → cambiar a Metagross para colocar Trampa Rocas, luego Poliwrath 6+4. / Usar medicina de Velocidad",
-              "variant": []
-            },
-            {
-              "detail": "Si Crobat no se retira → atacar con Lanzallamas, luego seguir el plan del escenario con Absorbe Fuego activado",
-              "variant": []
-            }
-          ]
+          "detail": "Si el rival se queda, entra con Volcarona, usa Danza Aleteo x1 y Psíquico. Frente a Electrode, vuelve a usar Danza Aleteo y termina de barrer.",
+          "variant": []
         }
       ]
     },
     {
-      "detail": "Lanzallamas [Zoroark disfrazado] → Chandelure usa Truco para intercambiar objetos, luego entra Scrafty con +3. / Usa Puño Drenaje + A Bocajarro para derrotar a Skarmory",
-      "variant": []
+      "detail": "Si Slowbro usa Bostezo frente a Zoroark, entra con Volcarona, usa Danza Aleteo x1 y Gigadrenado para derrotarlo.",
+      "variant": [
+        {
+          "detail": "Frente a Electrode o Tentacruel, usa Danza Aleteo una vez más y termina de barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona retrocede, cambia a Chansey, cura a Volcarona con Max Poción y repite la ruta.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Superdiente → entra Excadrill con Trampa Rocas, 4+2. // Terremoto para derrotar a Weezing / Nidoking. // Si luego entra Ditto al final del combate, cambia a Cloyster para derrotarlo // El daño de Superdiente se reduce y no te mata, ¡NO TE ASUSTES!",
-      "variant": []
+      "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte para sacar a Volcarona.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x1 y Gigadrenado. Frente a Electrode o Tentacruel, usa Danza Aleteo una vez más y termina de barrer.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Pájaro Osado → usa nuevamente Truco, bloquea a Rhyperior, // Luego Excadrill +6 y +2, coloca Trampa Rocas. / Terremoto para eliminar a Gengar",
-      "variant": []
-    },
-    {
-      "detail": "Nidoqueen → entra Cloyster +6. / Elimina todo con Carámbano // Si recibe daño de Lanzallamas, confirma que es Zoroark disfrazado y ajusta la estrategia según el patrón de ataque",
-      "variant": []
-    },
-    {
-      "detail": "RHYPERIOR → entra Excadrill +6 y+2, luego coloca Trampa Rocas. / Terremoto para derrotar a Gengar",
-      "variant": []
+      "detail": "Rutas por cambio rival:",
+      "variant": [
+        {
+          "detail": "Si sale Samurott, cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Ariados, usa Encanto y Amortiguador para forzar el cambio.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rhyperior, cambia a Slowbro y usa Bostezo. Luego usa Teletransporte hacia Poliwrath, usa Tambor hasta +6 Ataque y Puño Drenaje. Frente a Sharpedo, usa Velocidad X para +2 Velocidad y termina de barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y Bostezo. Observa si Tangrowth acierta: si acierta, usa Teletransporte hacia Volcarona; si falla, entra con Volcarona. En ambos casos, Volcarona usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Si Volcarona cae por crítico, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/ditto.json
+++ b/src/data/johto/koga/ditto.json
@@ -2,19 +2,20 @@
   "id": "ditto",
   "name": "Ditto",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "TRUCO FALLA (parálisis), cambia directo a Excadrill 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "PUÑO TRUENO → Excadrill 4+2, ¡no pongas Trampa Rocas!",
-      "variant": []
-    },
-    {
-      "detail": "NIDOKING → Cloyster 4, último Ditto, cambia a Poliwrath para rematar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Ditto se queda, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Si se sigue quedando, entra con Poliwrath, usa Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad. Usa Puño Drenaje contra Magmortar.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Sacrifica a Politoed, entra con Poliwrath y usa Ataque X. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/electrode.json
+++ b/src/data/johto/koga/electrode.json
@@ -2,33 +2,24 @@
   "id": "electrode",
   "name": "Electrode",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "NIDOQUEEN → Cloyster 6. / Mátalos a todos con Carambano. Si Cloyster recibe Fuego por error, confirma que es Zoroark y sigue la segunda línea.",
-      "variant": []
-    },
-    {
-      "detail": "Lanzallamas [Zoroark disfraz] → Chandelure usa Truco para cambiar objeto, Scrafty 3. / Usa Puño Drenaje + A Bocajarro para matar a Skarmory.",
-      "variant": []
-    },
-    {
-      "detail": "RAYO → Excadrill 6+2 / para huir de Nidoking, mira abajo 👇🏻",
+      "detail": "Coloca Trampa Rocas y revisa el movimiento de Electrode.",
       "variant": [
         {
-          "detail": "Cambia a Excadrill contra Nidoking → cambia a Chandelure para usar Truco y mira el movimiento:",
-          "variant": [
-            {
-              "detail": "Si usa Tierra Viva, Cloyster 6 / mátalos a todos con Carambano",
-              "variant": []
-            },
-            {
-              "detail": "Si usa Onda Tóxica, Scrafty 3 / usa Puño Drenaje + A Bocajarro para matar a Skarmory.",
-              "variant": []
-            }
-          ]
+          "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Gigadrenado para derrotar a Zoroark. Frente a Electrode o Tentacruel, usa Danza Aleteo una vez más.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona recibe retrocesos, cambia a Chansey, cura a Volcarona con Max Poción y repite la ruta.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Rayo, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2. Mantén los PS de Volcarona por encima del 50%; de lo contrario, Electrode puede usar Autodestrucción.",
+          "variant": []
         }
       ]
-    }    
+    }
   ]
 }

--- a/src/data/johto/koga/ferrothorn.json
+++ b/src/data/johto/koga/ferrothorn.json
@@ -2,15 +2,24 @@
   "id": "ferrothorn",
   "name": "Ferrothorn",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Nidoking → Cloyster +4, último Ditto, cambia a Poliwrath para rematar.",
-      "variant": []
-    },
-    {
-      "detail": "Swalot → Chandelure usa Truco para cambiar objeto, Excadrill 4+2, Terremoto para matar a Nidoking, si rompe el globo sigue barriendo, cuando salga Ditto cambia a Cloyster para rematar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Crobat, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Mantén Bostezo hasta tener a Magmortar enfrente.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed, entra con Poliwrath, usa Ataque X y empieza a barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/floatzel.json
+++ b/src/data/johto/koga/floatzel.json
@@ -2,32 +2,24 @@
   "id": "floatzel",
   "name": "Floatzel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "PUÑO TRUEÑO Y VER QUE PASA:",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Deja tocado al Floatzel → cambia a Chandelure contra Nidoking, usa Truco para encerrarlo en Terremoto o Tierra viva, Cloyster +4, último Ditto, cambia a Poliwrath para rematar.",
-      "variant": []
-    },
-    {
-      "detail": "Mata al Floatzel, entra Magmar → cambia a Chandelure y usa Truco, lo encierras en Rayo → Excadrill 4+2, Terremoto para matar a Nidoking, si rompe el globo sigue barriendo, cuando salga Ditto cambia a Cloyster para rematar.",
-      "variant": []
-    },
-    {
-      "detail": "Sale Stunfisk → cambia a Chandelure y usa Truco",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Si usa Tierra Viva, Cloyster 4",
+          "detail": "Si sale Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Sacrifica a Politoed, entra con Poliwrath, usa Ataque X y ataca. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Si usa Chispazo, Excadrill 2+2.// Terremoto para matar a Swalot afortunado (cuidado con Bostezo): no hace falta usar Truco, entra directo Excadrill 2+2.",
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si un crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Sale Nidoking → cambia a Excadrill, luego a Metagross para usar Truco, lo encierras en Tierra Viva, Cloyster 4, último Ditto, cambia a Poliwrath para rematar.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/koga/forretress.json
+++ b/src/data/johto/koga/forretress.json
@@ -2,11 +2,16 @@
   "id": "forretress",
   "name": "Forretress",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Truco para bloquear a Rhyperior/Nidoking",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Excadrill 4 + 2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Samurott, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/gengar.json
+++ b/src/data/johto/koga/gengar.json
@@ -2,15 +2,20 @@
   "id": "gengar",
   "name": "Gengar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "GASTA RECURSOS PERO RÁPIDO → Excadrill 6+2, luego pone Trampa Rocas. / Terremoto para matar a Gengar.",
-      "variant": []
-    },
-    {
-      "detail": "AHORRAR RECURSOS PERO LENTO → Excadrill hace Danza Espada una vez, luego pone Trampa Rocas, Cloyster +6.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Crobat, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Mantén Bostezo hasta que salga Gengar o Lapras.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/gliscor.json
+++ b/src/data/johto/koga/gliscor.json
@@ -2,11 +2,16 @@
   "id": "gliscor",
   "name": "Gliscor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Encerrar en Terremoto, Cloyster +6. Mátalos a todos con Carámbano",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Lucario, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/hypno.json
+++ b/src/data/johto/koga/hypno.json
@@ -2,19 +2,16 @@
   "id": "hypno",
   "name": "Hypno",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Para encerrar a Rhydon, elige lo que prefieras.",
-      "variant": []
-    },
-    {
-      "detail": "Más Rápido → Excadrill 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "Más barato → Excadrill pone Trampa Rocas, Cloyster 4.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Samurott, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/lanturn.json
+++ b/src/data/johto/koga/lanturn.json
@@ -2,19 +2,16 @@
   "id": "lanturn",
   "name": "Lanturn",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Escaldar → pon Trampa Rocas, Poliwrath 6+2",
-      "variant": []
-    },
-    {
-      "detail": "Rayo → Excadrill pone Trampa Rocas 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "Gliscor → Cloyster 6. / Mátalos a todos con Carámbano.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Lucario, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/lapras.json
+++ b/src/data/johto/koga/lapras.json
@@ -2,11 +2,20 @@
   "id": "lapras",
   "name": "Lapras",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Encerrar a Rhyperior, Excadrill 6+2 y luego poner Trampa Rocas. / Terremoto para matar a Gengar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Crobat, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Mantén Bostezo hasta que salga Gengar o Lapras.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/lucario.json
+++ b/src/data/johto/koga/lucario.json
@@ -2,11 +2,42 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Truco, para encerrar en Triturar, Scrafty +2. Dos Palizas seguidas para matar a Gliscor.",
-      "variant": []
+      "detail": "Opción rápida:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si Crobat pega crítico:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Opción estable:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar y usa Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Cambia a Slowbro y luego a Chansey para colocar Trampa Rocas.",
+          "variant": []
+        },
+        {
+          "detail": "Cuando salga Lucario, vuelve a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/magmortar.json
+++ b/src/data/johto/koga/magmortar.json
@@ -2,32 +2,24 @@
   "id": "magmortar",
   "name": "Magmortar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gran Llamarada → Truco para encerrar Rayo, Excadrill 4+2, Terremoto para matar a Nidoking, si rompe el globo sigue barriendo, cuando salga Ditto cambia a Cloyster para rematar. (NO PONGAS ROCAS)",
-      "variant": []
-    },
-    {
-      "detail": "Contra Ferrothorn → usa Lanzallamas para rematar y ve quién entra 👇🏻",
+      "detail": "Coloca Trampa Rocas. Si sale Crobat, cambia a Slowbro.",
       "variant": [
         {
-          "detail": "Sale Floatzel → cambia a Poliwrath, luego a Chandelure para usar Truco, encierra HidroBomba, Poliwrath 6+2 + revive Chandelure + cura todo. / Último Ditto, cambia a Chandelure para rematar.",
+          "detail": "Mantén Bostezo hasta que salga Magmortar.",
           "variant": []
         },
         {
-          "detail": "Si Nidoking hace CT y te mata, cambia a Metagross para usar Truco, encierra Terremoto, Cloyster 4 + revive Poliwrath.",
+          "detail": "Sacrifica a Politoed, entra con Poliwrath y usa Ataque X.",
           "variant": []
         },
         {
-          "detail": "Sale Swalot → cambia a Excadrill, luego a Chandelure para usar Truco, encierra Rayo, Excadrill 4+2, Terremoto para matar a Nidoking, espera a que Roca Afilada rompa el globo y sigue barriendo, cuando salga Ditto cambia a Cloyster para rematar. Si Roca Afilada falla, usa Danza Espada y espera a que acierte.",
+          "detail": "Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Sale Magmortar → Cambia a Excadrill, luego a Chandelure para usar Truco, encierra Rayo, Excadrill 4+2. Terremoto para matar a Nidoking, espera a que Roca Afilada rompa el globo y sigue barriendo, cuando salga Ditto cambia a Cloyster para rematar. Si Roca Afilada falla, usa Danza Espada y espera a que acierte.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/koga/muk.json
+++ b/src/data/johto/koga/muk.json
@@ -2,15 +2,20 @@
   "id": "muk",
   "name": "Muk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Puño Fuego → Truco para encerrar Puya Nociva / Sombra Vil, Excadrill 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "Contra Rhydon o Rhyperior → Truco para encerrar Terremoto, Excadrill 4+2.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Samurott, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "En esta ruta no sale Ditto.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/nidoking.json
+++ b/src/data/johto/koga/nidoking.json
@@ -2,11 +2,24 @@
   "id": "nidoking",
   "name": "Nidoking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Encerrar Tierra Viva, Cloyster +4. / Último Ditto, cambia a Poliwrath y usa A Bocajarro para rematar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Crobat, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo hasta que salga Magmortar.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed, entra con Poliwrath y usa Ataque X.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Puño Drenaje contra Magmortar. Si entra Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/nidoqueen.json
+++ b/src/data/johto/koga/nidoqueen.json
@@ -2,15 +2,24 @@
   "id": "nidoqueen",
   "name": "Nidoqueen",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Tierra Viva / después de Nidoking → Cloyster +6. / Debilita a todos con Carámbano. Si te queman por error, confirma que es Zoroark y sigue la segunda línea.",
-      "variant": []
-    },
-    {
-      "detail": "Lanzallamas [Zoroark disfrazado] → Chandelure usa Truco para cambiar objeto, Scrafty 3. / Usa Puño Drenaje + A Bocajarro para matar a Skarmory.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa el movimiento de Nidoqueen.",
+      "variant": [
+        {
+          "detail": "Si usa Tierra Viva o Bomba Lodo, usa Teletransporte hacia Slowbro y luego Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
+          "variant": []
+        },
+        {
+          "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Gigadrenado contra Zoroark. Barre hasta Electrode o Tentacruel y usa Danza Aleteo una vez más para terminar.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona retrocede, cambia a Chansey, cura a Volcarona al máximo y repite la ruta anterior.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/ninetales.json
+++ b/src/data/johto/koga/ninetales.json
@@ -2,15 +2,24 @@
   "id": "ninetales",
   "name": "Ninetales",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "LLAMARADA → Cambia a Chandelure y usa Truco para bloquear Rhyperior, Cloyster +4 // Elimina todo con Carámbano",
-      "variant": []
-    },
-    {
-      "detail": "RHYPERIOR → Cloyster +4. / Elimina todo con Carámbano",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Tangrowth, usa Teletransporte hacia Slowbro y luego Bostezo.",
+      "variant": [
+        {
+          "detail": "Observa si Latigazo acierta.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth acierta, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth falla, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/parasect.json
+++ b/src/data/johto/koga/parasect.json
@@ -2,29 +2,24 @@
   "id": "parasect",
   "name": "Parasect",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Chupa vidas → Lanzallamas para rematar, observa quién entra 👇🏻",
+      "detail": "Coloca Trampa Rocas. Si Parasect se queda, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Sale Rotom → Cambia a Poliwrath y luego a Chandelure, espera que cambie Voltiocambio, observa quién entra",
-          "variant": [
-            {
-              "detail": "Skuntank, Scrafty usa + Defensa X +3",
-              "variant": []
-            },
-            {
-              "detail": "Crobat, Truco para bloquear Veneno, Excadrill 6+2.",
-              "variant": []
-            }
-          ]
+          "detail": "Si todavía se queda, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario después de pasar por Poliwrath, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario directo, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
         }
       ]
-    },
-    {
-      "detail": "Contra Gliscor → Truco para bloquear Terremoto, Cloyster 6. / Usa carámbano para matar. Ahorrar: sin Truco, Excadrill pone Trampa Rocas 4+2.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/koga/rhyperior.json
+++ b/src/data/johto/koga/rhyperior.json
@@ -2,15 +2,24 @@
   "id": "rhyperior",
   "name": "Rhyperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Restos → Excadrill 6+2 y luego pone Trampa Rocas. / Terremoto para matar a Gengar",
-      "variant": []
-    },
-    {
-      "detail": "Chaleco Asalto → Cloyster +4. // Usa carámbano para matar // Sharpedo Banda Focus",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué pasa después.",
+      "variant": [
+        {
+          "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Hypno.",
+          "variant": []
+        },
+        {
+          "detail": "Si Rhyperior usa Terremoto, usa Encanto. Luego cambia a Slowbro, usa Bostezo y espera quedar frente a Gengar o Lapras. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y Bostezo. Observa si Tangrowth acierta: si acierta, usa Teletransporte hacia Volcarona; si falla, entra con Volcarona. En ambos casos, Volcarona usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/samurott.json
+++ b/src/data/johto/koga/samurott.json
@@ -2,17 +2,13 @@
   "id": "samurott",
   "name": "Samurott",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear a Rhyhorn, elige tú.",
+      "detail": "Coloca Trampa Rocas, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Rápido --> Excadrill 4+2",
-          "variant": []
-        },
-        {
-          "detail": "Ahorrar --> Excadrill pone Trampa Rocas, Cloyster 4",
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/scizor.json
+++ b/src/data/johto/koga/scizor.json
@@ -2,15 +2,20 @@
   "id": "scizor",
   "name": "Scizor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🦋 Cambia a Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Contra Stunfisk → Truco para bloquear Terremoto o Tierra Viva, Cloyster +4.",
-      "variant": []
-    },
-    {
-      "detail": "No cambia → Truco para bloquear Puño Bala, luego cambia a Metagross, Truco para bloquear a Stunfisk, Cloyster 4.",
-      "variant": []
+      "detail": "Cambia a Volcarona frente a Scizor.",
+      "variant": [
+        {
+          "detail": "Usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si un crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/sharpedo.json
+++ b/src/data/johto/koga/sharpedo.json
@@ -2,11 +2,24 @@
   "id": "sharpedo",
   "name": "Sharpedo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear Terremoto/Rhyperior, Cloyster +4. // Usa Carámbano para barrer TODO",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Tangrowth, usa Teletransporte hacia Slowbro y luego Bostezo.",
+      "variant": [
+        {
+          "detail": "Observa si Tangrowth acierta.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth acierta, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth falla, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/skarmory.json
+++ b/src/data/johto/koga/skarmory.json
@@ -2,20 +2,24 @@
   "id": "skarmory",
   "name": "Skarmory",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "NIDOQUEEN → Cloyster +6 // Elimina todo con Carámbano",
+      "detail": "Coloca Trampa Rocas y revisa el movimiento de Skarmory.",
       "variant": [
         {
-          "detail": "Si inesperadamente recibe Lanzallamas → Confirma que es Zoroark así que revisa la Estrategia de abajo.",
+          "detail": "Si usa Pico Taladro, cambia a Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
+          "variant": []
+        },
+        {
+          "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Gigadrenado contra Zoroark. Barre hasta Electrode o Tentacruel y usa Danza Aleteo una vez más para terminar.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona recibe retrocesos, cambia a Chansey, cura a Volcarona con Max Poción y repite la ruta.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "LANZALLAMAS (Zoroark Disfraz) → Chandelure usa Truco para intercambiar objeto, Scrafty +3 // Puño Drenaje + A Bocajarro para eliminar Skarmory",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/koga/skuntank.json
+++ b/src/data/johto/koga/skuntank.json
@@ -2,11 +2,20 @@
   "id": "skuntank",
   "name": "Skuntank",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Truco, Scrafty sube defensa +3, Paliza para eliminar a Gliscor",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Lucario, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "🔔 Skuntank tiene Pañuelo Elegido. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/starmie.json
+++ b/src/data/johto/koga/starmie.json
@@ -2,11 +2,20 @@
   "id": "starmie",
   "name": "Starmie",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "FLYGON → Truco para bloquear Terremoto, Cloyster +4 / Carámbano para Toxicroak y Crobat",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Toxicroak, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "🔔 Toxicroak tiene Banda Focus. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/stunfisk.json
+++ b/src/data/johto/koga/stunfisk.json
@@ -2,11 +2,20 @@
   "id": "stunfisk",
   "name": "Stunfisk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🦋 Cambia a Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Bloquear Tierra Viva, Cloyster 4",
-      "variant": []
+      "detail": "Cambia a Volcarona. Si sale Scizor, prepara el sweep.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si un crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/swalot.json
+++ b/src/data/johto/koga/swalot.json
@@ -2,11 +2,20 @@
   "id": "swalot",
   "name": "Swalot",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🦋 Cambia a Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Bloquear a Whiscash / Stunkfish, Cloyster +4 / Carámbano a Swalot",
-      "variant": []
+      "detail": "Cambia a Volcarona. Si sale Scizor, prepara el sweep.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si un crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/tangrowth.json
+++ b/src/data/johto/koga/tangrowth.json
@@ -2,11 +2,24 @@
   "id": "tangrowth",
   "name": "Tangrowth",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto, cambia a Cloyster +4 (Sharpedo muere con Carámbano)",
-      "variant": []
+      "detail": "Coloca Trampa Rocas, usa Teletransporte hacia Slowbro y luego Bostezo.",
+      "variant": [
+        {
+          "detail": "Observa si Tangrowth acierta su ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth acierta, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth falla, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/tentacruel.json
+++ b/src/data/johto/koga/tentacruel.json
@@ -2,19 +2,41 @@
   "id": "tentacruel",
   "name": "Tentacruel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Escaldar → Coloca Trampa Rocas, entra Poliwrath 6+2. // Usa A Bocajarro para derrotar a Skarmory",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Tentacruel se queda, revisa qué movimiento usa.",
+      "variant": [
+        {
+          "detail": "Si usa Escaldar, cambia a Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
+          "variant": []
+        },
+        {
+          "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Gigadrenado. Frente a Electrode o Tentacruel, usa Danza Aleteo una vez más para barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona retrocede, cambia a Chansey, cura a Volcarona al máximo con Max Poción y repite la ruta.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Después de Nidoqueen → Entra Cloyster +6. // Usa Carámbano contra todo. // Sí fue derrotado inesperadamente por Lanzallamas, confirma que era un Zoroark disfrazado y observa estrategia de abajo.",
-      "variant": []
-    },
-    {
-      "detail": "Lanzallamas [Zoroark disfrazado] → Chandelure usa Truco para intercambiar objetos, luego entra Scrafty +3. // Puño Drenaje + A Bocajarro para derrotar a Skarmory",
-      "variant": []
+      "detail": "Si sale Crobat, usa Teletransporte para ver el movimiento.",
+      "variant": [
+        {
+          "detail": "Si usa Veneno X o Puya Nociva, cambia a Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
+          "variant": []
+        },
+        {
+          "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Gigadrenado. Frente a Electrode o Tentacruel, usa Danza Aleteo una vez más para barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona retrocede, cambia a Chansey, cura a Volcarona al máximo con Max Poción y repite la ruta.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/venomoth.json
+++ b/src/data/johto/koga/venomoth.json
@@ -2,11 +2,20 @@
   "id": "venomoth",
   "name": "Venomoth",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🦋 Cambia a Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Cambia a Cloyster +4. Estando Stunfisk encerrado en tierra viva. (Swalot muere con Carámbano)",
-      "variant": []
+      "detail": "Cambia a Volcarona. Si queda frente a Scizor, prepara el sweep.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si un crítico derrota a Volcarona, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/weezing.json
+++ b/src/data/johto/koga/weezing.json
@@ -2,20 +2,20 @@
   "id": "weezing",
   "name": "Weezing",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "TRUCO, para bloquear Rayo, Excadrill pone Trampa Rocas.",
+      "detail": "Coloca Trampa Rocas frente a Crobat, cambia a Slowbro y usa Bostezo constantemente hasta que salga Gengar o Lapras.",
       "variant": [
         {
-          "detail": "NO CAMBIA : Excadrill 6+2. / Terremoto para matar a Gengar.",
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "SALE LAPRAS : Poliwrath 6+2. / Terremoto para matar a Gengar.",
+          "detail": "Usa Puño Hielo contra Gengar.",
           "variant": []
         }
       ]
-    }    
+    }
   ]
 }


### PR DESCRIPTION
## Resumen
- Actualiza las 33 estrategias de Johto Koga.
- Limpia textos antiguos con boosts crudos tipo `+4 +2`, `+6 +2` y rutas abreviadas.
- Normaliza instrucciones con Gengar, Poliwrath, Volcarona, Politoed, Precisión X, Velocidad X, Ataque X y Especial X.
- Mantiene la estructura JSON existente: `id`, `name`, `image`, `initialMove`, `tricks`, `variant`.

## Alcance
Solo se modifican archivos dentro de `src/data/johto/koga`.

## Nota
No se toca `main`, assets ni visuales.