### PR TITLE
Update Johto Bruno strategies

### DIFF
--- a/src/data/johto/bruno/aggron.json
+++ b/src/data/johto/bruno/aggron.json
@@ -2,11 +2,20 @@
   "id": "aggron",
   "name": "Aggron",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CLOISTER",
+  "initialMove": "❤️ Encanto ❤️",
   "tricks": [
     {
-      "detail": "Aggron: Cloyster usa Rompecoraza + 4 + Especial X. // Usa Surf para matar a Hitmontop / Machamp.",
-      "variant": []
+      "detail": "Usa Encanto y toma una Max Poción.",
+      "variant": [
+        {
+          "detail": "Luego usa Amortiguador contra Machamp.",
+          "variant": []
+        },
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez y Maquinación hasta +4.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/blastoise.json
+++ b/src/data/johto/bruno/blastoise.json
@@ -2,15 +2,24 @@
   "id": "blastoise",
   "name": "Blastoise",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A POLIWRATH",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Hidro Bomba → Poliwrath 6+2.",
-      "variant": []
-    },
-    {
-      "detail": "Contra Machamp → Chandelure usa Truco y lo bloquea en Roca Afilada. Luego entra Scrafty 2+ y usa Raíz Energía, después sube +1 más. Si Chandelure muere, haz un Danza Dragón extra.",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. 🔔 Blaziken tiene Pañuelo Elegido. 🔔",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo contra Metagross. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/blaziken.json
+++ b/src/data/johto/bruno/blaziken.json
@@ -2,19 +2,16 @@
   "id": "blaziken",
   "name": "Blaziken",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE Y TRUCO",
+  "initialMove": "💡 Cambia a Gengar 💡",
   "tricks": [
     {
-      "detail": "NO SE RETIRA → Excadrill 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "BLASTOISE → Poliwrath 6+2",
-      "variant": []
-    },
-    {
-      "detail": "MACHAMP → Scrafty 3. / A Bocajarro para matar a Machamp y Metagross.",
-      "variant": []
+      "detail": "Cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+      "variant": [
+        {
+          "detail": "🔔 Blaziken tiene Pañuelo Elegido. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/darmanitan.json
+++ b/src/data/johto/bruno/darmanitan.json
@@ -2,15 +2,34 @@
   "id": "darmanitan",
   "name": "Darmanitan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "DARMANITAN NO CAMBIA → Chandelure +4+0 , Usa Lanzallamas para limpiar equipo.",
-      "variant": []
+      "detail": "Opción para asegurar:",
+      "variant": [
+        {
+          "detail": "Entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "SEISMITOAD → Truco para bloquear Terremoto, luego Cloyster +4.",
-      "variant": []
+      "detail": "Opción estable:",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Opción arriesgada:",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/eelektross.json
+++ b/src/data/johto/bruno/eelektross.json
@@ -2,19 +2,28 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Chandelure.",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "NO CAMBIA → Truco para bloquear Rayo, Excadrill 4+2",
-      "variant": []
-    },
-    {
-      "detail": "MACHAMP → Truco para bloquear Roca afilada, Scrafty +5 / usa Raíz Energía para curar si tienes muy poca vida (cuidado Hitmonchan puede tener ultrapuño)",
-      "variant": []
-    },
-    {
-      "detail": "TORTERRA / SWAMPERT / METAGROSS → Truco para bloquear Terremoto, Cloyster +4",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. 🔔 Blaziken tiene Pañuelo Elegido. 🔔",
+          "variant": []
+        },
+        {
+          "detail": "Si quedas frente a Darmanitan, elige una ruta: ahorro con Volcarona usando Danza Aleteo x3; estable con Slowbro usando Bostezo, sacrificando a Politoed y entrando con Poliwrath para usar Tambor hasta +6 Ataque; o RNG sacrificando a Politoed y entrando directo con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo. Cuando salga Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/electivire.json
+++ b/src/data/johto/bruno/electivire.json
@@ -2,32 +2,45 @@
   "id": "electivire",
   "name": "Electivire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Aggron o Golem → Cloister 4+ +Especial X, usa Surf para acabar con Metagross y Hitmonp",
-      "variant": []
-    },
-    {
-      "detail": "Lanzallamas → Chandelure usa Truco, luego Excadrill 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "Gigalith → Cloister 4.",
-      "variant": []
-    },
-    {
-      "detail": "Slowbro → elegir según situación.",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Para quitar velocidad → pon Roca Afilada, entra Aggron, luego Cloister 4+ , usa Surf para matar a Conkeldurr.",
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo repetidamente hasta que salga Golem. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Para ahorrar → pon Trampa Rocas, entra Aggron, luego Cloister 4, usa Surf para matar a Conkeldurr.",
+          "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
           "variant": []
         }
       ]
-    }    
+    },
+    {
+      "detail": "Si Electivire se queda, cambia a Gengar y usa Maquinación hasta +4. Barre con Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Si sale Salamence, sigue barriendo hasta que salga Aggron.",
+          "variant": []
+        },
+        {
+          "detail": "Si Gengar derrota a Aggron con crítico, termina de barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si Aggron derrota a Gengar y no activa Cuerpo Maldito, entra con Volcarona, derrota a Aggron y frente a Slowbro enemigo usa Danza Aleteo antes de atacar.",
+          "variant": []
+        },
+        {
+          "detail": "Si Aggron derrota a Gengar y se activa Cuerpo Maldito, entra con Volcarona y usa Danza Aleteo x1.",
+          "variant": []
+        }
+      ]
+    }
   ]
 }

