### PR TITLE
Update Johto Karen strategies

### DIFF
--- a/src/data/johto/karen/absol.json
+++ b/src/data/johto/karen/absol.json
@@ -2,11 +2,16 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🦋 Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Bloquear a Seismitoad / Quagsire, luego Cloyster +4. // Surf contra Gengar",
-      "variant": []
+      "detail": "Entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+      "variant": [
+        {
+          "detail": "Usa Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/blastoise.json
+++ b/src/data/johto/karen/blastoise.json
@@ -2,15 +2,20 @@
   "id": "blastoise",
   "name": "Blastoise",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear a SEISMITOAD, luego Cloyster +4. Dos Poder Oculto para matar a Seismitoad. / Metagross Surf",
-      "variant": []
-    },
-    {
-      "detail": "Bloquear a QUAGSIRE, luego Cloyster +6. / Carámbano para Houndoom y Absol / Surf para Gengar",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol y entra con Volcarona.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Gigadrenado contra Absol. Frente a Houndoom no hay amenaza importante.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/electrode.json
+++ b/src/data/johto/karen/electrode.json
@@ -2,15 +2,20 @@
   "id": "electrode",
   "name": "Electrode",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Garchomp → entra Cloister +6 +Pildora Directo. / Si no, todo con ataques de Carámbano. Puede salir Feraligatr pero no hay peligro.",
-      "variant": []
-    },
-    {
-      "detail": "Rayo → entra Excadrill, pone Trampa Rocas 4+2. Si viene Garchomp, cambio a Chandelure y uso Truco, lo dejo bloqueado en Terremoto. Luego entra Cloister +6 +Pildora Directo. / Si no, barre con Carámbano.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas, usa Teletransporte y entra con Slowbro para usar Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Slowbro está paralizado y no puede usar Bostezo, cambia a Chansey, recupera vida al máximo y repite la operación.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/excadrill.json
+++ b/src/data/johto/karen/excadrill.json
@@ -2,17 +2,46 @@
   "id": "excadrill",
   "name": "Excadrill",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "OBSERVA SI TIENE GLOBO HELIO",
+  "initialMove": "💡 Observa qué objeto tiene 💡",
   "tricks": [
     {
-      "detail": "NO TIENE GLOBO HELIO, Truco para encerrar en Terremoto, Cloyster +4 (Houndoom muere de carámbano)",
-      "variant": []
-    },
-    {
-      "detail": "SI TIENE GLOBO HELIO, cambia a Cloyster e inmediatamente cambia a Chandelure, usa Truco para encerrar en Terremoto para así sacar a Cloyster y boostear +6",
+      "detail": "Si tiene Globo Helio:",
       "variant": [
         {
-          "detail": "Chandelure podría morir de un crítico de Avalancha, si esto llega a pasar haz lo siguiente) - Saca a Metagross para revivir a Chandelure y sacrifica al Metagross, Chandelure usa Truco, saca a Cloyster +6",
+          "detail": "Usa Encanto y coloca Trampa Rocas. Si Excadrill se queda, usa Amortiguador. Frente a Tyranitar, cambia a Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados, barre hasta Houndoom e ignora la amenaza.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Victreebel, cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Excadrill, sigue usando Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si no tiene Globo Helio:",
+      "variant": [
+        {
+          "detail": "Usa Encanto y coloca Trampa Rocas. Mantén Amortiguador hasta que el rival cambie.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Slowbro rival, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Mantén Otra Vez cuando sea necesario.",
+          "variant": []
+        },
+        {
+          "detail": "Si Excadrill entra mientras intentas boostearte, cambia a Slowbro y luego a Chansey. Usa Encanto, vuelve a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/karen/feraligatr.json
+++ b/src/data/johto/karen/feraligatr.json
@@ -2,19 +2,20 @@
   "id": "feraligatr",
   "name": "Feraligatr",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "❤️ Encanto ❤️",
   "tricks": [
     {
-      "detail": "GARCHOMP → Cloyster +6 + crítico. / Todo muere con Carámbano.",
-      "variant": []
-    },
-    {
-      "detail": "RHYDON → Cloyster +4. Usa Carámbano para matar a Houndoom.",
-      "variant": []
-    },
-    {
-      "detail": "CASCADA → Cloyster sube defensa +4 Especial X Si no temes al crítico, puedes no usar Especial X",
-      "variant": []
+      "detail": "Usa Encanto y revisa el daño recibido.",
+      "variant": [
+        {
+          "detail": "Si el daño es menor a 36%, coloca Trampa Rocas. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si el daño es mayor a 39%, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Cura la quemadura si ocurre.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/flareon.json
+++ b/src/data/johto/karen/flareon.json
@@ -2,11 +2,20 @@
   "id": "flareon",
   "name": "Flareon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA CHANDELURE",
+  "initialMove": "👻 Gengar + Slowbro 👻",
   "tricks": [
     {
-      "detail": "Cambiar a Chandelure y usar Bola Sombra; si entra Hydreigon, entrar con Scrafty +3. // Paliza para matar a Primeape (Banda Focus)",
-      "variant": []
+      "detail": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si el crítico de Typhlosion debilita a Poliwrath, entra con Gengar, usa Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/gallade.json
+++ b/src/data/johto/karen/gallade.json
@@ -2,21 +2,17 @@
   "id": "gallade",
   "name": "Gallade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Gengar + Slowbro 👻",
   "tricks": [
     {
-      "detail": "Truco, Rhydon →Cloister 4. Usa Carambano para matar a Houndoom.",
-      "variant": []
-    },
-    {
-      "detail": "Ataque Sorpresa → revisa si Chandelure murió :",
+      "detail": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Si murió → cambia a Scrafty y luego Metagross, contra Vileplume usa Truco para bloquear a Rhydon, luego Cloister 4. Usa Carambano para matar a Houndoom.",
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si no murió → Scrafty 4 o 2+ con Ataque. Usa Paliza para matar a Houndoom.",
+          "detail": "Cura la quemadura si ocurre antes de seguir barriendo.",
           "variant": []
         }
       ]

--- a/src/data/johto/karen/garchomp.json
+++ b/src/data/johto/karen/garchomp.json
@@ -2,11 +2,16 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear Terremoto, Cloyster +6 + Píldora para aumentar Críticos.Todo con ataques de Carámbano. Puede salir un Feraligatr, sin peligro.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Luego cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/gengar.json
+++ b/src/data/johto/karen/gengar.json
@@ -2,11 +2,20 @@
   "id": "gengar",
   "name": "Gengar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear a Quagsire, luego Cloyster +4. // Se necesita 2 Poder Oculto para matar a Quagsire",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol y entra con Volcarona.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/gyarados.json
+++ b/src/data/johto/karen/gyarados.json
@@ -2,58 +2,61 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "PUÑO TRUENO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si solo hiere a Gyarados → Ver si Gyarados recupera PS con Restos.",
+      "detail": "Coloca Trampa Rocas. Si Gyarados se queda, usa Amortiguador y espera el cambio.",
       "variant": [
         {
-          "detail": "NO tiene Restos → Cloyster +6. / Carámbano mata a Houndoom y Tyranitar.",
-          "variant": [
-            {
-              "detail": "Si entra Tyranitar mientras te boosteas, cambiar a Metagross y usar Truco, bloquear con Terremoto, Cloyster +6. / Carámbano mata a Houndoom.",
-              "variant": []
-            }       
-          ]
+          "detail": "Si sale Leafeon, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
         },
         {
-          "detail": "SI tiene Restos → Seguir usando Puño Trueno. Si entra Rhyperior, cambiar a Cloyster, luego a Metagross y usar Truco, bloquear con Terremoto, Cloyster +4. / Todo se mata con Carámbano.",
+          "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados, barre hasta Houndoom e ignora la amenaza.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Si Gyarados es derrotado de un golpe → Ver quién entra:",
+      "detail": "Ruta con Rhyperior:",
       "variant": [
         {
-          "detail": "Excadrill → Cambiar a Excadrill y luego a Chandelure.",
-          "variant": [
-            {
-              "detail": "Excadrill no se retira → Truco para bloquear con Terremoto, Cloyster +6. / Carámbano mata a Houndoom y Tyranitar.",
-              "variant": []
-            },
-            {
-              "detail": "Slowbro → Truco para bloquear Escaldar, Poliwrath +6 +4. / A Bocajarro mata a Excadrill. Si se quema, no curar, priorizar ataques super efectivos.",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Rhyperior → Cambiar a Excadrill, luego a Metagross y usar Truco, bloquear con Terremoto, Cloyster +4. / Todo se mata con Carámbano.",
+          "detail": "Usa Encanto y cambia a Slowbro.",
           "variant": []
         },
         {
-          "detail": "Houndoom → Cambiar a Chandelure, usar Truco y bloquear Pulso Umbrío o Persecución, luego Scrafty +2. / A Bocajarro mata a Rhyperior. // Si Chandelure entra por error frente a Rhyperior, usar Truco para bloquear con Terremoto, Cloyster +4. / Todo se mata con Carámbano.",
+          "detail": "Si Rhyperior se queda, usa Bostezo frente a Leafeon y luego entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, usa Bostezo, Protección y Bostezo otra vez frente a Leafeon. Luego entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Rhyperior → Cambiar a Excadrill, luego a Metagross y usar Truco, bloquear con Terremoto, Cloyster +4. / Todo se mata con Carámbano.",
-      "variant": []
+      "detail": "Ruta con Victreebel:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados después, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Quagsire → Cambiar a Cloyster, luego a Metagross y usar Truco, bloquear con Terremoto, Cloyster +4. / Todo se mata con Carámbano.",
+      "detail": "Si sale Excadrill, usa Encanto y Amortiguador frente a Tyranitar. Luego cambia a Poliwrath para derrotar a Tyranitar.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/honchkrow.json
+++ b/src/data/johto/karen/honchkrow.json
@@ -2,24 +2,20 @@
   "id": "honchkrow",
   "name": "Honchkrow",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Slowbro + Bostezo",
   "tricks": [
     {
-      "detail": "FUERZA BRUTA → cambia a Chandelure.",
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Houndoom.",
       "variant": [
         {
-          "detail": "NO SE VA → Truco para bloquear a Rhydon, luego Cloyster +4. // Usa Carámbano para matar a Houndoom.",
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "RHYPERIOR → Truco para bloquear Terremoto, luego Cloister 4. // Usa Carámbano para matar a Houndoom.",
+          "detail": "Cura la quemadura si ocurre antes de seguir barriendo.",
           "variant": []
         }
       ]
-    },   
-    {
-      "detail": "RHYPERIOR → Cloyster +6. Usa Carámbano para matar a Houndoom.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/karen/houndoom.json
+++ b/src/data/johto/karen/houndoom.json
@@ -2,97 +2,108 @@
   "id": "houndoom",
   "name": "Houndoom",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO / Si Houndoom ataca primero es Pañuelo Elegido",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lanzallamas → revisar objeto",
+      "detail": "Coloca Trampa Rocas. Si Houndoom se queda, revisa su objeto. Si falla el turno, usa Amortiguador.",
       "variant": [
         {
-          "detail": "Cinta Xperto → cambiar a Chandelure, ayudar a Metagross con Revivir o Cura Quemadura / usar Bola Sombra.",
-          "variant": [
-            {
-              "detail": "Hydreigon → Scrafty +3. / Paliza para Primeape",
-              "variant": []
-            }
-          ]
-        },    {
-          "detail": "Banda Focus / Vidasfera → cambiar a Chandelure y usar Truco.",
-          "variant": [
-            {
-              "detail": "Houndoom se queda → Scrafty +4 o +2 con X Ataque. / Paliza mata a Vileplume en 2 turnos",
-              "variant": []
-            },
-            {
-              "detail": "Feraligatr → Cloyster +4 + Defensa X (Primero la medicina)",
-              "variant": []
-            },
-            {
-              "detail": "Tyranitar → Scrafty +3. / Si Scrafty recibe Terremoto, cambiar a Cloyster +6",
-              "variant": []
-            },
-            {
-              "detail": "Rhyperior / Quagsire → Cloyster +4 / Si Cloyster se encuentra inesperadamente contra Gyarados → cambiar a Scrafty, usar Medicina Defensa X +3 / Cuidado con tu vida",
-              "variant": []
-            },
-            {
-              "detail": "Gyarados (Pañuelo Elegido) → cambiar a Poliwrath, luego cambiar a Scrafty. // Si Metagross está quemado, usar a Poliwrath para ayudar a quitar la quemadura (contra Slowbro), luego Scrafty +3",
-              "variant": [
-                {
-                  "detail": "Slowbro → Scrafty +3 / / Si tienes bajos PS usar Raíz Energía",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Gyarados (Restos) → Cloyster +4 con Medicina Defensa X. / / Primero usar medicina",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },  
-    {
-      "detail": "Llamarada (Pañuelo Elegido) → cambiar a Chandelure; ver qué movimiento usa Houndoom después. // Si Metagross falla Truco, no hay problema. ¡Chandelure no debe usar ningún movimiento!",
-      "variant": [
-        {
-          "detail": "Poder Oculto → Excadrill coloca Trampa Rocas, 4+2+2 (con Defensa Especial X)",
+          "detail": "Si tiene Vidasfera, usa Amortiguador dos veces. Si se queda, sacrifica a Politoed y entra con Poliwrath. Usa Ataque X y empieza a barrer.",
           "variant": []
         },
         {
-          "detail": "Llamarada / Vozarrón → Ayudar a Metagross con Revivir o Raíz Energía // Mirar la situación 👇🏻 ¡Chandelure no debe usar ningún movimiento!",
-          "variant": [
-            {
-              "detail": "Houndoom no se va → (Ayudar a Metagross a curarse hasta 90% o más) / un Poder Oculto para bajar PS / cambiar a Metagross frente a Gengar / Truco para bloquear a Quagsire / Cloyster +4",
-              "variant": []
-            },
-            {
-              "detail": "Blastoise → (Ayudar a Metagross a curarse hasta 83% o más) / cambiar a Poliwrath / cambiar a Metagross y usar Truco / bloquear a Quagsire / Cloyster +4",
-              "variant": []
-            }
-          ]
+          "detail": "Si no tiene Vidasfera, usa Amortiguador hasta que el rival cambie.",
+          "variant": []
         }
       ]
     },
     {
-      "detail": "Quagsire / Rhyperior → Cloyster +4 / Carámbano mata a Houndoom",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp → Cloyster +6 + Medicina Crítica. / Todo muere con Carámbano",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill → Mira el objeto.",
+      "detail": "Rutas con cambios directos:",
       "variant": [
         {
-          "detail": "Vidasfera → Cloyster +4. / Carámbano mata a Houndoom.",
+          "detail": "Si sale Leafeon, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
           "variant": []
         },
         {
-          "detail": "Globo Helio → Usa Truco para recuperarlo, luego vuelve a usar Truco para bloquear Terremoto, Cloyster +6. / Carámbano mata a Houndoom y Tyranitar.",
+          "detail": "Si sale Feraligatr, usa Encanto, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Honchkrow, Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Primeape, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade o Roserade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    }    
+    },
+    {
+      "detail": "Ruta con Gyarados o Victreebel:",
+      "variant": [
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados, barre hasta Houndoom e ignora la amenaza.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Victreebel, cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta con Excadrill:",
+      "variant": [
+        {
+          "detail": "Si Excadrill tiene Globo Helio, usa Encanto y Amortiguador frente a Tyranitar. Luego cambia a Poliwrath para derrotar a Tyranitar.",
+          "variant": []
+        },
+        {
+          "detail": "Si Excadrill no tiene Globo Helio, cambia a Slowbro y usa Bostezo. Si se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1, barre hasta Houndoom, luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mismagius, entra con Volcarona, usa Danza Aleteo x1 frente a Houndoom, luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta con Rhyperior:",
+      "variant": [
+        {
+          "detail": "Usa Encanto y cambia a Slowbro.",
+          "variant": []
+        },
+        {
+          "detail": "Si Rhyperior se queda, usa Bostezo frente a Leafeon y entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, usa Bostezo, Protección y Bostezo otra vez frente a Leafeon. Luego entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
+    }
   ]
 }

--- a/src/data/johto/karen/hydreigon.json
+++ b/src/data/johto/karen/hydreigon.json
@@ -2,11 +2,16 @@
   "id": "hydreigon",
   "name": "Hydreigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🥚 Chansey + Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Truco, si no se retira / encierra a Hydreigon, Scrafty 3. Usa paliza para matar a primeape",
-      "variant": []
+      "detail": "Chansey usa Amortiguador frente a Primeape.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. 🔔 Primeape tiene Banda Focus. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/leafeon.json
+++ b/src/data/johto/karen/leafeon.json
@@ -2,33 +2,42 @@
   "id": "leafeon",
   "name": "Leafeon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Tijera X → Cambia a Chandelure.",
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
       "variant": [
         {
-          "detail": "Contra Rhyperior → Usa Truco para bloquear con Terremoto, luego entra Cloyster +4.",
+          "detail": "Si Leafeon se queda, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
           "variant": []
         },
         {
-          "detail": "Si no se va → usa Lanzallamas para debilitar, mira quién entra abajo:",
-          "variant": [
-            {
-              "detail": "Si entra Rhydon → cambia a Excadrill, luego Chandelure usa Truco para bloquear Terremoto, luego Cloyster +4.",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Houndoom → cambia a Poliwrath para revivir a Chandelure, usa Truco para bloquear Juego Sucio, luego Scrafty +3.",
-              "variant": []
-            }
-          ]
-        }        
+          "detail": "Si sale Leafeon después de otra ruta, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
       ]
     },
     {
-      "detail": "Rhyperior → Cloyster +4",
-      "variant": []
+      "detail": "Ruta con Rhyperior:",
+      "variant": [
+        {
+          "detail": "Usa Encanto y cambia a Slowbro.",
+          "variant": []
+        },
+        {
+          "detail": "Si Rhyperior se queda, usa Bostezo frente a Leafeon y luego entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta con Gyarados:",
+      "variant": [
+        {
+          "detail": "Usa Bostezo, Protección y Bostezo otra vez frente a Leafeon. Luego entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/lucario.json
+++ b/src/data/johto/karen/lucario.json
@@ -2,15 +2,45 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si Cambia a Quagsire Cambia Excadrill 4+2 y al final Trampa Rocas (Si cambia a Salamence, cambia a Chandelure, Truco y luego cambia a Excadrill)",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa el movimiento o cambio rival.",
+      "variant": [
+        {
+          "detail": "Si usa Poder Oculto, cambia a Gengar y usa Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si Lucario se queda, Gengar usa Otra Vez y Maquinación hasta +6. 🔔 Lucario tiene Banda Focus. Barre con Bola Sombra. 🔔",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rapidash, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Spiritomb, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Si Spiritomb despierta, no es amenaza.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Lucario, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Si lucario se queda y usa Esfera Aural Cambia Chandelure usa Truco, y Cambia a Scrafty Danza Dragón a +4 o +2 + Ataque X.",
-      "variant": []
+      "detail": "Ruta con Salamence:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y mantén Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Spiritomb después de Bostezo y Protección, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Spiritomb despierto no es amenaza.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/luxray.json
+++ b/src/data/johto/karen/luxray.json
@@ -2,11 +2,20 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Chansey + Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Bloqueado en Rayo. Excadrill entra, pone Trampa Rocas con 4+2.",
-      "variant": []
+      "detail": "Chansey usa Amortiguador y luego coloca Trampa Rocas frente a un tipo Lucha.",
+      "variant": [
+        {
+          "detail": "Después cambia a Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/mismagius.json
+++ b/src/data/johto/karen/mismagius.json
@@ -2,26 +2,44 @@
   "id": "mismagius",
   "name": "Mismagius",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Garchomp → Cloyster +6 + Crítico. / Todo muere con Carámbano.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Mismagius se queda, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Si se mantiene, entra con Volcarona y usa Gigadrenado. Luego cambia a Chansey, usa Teletransporte hacia Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si quedas frente a Houndoom, sacrifica a Politoed y entra con Poliwrath. Usa Ataque X y empieza a barrer.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Excadrill → Cloyster +4. / Carámbano para Houndoom.",
-      "variant": []
+      "detail": "Ruta con Excadrill:",
+      "variant": [
+        {
+          "detail": "Usa Teletransporte hacia Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si Excadrill se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y ataca hasta quedar frente a Houndoom. Luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mismagius, entra con Volcarona, usa Danza Aleteo x1 frente a Houndoom, luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Hydreigon → Cambia a Chandelure y usa Truco, si Hydreigon se queda o bloqueas a Houndoom, Scrafty +3. / Paliza mata a Primeape.",
-      "variant": []
-    },
-    {
-      "detail": "Bola Sombra → Scrafty +3 / Paliza mata a Primeape.",
-      "variant": []
-    },
-    {
-      "detail": "Rayo → Excadrill Trampa Rocas, +4 +2.",
+      "detail": "Si sale Primeape, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/primeape.json
+++ b/src/data/johto/karen/primeape.json
@@ -2,15 +2,16 @@
   "id": "primeape",
   "name": "Primeape",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "Frente a Hydreigon, saco a Scrafty +3. / Paliza para Primeape",
-      "variant": []
-    },
-    {
-      "detail": "No se va, usó Truco para bloquearlo en Garra Umbría, saca a Scrafty +3",
-      "variant": []
+      "detail": "Cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+      "variant": [
+        {
+          "detail": "🔔 Primeape tiene Banda Focus. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/quagsire.json
+++ b/src/data/johto/karen/quagsire.json
@@ -2,6 +2,32 @@
   "id": "quagsire",
   "name": "Quagsire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Truco para bloquear con Terremoto, luego entra Cloyster +4. // Usa Poder Oculto (Planta) seguido de Carámbano para derrotar a Quagsire / Surf para Gengar y Houndoom, si Surf está bloqueado usar Carámbano",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, entra con Volcarona y usa Danza Aleteo x2. Volcarona aguanta Persecución de Absol; el límite extremo con crítico ronda el 50%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rhyperior, usa Encanto y cambia a Slowbro.",
+          "variant": []
+        },
+        {
+          "detail": "Si Rhyperior se queda, usa Bostezo y, frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Leafeon, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, usa Bostezo, Protección y Bostezo otra vez. Frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/johto/karen/rhyperior.json
+++ b/src/data/johto/karen/rhyperior.json
@@ -2,11 +2,32 @@
   "id": "rhyperior",
   "name": "Rhyperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquea Terremoto, Cloyster +4. Usa Carámbano para matar a Houndoom y Gallade",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Rhyperior se queda, usa Encanto y cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Si Rhyperior se queda, usa Bostezo y, frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Leafeon, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, usa Bostezo, Protección y otro Bostezo más. Frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Honchkrow, Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade o Roserade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/sableye.json
+++ b/src/data/johto/karen/sableye.json
@@ -2,15 +2,28 @@
   "id": "sableye",
   "name": "Sableye",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Rhyperior, Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "Pulso Umbrío → cambio a Chandelure contra Rhyperior, Truco bloquea Terremoto, Cloister +4. Dusclops no se va, entra Scrafty +2. / A Bocajarro mata a Rhyperior, a Dusclops hay que pegarle dos veces.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Sableye se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Leafeon, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rhyperior, usa Encanto y cambia a Slowbro.",
+          "variant": []
+        },
+        {
+          "detail": "Si Rhyperior se queda, usa Bostezo y, frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, usa Bostezo, Protección y otro Bostezo más. Frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/salamence.json
+++ b/src/data/johto/karen/salamence.json
@@ -2,15 +2,20 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Quagsire, Cloister +4",
-      "variant": []
-    },
-    {
-      "detail": "Gran Llamarada (muy poca probabilidad) → Chandelure con Poder Oculto entra Houndoom, Scrafty +3. Swampert es firme, hay que pegarle varias veces para acabar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol y entra con Volcarona.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x2. Aguanta Persecución de Absol; el límite extremo con crítico ronda el 50%.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Danza Aleteo una vez y barre hasta Houndoom. Luego usa Danza Aleteo otra vez para quedar en total con Danza Aleteo x2 y termina de barrer.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/slowbro.json
+++ b/src/data/johto/karen/slowbro.json
@@ -2,32 +2,58 @@
   "id": "slowbro",
   "name": "Slowbro",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "EXCADRILL SIN GLOBO → Cloyster 4+. Usa Carámbano para matar a Houndoom.",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill con globo → Usa Truco para recuperarlo, luego otro Truco para bloquear con Terremoto. Cloyster 6+. Usa Carámbano para matar a Houndoom.",
-      "variant": []
-    },
-    {
-      "detail": "CASCADA → Haz Truco otra vez para bloquear a Excadrill, Cloyster 4+. Usa Carámbano para matar a Houndoom.",
-      "variant": []
-    },
-    {
-      "detail": "LANZALLAMAS → Revisa si Metagross se quema o no.",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "No se quemó → Scrafty +2 + Raíz Energía +1. Usa Paliza para matar a Houndoom.",
+          "detail": "Si usa Puño Drenaje, entra con Volcarona y usa Danza Aleteo x2.",
           "variant": []
         },
         {
-          "detail": "Se quemó → Cambia a Chandelure y usa Truco para bloquear a Tyranitar. Excadrill entra y pone Trampa Rocas con 4+2.",
+          "detail": "Si sale Tyranitar, entra con Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados y frente a Houndoom sigue atacando; no te derrota.",
           "variant": []
         }
       ]
-    }    
+    },
+    {
+      "detail": "Ruta con Excadrill:",
+      "variant": [
+        {
+          "detail": "Si tiene Globo Helio, usa Encanto y Amortiguador frente a Tyranitar. Luego cambia a Poliwrath para derrotar a Tyranitar.",
+          "variant": []
+        },
+        {
+          "detail": "Si no tiene Globo Helio, usa Teletransporte hacia Slowbro y luego Bostezo. Si Excadrill se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y ataca hasta que entre Houndoom. Luego usa Danza Aleteo una vez más y derrótalo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mismagius, entra con Volcarona, usa Danza Aleteo x1 y ataca hasta que entre Houndoom. Luego usa Danza Aleteo una vez más y derrótalo.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta con Victreebel:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados después, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
+    }
   ]
 }

--- a/src/data/johto/karen/tyranitar.json
+++ b/src/data/johto/karen/tyranitar.json
@@ -2,11 +2,28 @@
   "id": "tyranitar",
   "name": "Tyranitar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "bloquea Terremoto, Cloister + 6. Carámbano para matar a Houndoom.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y cambia a Poliwrath para derrotar a Tyranitar.",
+      "variant": [
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados, barre hasta Houndoom e ignora la amenaza.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Victreebel, cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/umbreon.json
+++ b/src/data/johto/karen/umbreon.json
@@ -2,11 +2,20 @@
   "id": "umbreon",
   "name": "Umbreon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Scrafty +3 // 2 Paliza derrotan a Garchomp (Si usas Puño Drenaje te harás daño)",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Umbreon usa Juego Sucio y se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si entra Houndoom, sacrifica a Politoed y entra con Poliwrath. Usa Ataque X y empieza a barrer.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/victreebel.json
+++ b/src/data/johto/karen/victreebel.json
@@ -2,11 +2,36 @@
   "id": "victreebel",
   "name": "Victreebel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Truco para bloquear Terremoto, luego Cloyster +6 // Carámbano mata a Houndoom",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Victreebel se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Excadrill, usa Encanto y Amortiguador frente a Tyranitar. Luego cambia a Poliwrath para derrotar a Tyranitar.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados, barre hasta Houndoom e ignora la amenaza.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Victreebel, cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/vileplume.json
+++ b/src/data/johto/karen/vileplume.json
@@ -2,15 +2,32 @@
   "id": "vileplume",
   "name": "Vileplume",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Rhyperior / Excadrill → Cloyster +4. // Carámbano mata a Houndoom",
-      "variant": []
-    },
-    {
-      "detail": "Poder Oculto → Chandelure usa Lanzallamas para rematar, entra Slowbro, Poliwrath +2+6",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Honchkrow, Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Teletransporte hacia Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si Excadrill se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y barre hasta Houndoom. Luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mismagius, entra con Volcarona, usa Danza Aleteo x1 frente a Houndoom, luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/weavile.json
+++ b/src/data/johto/karen/weavile.json
@@ -2,24 +2,24 @@
   "id": "weavile",
   "name": "Weavile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO // SI TRUCO FALLA (POR RETROCESO), SEGUIR USANDO TRUCO",
+  "initialMove": "🥚 Amortiguador + 🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Carámbano, Patada Baja o Golpe Bajo → Cambiar a Chandelure.",
+      "detail": "Usa Amortiguador para recibir el golpe de hielo. Luego coloca Trampa Rocas frente a Excadrill.",
       "variant": [
         {
-          "detail": "Si aún no se retira → Usar Truco para intercambiar el objeto, luego sacar a Scrafty +4 o +2 con medicina de ataque. / Paliza o derrota al Houndoom.",
+          "detail": "Usa Teletransporte y envía a Slowbro para usar Bostezo.",
           "variant": []
         },
         {
-          "detail": "Excadrill → Usar Truco para bloquear con Terremoto, luego Cloyster +6. / Carámbano mata a Houndoom.",
+          "detail": "Si Excadrill se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y barre hasta Houndoom. Luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mismagius, entra con Volcarona, usa Danza Aleteo x1 frente a Houndoom, luego usa Danza Aleteo una vez más y termina el combate.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "EXCADRILL → Cloyster +4. / Carámbano mata a Houndoom.",
-      "variant": []
     }
   ]
 }


### PR DESCRIPTION
## Resumen
- Actualiza las 28 estrategias de Johto Karen.
- Limpia boosts crudos como `+4 +2`, `+2 +2 + Precisión X` y `+6`.
- Normaliza rutas con Gengar, Poliwrath, Volcarona, Slowbro, Chansey y Politoed.
- Mantiene la estructura JSON existente: `id`, `name`, `image`, `initialMove`, `tricks`, `variant`.

## Alcance
Solo se modifican archivos dentro de `src/data/johto/karen`.

## Nota
No se toca `main`, assets ni visuales.