### PR TITLE
Update Johto Lance strategies

### DIFF
--- a/src/data/johto/lance/aerodactyl.json
+++ b/src/data/johto/lance/aerodactyl.json
@@ -2,17 +2,17 @@
   "id": "aerodactyl",
   "name": "Aerodactyl",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "STEELIX → Cloyster +4 / Poder Oculto Feraligatr",
-      "variant": []
-    },
-    {
-      "detail": "Terremoto → Excadrill +4+2 // Si ocurre una situación inesperada, ver más abajo:",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Excadrill frente a Steelix → Cambia a Chandelure y usa Truco para encerrarlo en Terremoto, luego Cloyster +4.",
+          "detail": "Si sale Lucario, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Si quieres ahorrar, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad. Lucario no tiene Pañuelo Elegido.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo otra vez, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Steelix.",
           "variant": []
         }
       ]

--- a/src/data/johto/lance/ampharos.json
+++ b/src/data/johto/lance/ampharos.json
@@ -2,46 +2,24 @@
   "id": "ampharos",
   "name": "Ampharos",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Rayo → Observa si el rival tiene Vidasfera:",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Con Vidasfera → Usa Truco para encerrarlo en Rayo, luego Excadrill +4+2 + Trampa Rocas // Si Truco falla, Metagross usa Cura Total, Luego vuelve a usar Truco, entra Excadrill 4+2+Trampa Rocas. // Terremoto para Arcanine",
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Sin Vidasfera → Excadrill entra con +6+2",
-          "variant": []
-        }
-      ]
-    },    
-    {
-      "detail": "Frente a Tyranitar → Cambia a Scrafty y observa el movimiento:",
-      "variant": [
-        {
-          "detail": "Triturar → Scrafty +3",
+          "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo. Luego cambia a Chansey, usa Amortiguador y espera a Metagross. Usa Teletransporte hacia Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
           "variant": []
         },
         {
-          "detail": "Terremoto → Excadrill +6+2",
+          "detail": "Si sale Feraligatr, usa Encanto. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },    
-    {
-      "detail": "Frente a Metagross → Usa Lanzallamas para debilitarlo, Entra Tyranitar, Cambia a Scrafty y observa el movimiento:",
-      "variant": [
-        {
-          "detail": "Triturar → Scrafty +3",
-          "variant": []
-        },
-        {
-          "detail": "Terremoto → Excadrill +6+2",
-          "variant": []
-        }
-      ]
-    }    
+    }
   ]
 }

--- a/src/data/johto/lance/arbok.json
+++ b/src/data/johto/lance/arbok.json
@@ -2,11 +2,16 @@
   "id": "arbok",
   "name": "Arbok",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO PARA ENCERRAR A GARCHOMP/ FLYGON TERREMOTO",