--- a/src/data/johto/bruno/gliscor.json
+++ b/src/data/johto/bruno/gliscor.json
@@ -2,11 +2,20 @@
   "id": "gliscor",
   "name": "Gliscor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Bloquear Terremoto, luego Cloyster 6 + Defensa X",
-      "variant": []
+      "detail": "Usa Amortiguador y prepara la ruta con Slowbro.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo contra Metagross.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/golem.json
+++ b/src/data/johto/bruno/golem.json
@@ -2,11 +2,20 @@
   "id": "golem",
   "name": "Golem",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "❤️ Encanto + 🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "bloquear Terremoto, luego Cloyster +4. // Carámbano para Machamp",
-      "variant": []
+      "detail": "Usa Encanto y coloca Trampa Rocas.",
+      "variant": [
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/heracross.json
+++ b/src/data/johto/bruno/heracross.json
@@ -2,15 +2,66 @@
   "id": "heracross",
   "name": "Heracross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "ELEGIR SITUACIÓN",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Ejecución Segura→ usa Puño Trueno, entra Steelix, luego Cloister 4+ con Especial X. Si no usas Especial X, hay 12.5% de que Slowbro te contraataque y te mate.",
-      "variant": []
+      "detail": "Ruta arriesgada con Trampa Rocas:",
+      "variant": [
+        {
+          "detail": "Coloca Trampa Rocas. Si no recibes crítico, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si recibes crítico pero alcanzaste a usar Trampa Rocas, sacrifica a Politoed, entra con Poliwrath, luego vuelve a Gengar. Usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si recibes crítico sin haber usado Trampa Rocas, la ruta se cae y conviene reiniciar.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Ahorrar Recursos → Trampa Rocas y entra Steelix, luego Cloyster +4.",
-      "variant": []
+      "detail": "Ruta segura con Gengar:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Heracross se queda, derrótalo. Si sale Steelix, cambia a Slowbro, usa Bostezo, luego Teletransporte hacia Chansey y coloca Trampa Rocas.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp, cambia a Gengar y usa Otra Vez. Luego cambia a Chansey; cuando salga Staraptor, vuelve a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Staraptor, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Kangaskhan, cambia a Chansey y coloca Trampa Rocas. Luego sigue la ruta correspondiente de Kangaskhan.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta alternativa por Machamp:",
+      "variant": [
+        {
+          "detail": "Si sale Machamp, cambia a Chansey y luego a Gengar. Usa Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Machamp se queda, derrótalo. Si entra Steelix, cambia a Slowbro, mantén Bostezo hasta que salga Heracross, usa Teletransporte hacia Chansey y coloca Trampa Rocas.",
+          "variant": []
+        },
+        {
+          "detail": "Si luego sale Staraptor, vuelve a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/hitmonchan.json
+++ b/src/data/johto/bruno/hitmonchan.json
@@ -2,6 +2,16 @@
   "id": "hitmonchan",
   "name": "Hitmonchan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Chandelure y usa Truco para bloquear Roca Afilada, Scrafty +3 / A Bocajarro para eliminar Machamp. // Si Chandelure cae, ajusta a Scrafty +4 o también puede boostear a +2 + objeto Ataque X. (Depende de si lo quieres hacer rápido o quieres ahorrar)",
-  "tricks": []
+  "initialMove": "Slowbro + Bostezo",
+  "tricks": [
+    {
+      "detail": "Cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/johto/bruno/hitmonlee.json
+++ b/src/data/johto/bruno/hitmonlee.json
@@ -2,11 +2,28 @@
   "id": "hitmonlee",
   "name": "Hitmonlee",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Gengar → Slowbro → Chansey 💡",
   "tricks": [
     {
-      "detail": "Steelix, luego Cloyster +6.",
-      "variant": []
+      "detail": "Entra con Gengar, luego cambia a Slowbro y usa Bostezo. Después cambia a Chansey y coloca Trampa Rocas.",
+      "variant": [
+        {
+          "detail": "Si Hitmonlee se queda, vuelve a Gengar y derrótalo con Bola Sombra. Si sale Machamp, cambia a Chansey y luego vuelve a Gengar. Usa Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Machamp se queda, usa Maquinación hasta +6. Mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Salamence, derrótalo. Cuando salga Machamp, cambia a Poliwrath y luego vuelve a Gengar. Usa Maquinación hasta +6, mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp o Luxray, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Si se queda, sube con Maquinación hasta +6 y mantén Otra Vez cada vez que puedas.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/hitmontop.json
+++ b/src/data/johto/bruno/hitmontop.json
@@ -2,6 +2,16 @@
   "id": "hitmontop",
   "name": "Hitmontop",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Trampa Rocas, entra Aggron, luego Cloyster +4, usa Surf para matar a Hitmontop.",
-  "tricks": []
+  "initialMove": "🥚 Amortiguador 🥚",
+  "tricks": [
+    {
+      "detail": "Usa Amortiguador y revisa si entra Machamp.",
+      "variant": [
+        {
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/johto/bruno/kangaskhan.json
+++ b/src/data/johto/bruno/kangaskhan.json
@@ -2,11 +2,16 @@
   "id": "kangaskhan",
   "name": "Kangaskhan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "PUÑO TRUENO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "STEELIX → Cloyster +4 + Especial X / Carámbano para Heracross",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si quedas frente a Heracross, usa Amortiguador y luego Teletransporte para recibir A Bocajarro.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. 🔔 Heracross tiene Banda Focus. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/krookodile.json
+++ b/src/data/johto/bruno/krookodile.json
@@ -2,10 +2,10 @@
   "id": "krookodile",
   "name": "Krookodile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CLOISTER",
+  "initialMove": "🦋 Volcarona +2 🦋",
   "tricks": [
     {
-      "detail": "Cloister + 4 + Especial X. Usa Carámbano para matar a Lucario.",
+      "detail": "Entra con Volcarona y usa Danza Aleteo x2.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/lucario.json
+++ b/src/data/johto/bruno/lucario.json
@@ -2,15 +2,20 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "NO SE VA → Usar Truco para bloquear Pulso Umbrío o Bola Sombra, luego entra Scrafty con +4; también puedes usar A Bocajarro para eliminar a Poliwrath o Metagross",
-      "variant": []
-    },
-    {
-      "detail": "KROOKODILE→ Cloyster entra con +4 y usa Medicina Especial X para potenciar el ataque, también puedes usar Carámbano para eliminar a Lucario si entra en relevo",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Machamp, cambia a Gengar y usa Otra Vez. Luego cambia a Chansey; cuando salga Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Krookodile o Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/luxray.json
+++ b/src/data/johto/bruno/luxray.json
@@ -2,11 +2,20 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas → Gengar 🪨",
   "tricks": [
     {
-      "detail": "Bloquear a Steelix, luego Cloyster +6.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
+      "variant": [
+        {
+          "detail": "Si Luxray se queda, usa Maquinación hasta +6. Mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Salamence, derrótalo con Bola Sombra. Cuando salga Machamp, cambia a Poliwrath y luego vuelve a Gengar. Usa Otra Vez, Maquinación hasta +6 y mantén Otra Vez cada vez que puedas para derrotar a todos con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/machamp.json
+++ b/src/data/johto/bruno/machamp.json
@@ -2,96 +2,121 @@
   "id": "machamp",
   "name": "Machamp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "💡 Gengar 💡",
   "tricks": [
     {
-      "detail": "Puño Drenaje → Usar Truco",
+      "detail": "Entra con Gengar y revisa el ataque de Machamp.",
       "variant": [
         {
-          "detail": "Roca Afilada → Excadrill 4 + 2",
+          "detail": "Si usa Puño Dinámico, cambia a Slowbro y usa Bostezo.",
           "variant": []
         },
         {
-          "detail": "Corpulencia / Descanso → Cambiar a Metagross",
-          "variant": [
-            {
-              "detail": "Metagross → Truco y bloquear Terremoto, luego Cloyster +4",
-              "variant": []
-            },
-            {
-              "detail": "Darmanitan → Cambiar a Chandelure:",
-              "variant": [
-                {
-                  "detail": "Opción Rápida: Usar Chandelure con +4 en Ataque Especial, luego Truco para intercambiar objeto // Barrer con Lanzallamas",
-                  "variant": []
-                },
-                {
-                  "detail": "Ahorra Recursos: Usar Truco dos veces, bloquear con Avalancha // Scrafty +3",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Machamp no se retira → Truco para bloquear Quagsire / Torterra / Metagross / Seismitoad , Cloyster +4",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Puño Drenaje → Usar Lanzallamas // Si Machamp no se retira o aparece Torterra, seguir usando Lanzallamas",
-          "variant": [
-            {
-              "detail": "Entra Darmanitan → Excadrill 4 + 0 // Si darmanitan recupera salud cambia a Chandelure +4 + 0 y utiliza Truco 1 vez // Lanzallamas para barrer",
-              "variant": []
-            },
-            {
-              "detail": "Entra Quagsire / Seismitoad → Cambiar a Cloyster y luego a Metagross con Truco, bloquear Terremoto, Cloyster +4",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Vendetta→ Excadrill pone Trampa Rocas, luego cambiar a Scrafty y después a Metagross // Si aparece Volcarona, usar Puño Trueno (si entra Steelix), Cloyster +2 + Medicina Especial",
+          "detail": "Si usa Vendetta, usa Bostezo. Cuando salga Metagross o Eelektross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Quagsire / Torterra / Seismitoad → Cloyster +4",
+          "detail": "Si usa Roca Afilada, usa Bostezo.",
           "variant": []
         },
         {
-          "detail": "Darmanitan → Scrafty +3",
+          "detail": "Si usa Puño Hielo, usa Bostezo frente a Metagross. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Puño Dinámico → Truco y revisar el objeto",
+      "detail": "Ruta con Salamence sin Intimidación:",
       "variant": [
         {
-          "detail": "Baya Atania → Scrafty +3 (A Bocajarro mata a Hitmontop) // Te puedes curar con Puño Drenaje si estás +2",
+          "detail": "Cambia a Chansey y coloca Trampa Rocas. Frente a Hitmonlee, entra con Gengar y usa Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Restos → Scrafty usa medicina de Defensa y boostea a +3 (puede curarse con Puño Drenaje si está +2) // A Bocajarro para matara a Machamp o 2 Puño Drenaje si quieres curarte",
+          "detail": "Si el rival saca Machamp, cambia a Chansey y luego vuelve a Gengar. Usa Otra Vez y Maquinación hasta +4.",
           "variant": []
         },
         {
-          "detail": "Blastoise → Poliwrath +6 +2",
+          "detail": "Gengar tiene una probabilidad baja de debilitar a Steelix. Si Gengar cae, entra con Volcarona y usa Danza Aleteo x1.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Krookodile → Cloyster +4 + Especial X // Carámbano para Lucario",
-      "variant": []
+      "detail": "Ruta por Patada Salto Alta o si Hitmonlee huye frente a Machamp:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y luego a Chansey frente a Luxray. Entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Golem → Truco y bloquear Terremoto → Cloyster +4",
-      "variant": []
+      "detail": "Rutas por cambios del rival:",
+      "variant": [
+        {
+          "detail": "Si sale Eelektross, usa Encanto con Chansey. Frente a Aggron usa Amortiguador; cuando vuelva Machamp, cambia a Gengar, usa Otra Vez y Maquinación hasta +4.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross o Torterra, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "STEELIX → Cloyster +4 + Medicina Especial // Si no usas medicina especial, hay un 12.5% de probabilidad de ser derrotado de un golpe HERACROSS Tiene Banda Focus usar Carámbano",
-      "variant": []
+      "detail": "Si Machamp usa Puño Drenaje con Llamaesfera:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Si se queda, derrótalo. Si sale Steelix, cambia a Slowbro y usa Bostezo. Si se queda, usa Protección y luego Bostezo otra vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Heracross, cambia a Chansey y luego a Gengar. Usa Maquinación hasta +4 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si Heracross cambia a Steelix, coloca Trampa Rocas con Chansey.",
+          "variant": []
+        },
+        {
+          "detail": "Si Machamp vuelve, cambia a Gengar y luego a Chansey. Frente a Staraptor, entra con Gengar, usa Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Staraptor, cambia a Slowbro. Si después sale Lucario, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross y luego Lucario, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si Machamp usa Puño Drenaje sin Llamaesfera:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Golem, usa Teletransporte hacia Chansey y coloca Trampa Rocas. Si luego sale Metagross, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Derrótalo; cuando salga Golem, usa otra Maquinación y sigue barriendo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross o Torterra, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/metagross.json
+++ b/src/data/johto/bruno/metagross.json
@@ -2,89 +2,45 @@
   "id": "metagross_2",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto, revisar el objeto:",
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
       "variant": [
         {
-          "detail": "Refleluz → Excadrill con Trampa Rocas + 4 Atq / +2 Vel",
+          "detail": "Si Metagross se queda, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Baya Zidra → Cloyster +4",
+          "detail": "Si sale Darmanitan, puedes elegir entre ahorro con Volcarona usando Danza Aleteo x3, ruta estable con Slowbro usando Bostezo y Poliwrath con Tambor hasta +6 Ataque, o ruta RNG sacrificando a Politoed y entrando directo con Poliwrath.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo. Cuando vuelva Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Machada, cambiar a Chandelure",
+      "detail": "Si sale Machamp, cambia a Gengar y revisa el ataque.",
       "variant": [
         {
-          "detail": "Golem → Usar Truco para bloquear Terremoto, luego Cloyster +4",
+          "detail": "Si usa Puño Dinámico, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si no se retira → Usar Lanzallamas para debilitar, entra Golem, cambiar a Metagross para sacrificarlo, luego Chandelure con Truco para bloquear Terremoto, Cloyster +4",
+          "detail": "Si usa Puño Drenaje, usa Otra Vez con Gengar. Luego cambia a Chansey; cuando salga Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Krookodile o Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Puño Hielo, cambiar a Chandelure",
-      "variant": [
-        {
-          "detail": "Machamp o Eelektross → Usar Truco",
-          "variant": [
-            {
-              "detail": "Roca Afilada / Avalancha o Vendetta → Scrafty +3. / Usar A Bocajarro para eliminar a Metagross",
-              "variant": []
-            },
-            {
-              "detail": "Blastoise → Poliwrath +6 Atq / +2 Vel",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Blaziken → Excadrill +4 Atq / +2 Vel",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Poder Oculto, usar directamente Chandelure + 2 Píldoras de Ataque SP. / Usar Lanzallamas para barrer el equipo",
-      "variant": []
-    },
-    {
-      "detail": "Machamp, cambiar a Chandelure",
-      "variant": [
-        {
-          "detail": "Si no se retira → Usar Bola Sombra continuamente",
-          "variant": [
-            {
-              "detail": "Blastoise → Poliwrath +6 / +2. / Si cambia a Eelektross saca a Excadrill, luego a Chandelure y usar Truco para bloquear Puño Trueno, Excadrill +4 / +2",
-              "variant": []
-            },
-            {
-              "detail": "Eelektross → Cambiar a Excadrill, luego a Chandelure con Truco para bloquear Puño Trueno, Excadrill +4 / +2. Si entra Blastoise mientras te boosteas,entonces cambia Poliwrath +6 / +2",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Gliscor → Usar Truco para bloquear Terremoto, Cloyster +6 + Medicina Defensa",
-          "variant": []
-        },
-        {
-          "detail": "Golem → Usar Truco para bloquear terremoto, Cloyster +4",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Golem → Cloyster +4",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/bruno/muk.json
+++ b/src/data/johto/bruno/muk.json
@@ -2,11 +2,24 @@
   "id": "muk",
   "name": "Muk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRAMPA ROCAS",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Entra Chandelure +4, Vel +0. Usa Lanzallamas para barrer todo el equipo.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
+      "variant": [
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Muk usa Puya Nociva, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/poliwrath.json
+++ b/src/data/johto/bruno/poliwrath.json
@@ -2,11 +2,20 @@
   "id": "poliwrath",
   "name": "Poliwrath",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "USA PUÑO TRUENO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Entra Krookodile: Cambia a Cloyster y Rompecoraza a +6. /Usa Carámbano para Debilitar a Lucario, Metagross.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Krookodile o Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp, cambia a Gengar y usa Otra Vez. Luego cambia a Chansey; cuando salga Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/salamence.json
+++ b/src/data/johto/bruno/salamence.json
@@ -2,124 +2,45 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Revisa la habilidad 💡",
   "tricks": [
     {
-      "detail": "Metagross (Vidasfera) → Cambia a Chandelure",
+      "detail": "Si Salamence tiene Intimidación, usa Amortiguador y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "No se retira → Bola Sombra para eliminar, observa el siguiente movimiento👇🏻",
-          "variant": [
-            {
-              "detail": "Golem → Cambia a Metagross, se sacrifica, entra Chandelure y usa Truco para bloquear Terremoto, Cloyster +4",
-              "variant": []
-            },
-            {
-              "detail": "Machamp → Cambia a Scrafty, luego a Chandelure y usa Truco para bloquear Roca Afilada, Excadrill +4+2",
-              "variant": []
-            },
-            {
-              "detail": "Muk → Excadrill +4+2",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Contra Golem / Rhyperior → Truco para bloquear Terremoto, Cloyster +4",
-          "variant": []
-        }
-      ]
-    }, 
-    {
-      "detail": "Metagross (Restos) → Cambia a Chandelure",
-      "variant": [
-        {
-          "detail": "No se retira → Llamarada para eliminar, entra Blastoise, Poliwrath +6+2",
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Mantén Otra Vez cada vez que puedas.",
           "variant": []
         },
         {
-          "detail": "Machamp → Truco",
-          "variant": [
-            {
-              "detail": "Vendetta, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Blastoise, Poliwrath +6+2",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "Golem → Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "Steelix → Cloyster +6",
-      "variant": []
-    },
-    {
-      "detail": "Machamp → Cambia a Chandelure",
-      "variant": [
-        {
-          "detail": "No se retira → Truco",
-          "variant": [
-            {
-              "detail": "Blastoise, Poliwrath +6+2",
-              "variant": []
-            },
-            {
-              "detail": "Si sigue en campo, usa Lanzallamas para debilitarlo, entra Blastoise, Poliwrath +6+2",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Eelektross → Truco",
-          "variant": [
-            {
-              "detail": "Rayo, Excadrill +4+2",
-              "variant": []
-            },
-            {
-              "detail": "Blastoise, Poliwrath +6+2",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },    
-    {
-      "detail": "Terremoto → Cloyster +6 con píldora de critico",
-      "variant": []
-    },
-    {
-      "detail": "Onda Ígnea / Lanzallamas → Chandelure usa objeto para aumentar Ataque Especial 4+0 / Lanzallamas para barrer al equipo",
-      "variant": []
-    },
-    {
-      "detail": "Lanzallamas→ Revisar objeto",
-      "variant": [
-        {
-          "detail": "Vidasfera → Cambia a Chandelure y usa Truco para intercambiar objeto, Cloyster +4",
+          "detail": "Si sale Metagross, cambia a Chansey y usa Amortiguador. Si luego sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No es necesario usar Otra Vez.",
           "variant": []
         },
         {
-          "detail": "Gema Dragón → Chandelure usa Poder Oculto para eliminar, entra",
-          "variant": [
-            {
-              "detail": "Blastoise, Poliwrath +6+2",
-              "variant": []
-            },
-            {
-              "detail": "Aggron : Cloyster +4 + Especial X / Hitmontop Surf",
-              "variant": []
-            }
-          ]
+          "detail": "Si sale Blaziken directo, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No es necesario usar Otra Vez.",
+          "variant": []
         }
       ]
-    }   
+    },
+    {
+      "detail": "Si Salamence no tiene Intimidación, coloca Trampa Rocas.",
+      "variant": [
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hitmonlee, entra con Gengar y usa Bola Sombra. Si lo derrotas y sale Machamp, sigue con Bola Sombra; luego cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
+          "variant": []
+        },
+        {
+          "detail": "Si el rival cambia a Machamp, cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
   ]
 }

--- a/src/data/johto/bruno/seismitoad.json
+++ b/src/data/johto/bruno/seismitoad.json
@@ -2,11 +2,34 @@
   "id": "seismitoad",
   "name": "Seismitoad",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Bloquear Terremoto → luego Cloyster +4.",
-      "variant": []
+      "detail": "Opción ahorro:",
+      "variant": [
+        {
+          "detail": "Usa Amortiguador. Si sale Darmanitan, entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Opción estable:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Opción RNG:",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/slowbro.json
+++ b/src/data/johto/bruno/slowbro.json
@@ -2,67 +2,51 @@
   "id": "slowbro",
   "name": "Slowbro",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Steelix → revisa el objeto.",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Casco Dentado → Cloister 6.",
+          "detail": "Si sale Hitmonlee, entra con Gengar y usa Bola Sombra. Si lo derrotas y sale Machamp, continúa con Bola Sombra; luego cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
           "variant": []
         },
         {
-          "detail": "CINTA ELEGIDA → Cloyster +4 + Especial X / Si no usas la medicina, hay un 12.5% de probabilidad de que sea debilitado de un solo golpe",
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Machamp se queda, usa Maquinación hasta +4 y derrota a todos con Bola Sombra.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Aggron → Cloister 4+ con Especial X. Usa Surf para matar a Conkeldurr.",
-      "variant": []
-    },
-    {
-      "detail": "Escaldar → revisa el daño del ataque.",
+      "detail": "Ruta con Salamence y Aggron:",
       "variant": [
         {
-          "detail": "24.7%-29.1%【con alrededor de 40% de chance de quemar】 → revisa si Metagross queda quemado.",
+          "detail": "Si sale Salamence, usa Bola Sombra hasta que salga Aggron.",
           "variant": []
         },
         {
-          "detail": "Si está quemado → Poliwrath 6+2. Usa Puño Hielo para matar a Salamence.",
+          "detail": "Si Gengar derrota a Aggron con crítico, termina de barrer.",
           "variant": []
         },
         {
-          "detail": "Si no está quemado → cambia a Chandelure :",
+          "detail": "Si Aggron derrota a Gengar y no activa Cuerpo Maldito, entra con Volcarona, derrota a Aggron y frente al Slowbro rival usa Danza Aleteo x1.",
           "variant": []
         },
         {
-          "detail": "Si Slowbro no se va → Poliwrath 6+2. Usa Puño Hielo para matar a Salamence.",
-          "variant": []
-        },
-        {
-          "detail": "Contra Steelix → Truco para bloquear Terremoto, luego Cloyster +6.",
-          "variant": []
-        },
-        {
-          "detail": "Contra Salamence/Hitmontop → Truco para bloquear Terremoto, luego Cloister 6+ con crítico. Usa Carámbano para matar a Steelix.",
+          "detail": "Si Aggron derrota a Gengar y se activa Cuerpo Maldito, entra con Volcarona y usa Danza Aleteo x1.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Alrededor de 36%【con cerca de 54% de chance de crítico】 → pon Trampa Rocas :",
+      "detail": "Si sale Heracross, usa Amortiguador y luego Teletransporte hacia Gengar.",
       "variant": [
         {
-          "detail": "Si no se va → Poliwrath 6+2. // Si cambia a Staraptor , sacrifica a Poliwrath, Chandelure usa Poder oculto para debilitar rápido, entra Steelix, luego Cloister 4.",
-          "variant": []
-        },
-        {
-          "detail": "Si sale Steelix → Cloister 4.",
-          "variant": []
-        },
-        {
-          "detail": "Si sale Heracross → cambia a Chandelure y usa Truco para bloquear Roca Afilada, luego Excadrill 4+2+2 (con Defensa). Primero usa Defensa X para subir defensa.",
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +2 y Precisión X. Mantén Otra Vez de nuevo cuando sea necesario. 🔔 Heracross tiene Banda Focus. 🔔",
           "variant": []
         }
       ]

--- a/src/data/johto/bruno/staraptor.json
+++ b/src/data/johto/bruno/staraptor.json
@@ -2,19 +2,41 @@
   "id": "staraptor",
   "name": "Staraptor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Slowbro + revisar objeto",
   "tricks": [
     {
-      "detail": "A BOCAJARRO → Chandelure usa Lanzallamas para debilitar o matar, entra Krookodile, luego Cloyster +4 + Especial X // Usa Carámbano para matar a Lucario.",
-      "variant": []
+      "detail": "Cambia a Slowbro y revisa si Staraptor tiene Vidasfera.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidasfera, usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si se queda, usa Teletransporte hacia Chansey, coloca Trampa Rocas y vuelve con Teletransporte hacia Gengar. Usa Otra Vez, Maquinación hasta +2 y Precisión X. 🔔 Heracross tiene Banda Focus. 🔔",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Heracross, usa Protección, cambia a Chansey y espera a Steelix. Coloca Trampa Rocas y mantén Amortiguador hasta que vuelva a cambiar.",
+          "variant": []
+        },
+        {
+          "detail": "Si Heracross se queda, continúa usando Amortiguador.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Staraptor o Machamp, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "STEELIX → Cloyster +4 con medicina de Ataque Especial.",
-      "variant": []
-    },
-    {
-      "detail": "METAGROSS → Excadrill con Trampa Rocas y 4+2",
-      "variant": []
+      "detail": "Si Staraptor no tiene Vidasfera:",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo. Cuando salga Lucario, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2. Mantén los PS de Volcarona por encima del 17%.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/steelix.json
+++ b/src/data/johto/bruno/steelix.json
@@ -2,15 +2,28 @@
   "id": "steelix",
   "name": "Steelix",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Casco Dentado → Cloyster 6.",
-      "variant": []
-    },
-    {
-      "detail": "Cinta Elegida → Cloyster 4 + medicina de Ataque Especial. Si no usas la medicina de Sp. Atk, hay 12.5% de probabilidad de que Slowbro te reviente.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
+      "variant": [
+        {
+          "detail": "Si Steelix usa Terremoto, usa Encanto y luego Amortiguador hasta que salga Heracross.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Heracross, usa Amortiguador y luego Teletransporte para recibir A Bocajarro. Entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hitmonlee, entra con Gengar y usa Bola Sombra. Cuando lo derrotes y salga Machamp, continúa con Bola Sombra, luego cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp directo, cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/torterra.json
+++ b/src/data/johto/bruno/torterra.json
@@ -2,11 +2,25 @@
   "id": "torterra",
   "name": "Torterra",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Bloquear Terremoto, luego Cloister 4.",
-      "variant": []
+      "detail": "Opción ahorro:",
+      "variant": [
+        {
+          "detail": "Usa Amortiguador. Si sale Darmanitan, entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Opción estable:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Resumen
- Actualiza las 26 estrategias de Johto Bruno.
- Limpia boosts crudos como `+4 +2`, `+2 + Precisión X` y `+6`.
- Normaliza rutas con Gengar, Poliwrath, Volcarona, Slowbro, Chansey y Politoed.
- Mantiene la estructura JSON existente: `id`, `name`, `image`, `initialMove`, `tricks`, `variant`.

## Alcance
Solo se modifican archivos dentro de `src/data/johto/bruno`.

## Nota
No se toca `main`, assets ni visuales.