+  "initialMove": "Slowbro + Bostezo",
   "tricks": [
     {
-      "detail": "Cloyster +4",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Eelektross.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/arcanine.json
+++ b/src/data/johto/lance/arcanine.json
@@ -2,50 +2,28 @@
   "id": "arcanine",
   "name": "Arcanine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Gengar + Trampa Rocas 👻",
   "tricks": [
     {
-      "detail": "ENVITE ÍGNEO → Truco",
+      "detail": "Gengar usa Otra Vez. Luego cambia a Chansey y después a Dragonite para colocar Trampa Rocas.",
       "variant": [
         {
-          "detail": "ENVITE ÍGNEO (SEGUNDA VEZ) → Usar Truco hasta que cambie de movimiento o cambie de poke",
-          "variant": [
-            {
-              "detail": "ARCANINE NO RE RETIRA / AMPHAROS → Excadrill +2 + Trampa Rocas +Velocidad X. → Terremoto para derrotar a Arcanine",
-              "variant": []
-            },
-            {
-              "detail": "Hydreigon → cambia a Metagross para poner Trampa Rocas, luego Scrafty +2",
-              "variant": []
-            },
-            {
-              "detail": "SALAMANCE → Cambiar a Metagross para poner Trampa Rocas, luego Scrafty +2",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "VOLTIOCRUEL→ Excadrill 4+2",
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "FERALIGATR → Ver objeto:",
-          "variant": [
-            {
-              "detail": "VIDASFERA → Poliwrath 6+2+2 (Defensa especial) → Necesita Puño Hielo // Si recibe un golpe crítico, cura con raíz energía y sigue barriendo",
-              "variant": []
-            },
-            {
-              "detail": "PAÑ. ELEGIDO → Cambiar a Metagross para poner Trampa Rocas, luego Poliwrath 6+2",
-              "variant": []
-            }
-          ]
+          "detail": "Si sale Scizor, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona cae por crítico, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Feraligatr, usa Encanto. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
         }
       ]
-    },
-    {
-      "detail": "STEELIX → Truco para encerrar en Terremoto → Cloyster +4",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/charizard.json
+++ b/src/data/johto/lance/charizard.json
@@ -2,11 +2,24 @@
   "id": "charizard",
   "name": "Charizard",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO PARA ENCERRAR EN LLAMARADA",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Cambia a Chandelure y luego a Scrafty, frente a Tyranitar, Excadrill 6 + 2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Tyranitar y cambia a Poliwrath para derrotarlo.",
+      "variant": [
+        {
+          "detail": "Después entra con Chansey y usa Amortiguador.",
+          "variant": []
+        },
+        {
+          "detail": "Espera a que entre Metagross, usa Teletransporte hacia Slowbro y luego Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/dragonite.json
+++ b/src/data/johto/lance/dragonite.json
@@ -2,172 +2,66 @@
   "id": "dragonite",
   "name": "Dragonite",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gema Dragón + Puño Fuego → Chandelure (Truco) para bloquear a Feraligatr. Poliwrath 6+2+2 (Defensa Especial). Necesita Puño Hielo. Si Poliwrath recibe un golpe crítico, usar Raíz Grande para curarse y continuar barriendo.",
-      "variant": []
-    },
-    {
-      "detail": "Restos + Puño Fuego → Colocar Trampa Rocas, luego cambiar a Chandelure y usar Truco.",
+      "detail": "Coloca Trampa Rocas. Si Dragonite no cambia, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Kingdra/Feraligatr → Poliwrath 6+2, no necesita Carámbano.",
+          "detail": "Si sale Scizor, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Arcanine → Excadrill 4+2. En prueba, revisar el registro de combate.",
+          "detail": "Si sale Flygon, usa Protección y Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Gyarados → Cloyster +4 + Medicina de Defensa. Usar primero la medicina.",
-          "variant": []
-        }
-      ]
-    },   
-    {
-      "detail": "Llamarada → Cambiar a Chandelure y usar Poder Oculto. Si Dragonite no se retira, seguir atacando.",
-      "variant": [
-        {
-          "detail": "Sale Scrafty → Cambiar a Metagross para colocar Trampa Rocas. // Si Metagross falla al colocar Trampa Rocas, usar Excadrill para hacerlo. // Si Scrafty no se va o si entra Infernape, cambiar a Chandelure y usar Truco. 👇🏻",
-          "variant": [
-            {
-              "detail": "Triturar → Evaluar los PS de Dragonite:",
-              "variant": [
-                {
-                  "detail": "Si no está a PS completo → Scrafty +3.",
-                  "variant": []
-                },
-                {
-                  "detail": "Si está a PS completo → usar Protec. Esp (Esto ayuda a que no bajen las estadísticas de tu equipo) y sacrificar, luego Poliwrath 2+2. / Priorizar ataques de alta potencia y eficaces.",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Puño Trueno → Excadrill 4+2.",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Sale Feraligatr → Cambiar a Metagross para colocar Trampa Rocas y sacrificarlo. Luego entra Chandelure con Truco, bloquear Cascada, y Poliwrath 6+2. // Si no se pudo colocar Trampa Rocas, no importa. Usar medicina de Defensa Especial. // Si recibe un golpe crítico significativo usar Raíz Energía.",
+          "detail": "Si sale Eelektross, usa Teletransporte o sacrifica a Politoed. Luego entra con Gengar, usa Maquinación y barre con Bola Sombra.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "TRUENO → Cambiar a Excadrill",
+      "detail": "Ruta con Scizor y evaluación de daño:",
       "variant": [
         {
-          "detail": "Si Dragonite no se va → Excadrill coloca Trampa Rocas, entra Lapras, Poliwrath 6+2.",
+          "detail": "Usa Teletransporte y revisa cuánto daño hace Scizor.",
           "variant": []
         },
         {
-          "detail": "Contra Steelix → Cambiar a Chandelure y usar Truco para bloquear Terremoto. Luego Excadrill coloca Trampa Rocas + 2+2. // Si cambia a Lapras, Poliwrath 6+2.",
+          "detail": "Si el daño es cercano al 60%, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si el daño es cercano al 90%, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona cae por crítico, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Fuerza Bruta → Revisar el objeto.",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Si tiene Restos → Cambiar a Chandelure:",
-          "variant": [
-            {
-              "detail": "Si Dragonite no se va → Bola Sombra para revelar a Kangaskhan, Cloyster +4.",
-              "variant": []
-            },
-            {
-              "detail": "Contra Kangaskhan → Cloyster +4.",
-              "variant": []
-            },
-            {
-              "detail": "Contra Haxorus o Metagross → Truco para bloquear Terremoto, Cloyster +4.",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Cinta Elegida → Colocar Trampa Rocas, luego cambiar a Chandelure y usar Truco.",
-          "variant": [
-            {
-              "detail": "Si entra Aerodactyl → Excadrill + Defensa X + 4 + 2.",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Feraligatr → Poliwrath 6+2.",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },    
-    {
-      "detail": "Garchomp / Steelix / Kangaskhan → Cloyster +4.",
-      "variant": []
-    },
-    {
-      "detail": "Metagross → Revisar el objeto.",
-      "variant": [
-        {
-          "detail": "Si lleva Gema Acero → Cloyster +4.",
+          "detail": "Si sale Tyranitar, entra con Poliwrath para derrotarlo. Después cambia a Chansey y usa Amortiguador. Espera a Metagross, usa Teletransporte hacia Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si lleva Vidasfera → Chandelure usa Lanzallamas para debilitar. Entra Tyranitar, cambiar a Scrafty y observar el movimiento:",
-          "variant": [
-            {
-              "detail": "Si usa Triturar → Scrafty 3.",
-              "variant": []
-            },
-            {
-              "detail": "Si usa Terremoto → Excadrill 6+2.",
-              "variant": []
-            }
-          ]
-        }       
-      ]
-    },
-    {
-      "detail": "Ampharos → Cambiar a Excadrill.",
-      "variant": [
-        {
-          "detail": "Si Ampharos no se retira → Excadrill 4+2. / Usar Terremoto para derrotar a Arcanine.",
+          "detail": "Si sale Infernape, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Contra Dragonite → Un solo Cabeza Hierro para romper la habilidad, luego cambiar a Chandelure y usar Poder Oculto para rematar. Evaluar quién entra después:",
-          "variant": [
-            {
-              "detail": "Si entra Arcanine → Excadrill 4+2 + usar medicina fuerte para curarse.",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Feraligatr → Cambiar a Metagross para colocar Trampa Rocas y sacrificarlo. Chandelure usa Truco para bloquear Cascada, Poliwrath 6+2. // Si entra Ampharos, salir con Excadrill 4+2.",
-              "variant": []
-            }
-          ]
-        }       
-      ]
-    },
-    {
-      "detail": "Hydreigon → Cambiar a Chandelure y usar Truco.",
-      "variant": [
-        {
-          "detail": "Si Hydreigon no se va → Scrafty usa medicina de Defensa Especial +3. / Usar Puño Drenaje para derrotar a Lucario. // Scrafty es derrotado por crítico de Lucario → Chandelure usa Truco para bloquear Pulso Umbrío, revivir a Scrafty, Scrafty 3.",
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si entra Feraligatr → Poliwrath 6+2+2 (Defensa Especial). Necesita Puño Hielo. Si recibe golpe crítico de Lucha Especial, usar Raíz Energía para curarse y continuar barriendo.",
+          "detail": "Si sale Feraligatr, Chansey usa Encanto. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Tyranitar → Excadrill 6+2.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/eelektross.json
+++ b/src/data/johto/lance/eelektross.json
@@ -2,11 +2,16 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE Y USA TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear Rayo, luego entra Excadrill con +6 +2.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Luego usa Teletransporte o sacrifica a Politoed.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar frente a Dragonite, usa Maquinación y barre al equipo con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/electivire.json
+++ b/src/data/johto/lance/electivire.json
@@ -2,11 +2,20 @@
   "id": "electivire",
   "name": "Electivire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "TRUCO → luego Excadrill pone Trampa Rocas 4+2.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
+      "variant": [
+        {
+          "detail": "Si usa Tajo Cruzado, cambia a Slowbro y usa Bostezo. Luego usa Protección y Bostezo otra vez. Frente a Lucario, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Infernape, cambia a Slowbro y usa Bostezo frente a Electivire. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/feraligatr.json
+++ b/src/data/johto/lance/feraligatr.json
@@ -2,119 +2,66 @@
   "id": "feraligatr",
   "name": "Feraligatr",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "DRAGONITE → Cambia a Chandelure y observa el movimiento:",
+      "detail": "Coloca Trampa Rocas. Si Feraligatr se queda, revisa el movimiento.",
       "variant": [
         {
-          "detail": "Puño Fuego → Usa Truco para bloquear con Feraligatr, luego entra Poliwrath con +6 y +2+2 (Def. Esp.). Si recibe un golpe crítico de Esfera Aural y queda debilitado, usa Raíz Grande para curarse y seguir barriendo (prevención contra prioridad)",
+          "detail": "Cascada: cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Llamarada → Usa Poder Oculto al punto; si Dragonite no cambia, sigue atacando",
-          "variant": [
-            {
-              "detail": "Sale Scrafty → Cambia a Metagross para colocar Trampa Rocas. Si Scrafty no se retira, o si sale Infernape, cambia a Chandelure y usa Truco.👇🏻",
-              "variant": [
-                {
-                  "detail": "Triturar → Según la vida de Dragonite:",
-                  "variant": [
-                    {
-                      "detail": "Si no tiene los PS completos → Scrafty +3",
-                      "variant": []
-                    },
-                    {
-                      "detail": "Si tiene PS completos → usa Protec. Esp. (Píldora para que el equipo no baje estadísticas) para sacrificarse y luego entra Poliwrath con +2+2. // Prioriza movimientos eficaces",
-                      "variant": []
-                    }
-                  ]
-                },
-                {
-                  "detail": "Puño Trueno → Excadrill +4+2",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Sale Feraligatr → Cambia a Metagross para colocar trampas, sacrificarlo, luego entra Chandelure y usa Truco para bloquear con Cascada, luego entra Poliwrath con +6+2. // Si no pudiste colocar trampas, no importa, solo usa una medicina de Def. Esp. // Si recibe crítico de Esfera Aural, usa Raíz Energía para curarse",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "STEELIX → Depende del objeto:",
-      "variant": [
-        {
-          "detail": "Casco Dentado → Cloyster +4 // Lucario muere con Carámbano",
+          "detail": "Fuerza Bruta: usa Teletransporte para revisar. Si vuelve a usar Fuerza Bruta, Slowbro usa Bostezo frente a Ampharos. Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Baya Chiri → Metagross coloca Trampa Rocas, luego Excadrill con +2 Ataque, No necesitas velocidad. Si luego entra Lapras, ignóralo: ya estás completamente potenciado",
+          "detail": "Otro movimiento: cambia a Poliwrath, luego a Slowbro y usa Bostezo frente a Ampharos. Después entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "METAGROSS → Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "AMPHAROS → Excadrill coloca Trampa Rocas +4+2. / Terremoto mata a Arcanine",
+      "detail": "Ruta con Scizor:",
       "variant": [
         {
-          "detail": "Dragonite → Usa Cabeza Hierro para romper la habilidad, luego cambia a Chandelure y remata con Poder Oculto, observa qué sale después👇🏻",
-          "variant": [
-            {
-              "detail": "Arcanine → (Chandelure ayuda a Excadrill a quitar la quemadura), Excadrill coloca Trampa Rocas +4+2 y se cura con Raíz Energía",
-              "variant": []
-            },
-            {
-              "detail": "Feraligatr → cambia a Metagross (Trampa Rocas), sacrifica, Chandelure usa Truco para bloquear en Cascada, Poliwrath +6+2",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "HYDREIGON → Cambia a Chandelure y usa Truco",
-      "variant": [
-        {
-          "detail": "Si Hydreigon no se va, Scrafty usa medicina de Def. Esp. y se potencia a +3. / Puño Drenaje derrota a Lucario // Si Scrafty fue derrotado por Lucario → Chandelure usa Truco para bloquear con Pulso Umbrío, revive a Scrafty, Scrafty entra con +3",
+          "detail": "Usa Teletransporte y evalúa el daño.",
           "variant": []
         },
         {
-          "detail": "Si entra Feraligatr, Poliwrath +6+2+2 (Def. Esp.) Si Poliwrath recibe un crítico de Esfera Aural, usa Raíz Grande para curarse y seguir barriendo",
+          "detail": "Daño cercano al 60%: envía a Slowbro, usa Bostezo y luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Daño cercano al 90%: entra con Volcarona, usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona cae por crítico, usa la ruta de Slowbro con Bostezo y Poliwrath con Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "TYRANITAR → Excadrill +6+2",
-      "variant": []
-    },
-    {
-      "detail": "SCRAFTY → Cambia a Chandelure contra Infernape, usa Truco para bloquear con Puño Trueno, luego entra Excadrill con +4+2 y trampa rocas",
-      "variant": []
-    },
-    {
-      "detail": "FLYGON / GARCHOMP → Cambia a Chandelure (resiste Llamarada), usa Truco para intercambiar objeto, luego entra Excadrill, Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "TERREMOTO → Excadrill +4+2",
-      "variant": []
-    },
-    {
-      "detail": "ESCALDAR → Coloca Trampa Rocas, luego Poliwrath +6+2+6 (gracias a Absorbe Agua se cura completamente)",
-      "variant": []
-    },
-    {
-      "detail": "CASCADA → Poliwrath +6+2+2 (Def. Esp.). // Si hay Lucario con Banda Focus, y recibe un crítico de Esfera Aural, usa Raíz Grande para curarse y seguir barriendo",
-      "variant": []
+      "detail": "Rutas por cambio rival:",
+      "variant": [
+        {
+          "detail": "Haxorus: cambia a Slowbro y usa Bostezo. Frente a Scizor, entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Dragonite: cambia a Slowbro y usa Bostezo. Contra Scizor usa la ruta de Poliwrath. Contra Flygon usa Protección y Bostezo antes de entrar con Poliwrath. Usa Puño Drenaje contra Steelix.",
+          "variant": []
+        },
+        {
+          "detail": "Lucario: cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Para ahorrar, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad. Lucario no tiene objeto elegido.",
+          "variant": []
+        },
+        {
+          "detail": "Infernape: cambia a Slowbro y usa Bostezo frente a Electivire. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/flygon.json
+++ b/src/data/johto/lance/flygon.json
@@ -2,15 +2,20 @@
   "id": "flygon",
   "name": "Flygon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto → Excadrill +4+2 y luego coloca Trampa Rocas",
-      "variant": []
-    },
-    {
-      "detail": "Llamarada → Chandelure usa Truco para intercambiar objeto, luego Excadrill +4+2 y coloca Trampa Rocas",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Lucario, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Para ahorrar, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad. Lucario no tiene objeto elegido.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo, y entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/garchomp.json
+++ b/src/data/johto/lance/garchomp.json
@@ -2,11 +2,16 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Slowbro + Bostezo",
   "tricks": [
     {
-      "detail": "Terremoto → Cloyster +4.",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Eelektross.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/gyarados.json
+++ b/src/data/johto/lance/gyarados.json
@@ -2,19 +2,20 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Puño Trueno derrota, espera a ver qué entra 👇🏻",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Garchomp → Cambia a Chandelure para sacrificarlo, entra Metagross con Truco, bloquea con Terremoto, Cloyster +6 // Surf para debilitar a Metagross.",
-      "variant": []
-    },
-    {
-      "detail": "Eelektross → Cambia a Chandelure y usa Truco para bloquear con Rayo, Excadrill +4+2",
-      "variant": []
-    },
-    {
-      "detail": "Tyranitar → Cambia a Cloyster +6 // Surf para debilitar a Metagross.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y usa Teletransporte hacia Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo y luego Teletransporte hacia Gengar.",
+          "variant": []
+        },
+        {
+          "detail": "Gengar usa Maquinación y ataca para barrer.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/haxorus.json
+++ b/src/data/johto/lance/haxorus.json
@@ -2,19 +2,20 @@
   "id": "haxorus",
   "name": "Haxorus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Gengar + Bola Sombra",
   "tricks": [
     {
-      "detail": "METAGROSS / KANGASKHAN → Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "Dragonite → Chandelure usa Bola Sombra, entra Kangaskhan, Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "TERREMOTO → Cloyster +4",
-      "variant": []
+      "detail": "Cambia a Gengar y úsalo como sacrificio atacando con Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Luego Slowbro usa Bostezo frente a Scizor.",
+          "variant": []
+        },
+        {
+          "detail": "Entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/hydreigon.json
+++ b/src/data/johto/lance/hydreigon.json
@@ -2,21 +2,21 @@
   "id": "hydreigon",
   "name": "Hydreigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE Y TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Pulso Umbrío, Scrafty usa + Defensa Especial X y sube a +4 // Si Chandelure muere, cambia el +4 por +3, luego usar Puño Drenaje + Paliza para derrotar a Dragonite // Paliza + Puño Drenaje para Lucario",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty es derrotado por Lucario con un golpe crítico:",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Metagross usa Truco : Si sale Ampharos: Excadrill 4+2",
+          "detail": "Si sale Feraligatr, usa Encanto. Luego cambia a Slowbro, usa Bostezo y entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Dragonite: Poliwrath 6, usar Raíz Grande para curarse y luego subir +2 Velocidad",
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Primeape, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
           "variant": []
         }
       ]

--- a/src/data/johto/lance/infernape.json
+++ b/src/data/johto/lance/infernape.json
@@ -2,6 +2,24 @@
   "id": "infernape",
   "name": "Infernape",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Chandelure y usar Truco para bloquear en Puño Trueno, luego Excadrill con Trampa Rocas entra y se potencia con +4 en ataque y +2 en velocidad.",
-  "tricks": []
+  "initialMove": "👻 Gengar + Trampa Rocas 👻",
+  "tricks": [
+    {
+      "detail": "Gengar usa Otra Vez. Luego cambia a Chansey y después a Dragonite.",
+      "variant": [
+        {
+          "detail": "Coloca Trampa Rocas frente a Infernape.",
+          "variant": []
+        },
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/johto/lance/kangaskhan.json
+++ b/src/data/johto/lance/kangaskhan.json
@@ -2,6 +2,16 @@
   "id": "kangaskhan",
   "name": "Kangaskhan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia directamente a Cloyster con +6. // Si el rival cambia a Metagross, cambiar a Metagross propio y usar Truco para bloquear en Terremoto, luego volver a usar Cloyster con +4.",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/johto/lance/kingdra.json
+++ b/src/data/johto/lance/kingdra.json
@@ -2,15 +2,20 @@
   "id": "kingdra",
   "name": "Kingdra",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si usa Surf coloca Trampa Rocas, Luego cambia a Poliwrath 2 Tambores, 1 Velocidad X.(Si no Lograste Poner Trampa Rocas + Defensa X a Poliwrath).",
-      "variant": []
-    },
-    {
-      "detail": "Si cambia a Steelix Cambia a Cloyster +4",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si sale Scizor.",
+      "variant": [
+        {
+          "detail": "Si sale Scizor, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona cae por crítico, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/lapras.json
+++ b/src/data/johto/lance/lapras.json
@@ -2,38 +2,17 @@
   "id": "lapras",
   "name": "Lapras",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Steelix → Metagross pone Trampa Rocas, Excadrill 2+0 (Si sale Lapras no importa, ya tienes todas las mejoras hechas)",
-      "variant": []
-    },
-    {
-      "detail": "Donphan → Excadrill 6+2",
-      "variant": []
-    },
-    {
-      "detail": "Rayo + Baya → Excadrill 6+2",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Tyranitar → Scrafty +4 o +2 y ATK X",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Rayo + Gafas Elegidas → Excadrill 4+2",
-      "variant": []
-    },
-    {
-      "detail": "Surf → Revisa el objeto",
-      "variant": [
-        {
-          "detail": "Baya Atania → Poliwrath 6+2",
+          "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo. Luego cambia a Chansey y usa Amortiguador. Espera a Metagross, usa Teletransporte hacia Slowbro, usa Bostezo y entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Gafas Elegidas → Pone Trampa Rocas, Poliwrath 6+2",
+          "detail": "Si sale Scizor, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/lance/lucario.json
+++ b/src/data/johto/lance/lucario.json
@@ -2,111 +2,37 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Cambia a Gengar 👻",
   "tricks": [
     {
-      "detail": "LUCARIO NO CAMBIA → Usar Truco con Chandelure para ver el movimiento.",
+      "detail": "Si usa A Bocajarro, Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Pulso Umbrío → Scrafty con +5 o +3 + ATQ X",
+          "detail": "Luego cambia a Slowbro y usa Bostezo frente a Flygon.",
           "variant": []
         },
         {
-          "detail": "Triturar → Scrafty con +3. / Usar Paliza + Puño Drenaje para vencer a Steelix. (Esto es para que no llegue a rango de Baya Chiri) / Aerodactyl banda focus",
+          "detail": "Cambia a Chansey y coloca Trampa Rocas. Después vuelve a Slowbro, usa Bostezo y entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "DRAGONITE → Chandelure lanza un Poder Oculto (Hielo), verificar si acierta Cometa Draco.",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Si acierta y Chandelure es debilitado → Sacar Metagross y colocar Trampa Rocas.",
-          "variant": [
-            {
-              "detail": "Scrafty → Cambiar a Poliwrath, revivir a Chandelure, usar Truco para bloquear en Triturar, luego Scrafty con +2.",
-              "variant": []
-            },
-            {
-              "detail": "Ampharos → Cambiar a Excadrill, luego a Metagross y usar Truco para bloquear en Rayo, Excadrill +4+2 (pendiente de testeo).",
-              "variant": []
-            },
-            {
-              "detail": "Hydreigon → Revivir a Chandelure, usar Truco con Chandelure para bloquear en Pulso Umbrío, luego Scrafty con +3. (priorizar Puño Drenaje, pendiente de testeo).",
-              "variant": []
-            },
-            {
-              "detail": "Dragonite no cambia → Revivir a Chandelure, cambiar entre Scrafty y Chandelure:",
-              "variant": [
-                {
-                  "detail": "Si entra Arcanine → Excadrill +4+2",
-                  "variant": []
-                },
-                {
-                  "detail": "Si entra Feraligatr → Usar Truco con Chandelure para bloquear en Cascada, luego Poliwrath +6+2.",
-                  "variant": []
-                }        
-              ]
-            }
-          ]
-        },
-        {
-          "detail": "SI ACIERTA Y NO DEBILITA → Seguir usando Poder Oculto (Hielo)",
-          "variant": [
-            {
-              "detail": "Si entra Arcanine o Electivire → Excadrill con +4+2 + Trampa Rocas",
-              "variant": []
-            },
-            {
-              "detail": "FERALIGATR → Cambiar a Metagross, usar Truco para bloquear en Cascada, luego Poliwrath +6+2+6 / No es necesario Puño Hielo.",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Si Cometa Draco falla → Seguir usando Poder Oculto (Hielo) y ver quién entra.",
-          "variant": [
-            {
-              "detail": "Si entra Arcanine → Excadrill +4+2",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Feraligatr → Cambiar a Metagross, usar Truco para bloquear en Cascada, luego Poliwrath +6+2 (con +2 Defensa Especial). Si Poliwrath es dañado por un golpe crítico de Pulso Dragón, usar Raíz Grande para curarse y continuar el sweep.",
-              "variant": []
-            }      
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "Contra Hydreigon → Usar Truco para bloquear en Pulso Umbrío, Scrafty con +4 y medicina de Defensa Especial. Si Chandelure cae, hacerlo con +3. // Si Scrafty es derrotado por un crítico de Lucario → Metagross usa Truco:",
-      "variant": [
-        {
-          "detail": "Si entra Ampharos → Excadrill con +4+2",
+          "detail": "Si sale Infernape, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si entra Dragonite → Poliwrath con +6 y curación con Raíz Grande, luego +2",
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque. Usa Puño Drenaje contra Lucario y Ampharos.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Feraligatr, sacrifica a Gengar con Bola Sombra. Luego Slowbro usa Bostezo y entra con Poliwrath usando Tambor hasta +6 Ataque. Usa Puño Drenaje para mantener la salud.",
           "variant": []
         }
       ]
-    },    
-    {
-      "detail": "Contra Scrafty rival → Cambiar a Metagross y usar Truco para bloquear en Triturar, luego cambiar a Excadrill.",
-      "variant": [
-        {
-          "detail": "Si Scrafty no cambia → Colocar Trampa Rocas, usar Protec. Esp, luego Poliwrath +2+2 (priorizar movimientos de alta potencia).",
-          "variant": []
-        },
-        {
-          "detail": "Contra Infernape → Cambiar a Chandelure y usar Truco para bloquear en Puño Trueno, luego Excadrill con +4+2.",
-          "variant": []
-        }
-      ]
-    },    
-    {
-      "detail": "Contra Ampharos → Usar Truco para bloquear en Rayo, luego Excadrill con +4+2, usar TRAMPA ROCAS. Terremoto derrota a Arcanine.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/metagross.json
+++ b/src/data/johto/lance/metagross.json
@@ -2,41 +2,41 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Poder Oculto → Chandelure usa Lanzallamas para debilitar, entra Tyranitar, cambia a Scrafty para ver movimiento:",
+      "detail": "Coloca Trampa Rocas y revisa qué movimiento o cambio aparece.",
       "variant": [
         {
-          "detail": "Triturar → Scrafty +3",
+          "detail": "Si usa Puño Meteoro, usa Teletransporte hacia Slowbro y usa Bostezo.",
           "variant": []
         },
         {
-          "detail": "Terremoto → Excadrill +6+2",
+          "detail": "Si quedas frente a Tyranitar, envía a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si aparece Hierba Lazo, Ampharos, Scizor, Dragonite o Lapras, entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross, usa Teletransporte hacia Gengar. Gengar usa Maquinación y barre con Bola Sombra.",
           "variant": []
         }
       ]
-    },   
+    },
     {
-      "detail": "Terremoto → Observa objeto Rival:",
+      "detail": "Ruta con Scizor o Tyranitar:",
       "variant": [
         {
-          "detail": "Gema Acero → Cloyster +4",
+          "detail": "Si sale Scizor, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Casco Dentado → Excadrill +4+0",
-          "variant": []
-        },
-        {
-          "detail": "Restos → Excadrill +6+2",
+          "detail": "Si sale Tyranitar, cambia a Poliwrath y usa Puño Drenaje para derrotarlo. Luego cambia a Chansey, usa Amortiguador y espera a Metagross. Usa Teletransporte hacia Slowbro, usa Bostezo y entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },    
-    {
-      "detail": "Garchomp → Cloyster +4l:",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/scizor.json
+++ b/src/data/johto/lance/scizor.json
@@ -2,80 +2,28 @@
   "id": "scizor",
   "name": "Scizor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "SI NO SE RETIRA → Usar Lanzallamas para matar.",
+      "detail": "Coloca Trampa Rocas y evalúa el daño de Scizor.",
       "variant": [
         {
-          "detail": "Feraligatr → Seguir usando Lanzallamas y observar el resultado:",
-          "variant": [
-            {
-              "detail": "Feraligatr ataca primero y deja a Chandelure con poca vida → Cambiar a Metagross para colocar Trampa Rocas, luego entrar con Poliwrath +6 ataque y +2 velocidad.",
-              "variant": []
-            },
-            {
-              "detail": "Feraligatr ataca primero y debilita completamente a Chandelure → Sacar a Metagross y usar Truco:",
-              "variant": [
-                {
-                  "detail": "Si entra Steelix o Metagross, luego Cloyster +4.",
-                  "variant": []
-                },
-                {
-                  "detail": "Si el rival no se cambia, Excadrill +4 ataque y +2 velocidad.",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Si Feraligatr ataca después y debilita o daña a Chandelure → Cambiar a Metagross y usar Truco:",
-              "variant": [
-                {
-                  "detail": "Si entra Steelix, poner Trampa Rocas y luego Excadrill 2+2.",
-                  "variant": []
-                },
-                {
-                  "detail": "Cascada, poner Trampa Rocas y luego Poliwrath +6 ataque y +2 velocidad. // (Si entra Lapras después, no importa: ya estás completamente potenciado).",
-                  "variant": []
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "detail": "Haxorus → Cambiar a Cloyster, luego a Chandelure, usar Truco para bloquear con Terremoto, luego Cloyster +4.",
+          "detail": "Si el daño es cercano al 90%, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
           "variant": []
         },
         {
-          "detail": "Lapras → Cambiar a Metagross para colocar Trampa Rocas, luego Poliwrath +6 ataque y +2 velocidad.",
+          "detail": "Si Volcarona cae por crítico, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si el daño es cercano al 60%, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si cae por crítico y no alcanzaste a colocar Trampa Rocas, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "ENTRA FERALIGATR DESPUES DE IDA Y VUELTA → Cambiar a Metagross para colocar Trampa Rocas, luego Poliwrath +6 ataque y +2 velocidad.",
-      "variant": []
-    },
-    {
-      "detail": "STEELIX → Usar Truco para bloquear con Terremoto, luego cambiar a Metagross para colocar Trampa Rocas, luego Excadrill +2 ataque y sin boost de velocidad. // (Si entra Lapras, ignorarlo: ya puedes barrer al equipo).",
-      "variant": []
-    },
-    {
-      "detail": "METAGROSS → Usar Truco y observar el objeto:",
-      "variant": [
-        {
-          "detail": "Gema Acero → luego Cloyster +4.",
-          "variant": []
-        },
-        {
-          "detail": "Casco Dentado → luego Excadrill +4 ataque sin velocidad.",
-          "variant": []
-        }
-      ]
-    },   
-    {
-      "detail": "Kangaskhan → Cloyster +4.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/scrafty.json
+++ b/src/data/johto/lance/scrafty.json
@@ -2,28 +2,20 @@
   "id": "scrafty",
   "name": "Scrafty",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Dragonite → Colocar Trampa Rocas, dejarlo debilitar para que Poliwrath recupere todos los PS, luego entra con +2 en Ataque y +2 en Velocidad; prioriza siempre los movimientos de mayor potencia. // Si Poliwrath ha sido quemado, usar Cura Total para eliminar el estado y evitar el daño de habilidades de prioridad.",
-      "variant": []
-    },
-    {
-      "detail": "Triturar → Cambiar a Excadrill.",
+      "detail": "Coloca Trampa Rocas frente a Primeape.",
       "variant": [
         {
-          "detail": "Scrafty no se retira → Colocar Trampa Rocas, usar Protec. Esp., luego entra Poliwrath con +2 en Ataque y +2 en Velocidad; prioriza siempre movimientos de mayor potencia, se requiere la Gema Hielo para asegurar el KO.",
+          "detail": "Luego cambia a Slowbro y usa Bostezo frente a Electivire.",
           "variant": []
         },
         {
-          "detail": "Contra Infernape → Cambiar a Chandelure, usar Truco para bloquear Puño Trueno, luego entra Excadrill, +4 +2 Trampa Rocas",
+          "detail": "Entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Puño Drenaje → Cambiar a Chandelure, usar Truco para bloquear Puño Trueno, luego entra Excadrill a completar +4 +2 Trampa Rocas",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/steelix.json
+++ b/src/data/johto/lance/steelix.json
@@ -2,15 +2,41 @@
   "id": "steelix",
   "name": "Steelix",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO Y MIRA EL OBJETO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "BAYA LICHI / CASCO DENTADO → entra Cloyster +4.// Carámbano mata a Lucario",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
+      "variant": [
+        {
+          "detail": "Si usa Terremoto, usa Encanto y luego Amortiguador. Espera a Scizor y usa Teletransporte para evaluar el daño.",
+          "variant": []
+        },
+        {
+          "detail": "Si el daño de Scizor es cercano al 60%, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si el daño de Scizor es cercano al 90%, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona cae por crítico, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "BAYA CHIRI → Metagross pone Trampa Rocas, luego Excadrill 2+0. Si sale Lapras, ignóralo, sigue barriendo.",
-      "variant": []
+      "detail": "Rutas por cambio rival:",
+      "variant": [
+        {
+          "detail": "Si sale Lucario, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Para ahorrar, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad. Lucario no tiene objeto elegido.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo, y entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/tyranitar.json
+++ b/src/data/johto/lance/tyranitar.json
@@ -2,6 +2,24 @@
   "id": "tyranitar",
   "name": "Tyranitar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Excadrill +6 +2",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas y cambia a Poliwrath para derrotar a Tyranitar.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Chansey y usa Amortiguador. Si los PS están bajos, usa Max Poción.",
+          "variant": []
+        },
+        {
+          "detail": "Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Resumen
- Actualiza las 24 estrategias de Johto Lance.
- Limpia boosts crudos como `+2 +2`, `+6`, `+4+2` y rutas abreviadas.
- Normaliza rutas con Gengar, Poliwrath, Volcarona, Slowbro, Chansey y Politoed.
- Mantiene la estructura JSON existente: `id`, `name`, `image`, `initialMove`, `tricks`, `variant`.

## Alcance
Solo se modifican archivos dentro de `src/data/johto/lance`.

## Nota
No se toca `main`, assets ni visuales.