### PR TITLE
Release Johto strategy updates

### DIFF
--- a/src/data/johto/bruno/aggron.json
+++ b/src/data/johto/bruno/aggron.json
@@ -2,11 +2,20 @@
   "id": "aggron",
   "name": "Aggron",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CLOISTER",
+  "initialMove": "❤️ Encanto ❤️",
   "tricks": [
     {
-      "detail": "Aggron: Cloyster usa Rompecoraza + 4 + Especial X. // Usa Surf para matar a Hitmontop / Machamp.",
-      "variant": []
+      "detail": "Usa Encanto y toma una Max Poción.",
+      "variant": [
+        {
+          "detail": "Luego usa Amortiguador contra Machamp.",
+          "variant": []
+        },
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez y Maquinación hasta +4.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/blastoise.json
+++ b/src/data/johto/bruno/blastoise.json
@@ -2,15 +2,24 @@
   "id": "blastoise",
   "name": "Blastoise",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A POLIWRATH",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Hidro Bomba → Poliwrath 6+2.",
-      "variant": []
-    },
-    {
-      "detail": "Contra Machamp → Chandelure usa Truco y lo bloquea en Roca Afilada. Luego entra Scrafty 2+ y usa Raíz Energía, después sube +1 más. Si Chandelure muere, haz un Danza Dragón extra.",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. 🔔 Blaziken tiene Pañuelo Elegido. 🔔",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo contra Metagross. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/blaziken.json
+++ b/src/data/johto/bruno/blaziken.json
@@ -2,19 +2,16 @@
   "id": "blaziken",
   "name": "Blaziken",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE Y TRUCO",
+  "initialMove": "💡 Cambia a Gengar 💡",
   "tricks": [
     {
-      "detail": "NO SE RETIRA → Excadrill 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "BLASTOISE → Poliwrath 6+2",
-      "variant": []
-    },
-    {
-      "detail": "MACHAMP → Scrafty 3. / A Bocajarro para matar a Machamp y Metagross.",
-      "variant": []
+      "detail": "Cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+      "variant": [
+        {
+          "detail": "🔔 Blaziken tiene Pañuelo Elegido. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/darmanitan.json
+++ b/src/data/johto/bruno/darmanitan.json
@@ -2,15 +2,34 @@
   "id": "darmanitan",
   "name": "Darmanitan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "DARMANITAN NO CAMBIA → Chandelure +4+0 , Usa Lanzallamas para limpiar equipo.",
-      "variant": []
+      "detail": "Opción para asegurar:",
+      "variant": [
+        {
+          "detail": "Entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "SEISMITOAD → Truco para bloquear Terremoto, luego Cloyster +4.",
-      "variant": []
+      "detail": "Opción estable:",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Opción arriesgada:",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/eelektross.json
+++ b/src/data/johto/bruno/eelektross.json
@@ -2,19 +2,28 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Chandelure.",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "NO CAMBIA → Truco para bloquear Rayo, Excadrill 4+2",
-      "variant": []
-    },
-    {
-      "detail": "MACHAMP → Truco para bloquear Roca afilada, Scrafty +5 / usa Raíz Energía para curar si tienes muy poca vida (cuidado Hitmonchan puede tener ultrapuño)",
-      "variant": []
-    },
-    {
-      "detail": "TORTERRA / SWAMPERT / METAGROSS → Truco para bloquear Terremoto, Cloyster +4",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. 🔔 Blaziken tiene Pañuelo Elegido. 🔔",
+          "variant": []
+        },
+        {
+          "detail": "Si quedas frente a Darmanitan, elige una ruta: ahorro con Volcarona usando Danza Aleteo x3; estable con Slowbro usando Bostezo, sacrificando a Politoed y entrando con Poliwrath para usar Tambor hasta +6 Ataque; o RNG sacrificando a Politoed y entrando directo con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo. Cuando salga Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/electivire.json
+++ b/src/data/johto/bruno/electivire.json
@@ -2,32 +2,45 @@
   "id": "electivire",
   "name": "Electivire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Aggron o Golem → Cloister 4+ +Especial X, usa Surf para acabar con Metagross y Hitmonp",
-      "variant": []
-    },
-    {
-      "detail": "Lanzallamas → Chandelure usa Truco, luego Excadrill 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "Gigalith → Cloister 4.",
-      "variant": []
-    },
-    {
-      "detail": "Slowbro → elegir según situación.",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Para quitar velocidad → pon Roca Afilada, entra Aggron, luego Cloister 4+ , usa Surf para matar a Conkeldurr.",
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo repetidamente hasta que salga Golem. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Para ahorrar → pon Trampa Rocas, entra Aggron, luego Cloister 4, usa Surf para matar a Conkeldurr.",
+          "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
           "variant": []
         }
       ]
-    }    
+    },
+    {
+      "detail": "Si Electivire se queda, cambia a Gengar y usa Maquinación hasta +4. Barre con Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Si sale Salamence, sigue barriendo hasta que salga Aggron.",
+          "variant": []
+        },
+        {
+          "detail": "Si Gengar derrota a Aggron con crítico, termina de barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si Aggron derrota a Gengar y no activa Cuerpo Maldito, entra con Volcarona, derrota a Aggron y frente a Slowbro enemigo usa Danza Aleteo antes de atacar.",
+          "variant": []
+        },
+        {
+          "detail": "Si Aggron derrota a Gengar y se activa Cuerpo Maldito, entra con Volcarona y usa Danza Aleteo x1.",
+          "variant": []
+        }
+      ]
+    }
   ]
 }

--- a/src/data/johto/bruno/gliscor.json
+++ b/src/data/johto/bruno/gliscor.json
@@ -2,11 +2,20 @@
   "id": "gliscor",
   "name": "Gliscor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Bloquear Terremoto, luego Cloyster 6 + Defensa X",
-      "variant": []
+      "detail": "Usa Amortiguador y prepara la ruta con Slowbro.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo contra Metagross.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/golem.json
+++ b/src/data/johto/bruno/golem.json
@@ -2,11 +2,20 @@
   "id": "golem",
   "name": "Golem",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "❤️ Encanto + 🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "bloquear Terremoto, luego Cloyster +4. // Carámbano para Machamp",
-      "variant": []
+      "detail": "Usa Encanto y coloca Trampa Rocas.",
+      "variant": [
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/heracross.json
+++ b/src/data/johto/bruno/heracross.json
@@ -2,15 +2,66 @@
   "id": "heracross",
   "name": "Heracross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "ELEGIR SITUACIÓN",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Ejecución Segura→ usa Puño Trueno, entra Steelix, luego Cloister 4+ con Especial X. Si no usas Especial X, hay 12.5% de que Slowbro te contraataque y te mate.",
-      "variant": []
+      "detail": "Ruta arriesgada con Trampa Rocas:",
+      "variant": [
+        {
+          "detail": "Coloca Trampa Rocas. Si no recibes crítico, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si recibes crítico pero alcanzaste a usar Trampa Rocas, sacrifica a Politoed, entra con Poliwrath, luego vuelve a Gengar. Usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si recibes crítico sin haber usado Trampa Rocas, la ruta se cae y conviene reiniciar.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Ahorrar Recursos → Trampa Rocas y entra Steelix, luego Cloyster +4.",
-      "variant": []
+      "detail": "Ruta segura con Gengar:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Heracross se queda, derrótalo. Si sale Steelix, cambia a Slowbro, usa Bostezo, luego Teletransporte hacia Chansey y coloca Trampa Rocas.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp, cambia a Gengar y usa Otra Vez. Luego cambia a Chansey; cuando salga Staraptor, vuelve a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Staraptor, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Kangaskhan, cambia a Chansey y coloca Trampa Rocas. Luego sigue la ruta correspondiente de Kangaskhan.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta alternativa por Machamp:",
+      "variant": [
+        {
+          "detail": "Si sale Machamp, cambia a Chansey y luego a Gengar. Usa Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Machamp se queda, derrótalo. Si entra Steelix, cambia a Slowbro, mantén Bostezo hasta que salga Heracross, usa Teletransporte hacia Chansey y coloca Trampa Rocas.",
+          "variant": []
+        },
+        {
+          "detail": "Si luego sale Staraptor, vuelve a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/hitmonchan.json
+++ b/src/data/johto/bruno/hitmonchan.json
@@ -2,6 +2,16 @@
   "id": "hitmonchan",
   "name": "Hitmonchan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Chandelure y usa Truco para bloquear Roca Afilada, Scrafty +3 / A Bocajarro para eliminar Machamp. // Si Chandelure cae, ajusta a Scrafty +4 o también puede boostear a +2 + objeto Ataque X. (Depende de si lo quieres hacer rápido o quieres ahorrar)",
-  "tricks": []
+  "initialMove": "Slowbro + Bostezo",
+  "tricks": [
+    {
+      "detail": "Cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/johto/bruno/hitmonlee.json
+++ b/src/data/johto/bruno/hitmonlee.json
@@ -2,11 +2,28 @@
   "id": "hitmonlee",
   "name": "Hitmonlee",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Gengar → Slowbro → Chansey 💡",
   "tricks": [
     {
-      "detail": "Steelix, luego Cloyster +6.",
-      "variant": []
+      "detail": "Entra con Gengar, luego cambia a Slowbro y usa Bostezo. Después cambia a Chansey y coloca Trampa Rocas.",
+      "variant": [
+        {
+          "detail": "Si Hitmonlee se queda, vuelve a Gengar y derrótalo con Bola Sombra. Si sale Machamp, cambia a Chansey y luego vuelve a Gengar. Usa Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Machamp se queda, usa Maquinación hasta +6. Mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Salamence, derrótalo. Cuando salga Machamp, cambia a Poliwrath y luego vuelve a Gengar. Usa Maquinación hasta +6, mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp o Luxray, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Si se queda, sube con Maquinación hasta +6 y mantén Otra Vez cada vez que puedas.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/hitmontop.json
+++ b/src/data/johto/bruno/hitmontop.json
@@ -2,6 +2,16 @@
   "id": "hitmontop",
   "name": "Hitmontop",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Trampa Rocas, entra Aggron, luego Cloyster +4, usa Surf para matar a Hitmontop.",
-  "tricks": []
+  "initialMove": "🥚 Amortiguador 🥚",
+  "tricks": [
+    {
+      "detail": "Usa Amortiguador y revisa si entra Machamp.",
+      "variant": [
+        {
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/johto/bruno/kangaskhan.json
+++ b/src/data/johto/bruno/kangaskhan.json
@@ -2,11 +2,16 @@
   "id": "kangaskhan",
   "name": "Kangaskhan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "PUÑO TRUENO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "STEELIX → Cloyster +4 + Especial X / Carámbano para Heracross",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si quedas frente a Heracross, usa Amortiguador y luego Teletransporte para recibir A Bocajarro.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. 🔔 Heracross tiene Banda Focus. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/krookodile.json
+++ b/src/data/johto/bruno/krookodile.json
@@ -2,10 +2,10 @@
   "id": "krookodile",
   "name": "Krookodile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CLOISTER",
+  "initialMove": "🦋 Volcarona +2 🦋",
   "tricks": [
     {
-      "detail": "Cloister + 4 + Especial X. Usa Carámbano para matar a Lucario.",
+      "detail": "Entra con Volcarona y usa Danza Aleteo x2.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/lucario.json
+++ b/src/data/johto/bruno/lucario.json
@@ -2,15 +2,20 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "NO SE VA → Usar Truco para bloquear Pulso Umbrío o Bola Sombra, luego entra Scrafty con +4; también puedes usar A Bocajarro para eliminar a Poliwrath o Metagross",
-      "variant": []
-    },
-    {
-      "detail": "KROOKODILE→ Cloyster entra con +4 y usa Medicina Especial X para potenciar el ataque, también puedes usar Carámbano para eliminar a Lucario si entra en relevo",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Machamp, cambia a Gengar y usa Otra Vez. Luego cambia a Chansey; cuando salga Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Krookodile o Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/luxray.json
+++ b/src/data/johto/bruno/luxray.json
@@ -2,11 +2,20 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas → Gengar 🪨",
   "tricks": [
     {
-      "detail": "Bloquear a Steelix, luego Cloyster +6.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
+      "variant": [
+        {
+          "detail": "Si Luxray se queda, usa Maquinación hasta +6. Mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Salamence, derrótalo con Bola Sombra. Cuando salga Machamp, cambia a Poliwrath y luego vuelve a Gengar. Usa Otra Vez, Maquinación hasta +6 y mantén Otra Vez cada vez que puedas para derrotar a todos con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/machamp.json
+++ b/src/data/johto/bruno/machamp.json
@@ -2,96 +2,121 @@
   "id": "machamp",
   "name": "Machamp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "💡 Gengar 💡",
   "tricks": [
     {
-      "detail": "Puño Drenaje → Usar Truco",
+      "detail": "Entra con Gengar y revisa el ataque de Machamp.",
       "variant": [
         {
-          "detail": "Roca Afilada → Excadrill 4 + 2",
+          "detail": "Si usa Puño Dinámico, cambia a Slowbro y usa Bostezo.",
           "variant": []
         },
         {
-          "detail": "Corpulencia / Descanso → Cambiar a Metagross",
-          "variant": [
-            {
-              "detail": "Metagross → Truco y bloquear Terremoto, luego Cloyster +4",
-              "variant": []
-            },
-            {
-              "detail": "Darmanitan → Cambiar a Chandelure:",
-              "variant": [
-                {
-                  "detail": "Opción Rápida: Usar Chandelure con +4 en Ataque Especial, luego Truco para intercambiar objeto // Barrer con Lanzallamas",
-                  "variant": []
-                },
-                {
-                  "detail": "Ahorra Recursos: Usar Truco dos veces, bloquear con Avalancha // Scrafty +3",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Machamp no se retira → Truco para bloquear Quagsire / Torterra / Metagross / Seismitoad , Cloyster +4",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Puño Drenaje → Usar Lanzallamas // Si Machamp no se retira o aparece Torterra, seguir usando Lanzallamas",
-          "variant": [
-            {
-              "detail": "Entra Darmanitan → Excadrill 4 + 0 // Si darmanitan recupera salud cambia a Chandelure +4 + 0 y utiliza Truco 1 vez // Lanzallamas para barrer",
-              "variant": []
-            },
-            {
-              "detail": "Entra Quagsire / Seismitoad → Cambiar a Cloyster y luego a Metagross con Truco, bloquear Terremoto, Cloyster +4",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Vendetta→ Excadrill pone Trampa Rocas, luego cambiar a Scrafty y después a Metagross // Si aparece Volcarona, usar Puño Trueno (si entra Steelix), Cloyster +2 + Medicina Especial",
+          "detail": "Si usa Vendetta, usa Bostezo. Cuando salga Metagross o Eelektross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Quagsire / Torterra / Seismitoad → Cloyster +4",
+          "detail": "Si usa Roca Afilada, usa Bostezo.",
           "variant": []
         },
         {
-          "detail": "Darmanitan → Scrafty +3",
+          "detail": "Si usa Puño Hielo, usa Bostezo frente a Metagross. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Puño Dinámico → Truco y revisar el objeto",
+      "detail": "Ruta con Salamence sin Intimidación:",
       "variant": [
         {
-          "detail": "Baya Atania → Scrafty +3 (A Bocajarro mata a Hitmontop) // Te puedes curar con Puño Drenaje si estás +2",
+          "detail": "Cambia a Chansey y coloca Trampa Rocas. Frente a Hitmonlee, entra con Gengar y usa Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Restos → Scrafty usa medicina de Defensa y boostea a +3 (puede curarse con Puño Drenaje si está +2) // A Bocajarro para matara a Machamp o 2 Puño Drenaje si quieres curarte",
+          "detail": "Si el rival saca Machamp, cambia a Chansey y luego vuelve a Gengar. Usa Otra Vez y Maquinación hasta +4.",
           "variant": []
         },
         {
-          "detail": "Blastoise → Poliwrath +6 +2",
+          "detail": "Gengar tiene una probabilidad baja de debilitar a Steelix. Si Gengar cae, entra con Volcarona y usa Danza Aleteo x1.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Krookodile → Cloyster +4 + Especial X // Carámbano para Lucario",
-      "variant": []
+      "detail": "Ruta por Patada Salto Alta o si Hitmonlee huye frente a Machamp:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y luego a Chansey frente a Luxray. Entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Golem → Truco y bloquear Terremoto → Cloyster +4",
-      "variant": []
+      "detail": "Rutas por cambios del rival:",
+      "variant": [
+        {
+          "detail": "Si sale Eelektross, usa Encanto con Chansey. Frente a Aggron usa Amortiguador; cuando vuelva Machamp, cambia a Gengar, usa Otra Vez y Maquinación hasta +4.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross o Torterra, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "STEELIX → Cloyster +4 + Medicina Especial // Si no usas medicina especial, hay un 12.5% de probabilidad de ser derrotado de un golpe HERACROSS Tiene Banda Focus usar Carámbano",
-      "variant": []
+      "detail": "Si Machamp usa Puño Drenaje con Llamaesfera:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Si se queda, derrótalo. Si sale Steelix, cambia a Slowbro y usa Bostezo. Si se queda, usa Protección y luego Bostezo otra vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Heracross, cambia a Chansey y luego a Gengar. Usa Maquinación hasta +4 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si Heracross cambia a Steelix, coloca Trampa Rocas con Chansey.",
+          "variant": []
+        },
+        {
+          "detail": "Si Machamp vuelve, cambia a Gengar y luego a Chansey. Frente a Staraptor, entra con Gengar, usa Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Staraptor, cambia a Slowbro. Si después sale Lucario, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross y luego Lucario, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si Machamp usa Puño Drenaje sin Llamaesfera:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Golem, usa Teletransporte hacia Chansey y coloca Trampa Rocas. Si luego sale Metagross, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Derrótalo; cuando salga Golem, usa otra Maquinación y sigue barriendo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross o Torterra, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/metagross.json
+++ b/src/data/johto/bruno/metagross.json
@@ -2,89 +2,45 @@
   "id": "metagross_2",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto, revisar el objeto:",
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
       "variant": [
         {
-          "detail": "Refleluz → Excadrill con Trampa Rocas + 4 Atq / +2 Vel",
+          "detail": "Si Metagross se queda, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Baya Zidra → Cloyster +4",
+          "detail": "Si sale Darmanitan, puedes elegir entre ahorro con Volcarona usando Danza Aleteo x3, ruta estable con Slowbro usando Bostezo y Poliwrath con Tambor hasta +6 Ataque, o ruta RNG sacrificando a Politoed y entrando directo con Poliwrath.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo. Cuando vuelva Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Machada, cambiar a Chandelure",
+      "detail": "Si sale Machamp, cambia a Gengar y revisa el ataque.",
       "variant": [
         {
-          "detail": "Golem → Usar Truco para bloquear Terremoto, luego Cloyster +4",
+          "detail": "Si usa Puño Dinámico, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si no se retira → Usar Lanzallamas para debilitar, entra Golem, cambiar a Metagross para sacrificarlo, luego Chandelure con Truco para bloquear Terremoto, Cloyster +4",
+          "detail": "Si usa Puño Drenaje, usa Otra Vez con Gengar. Luego cambia a Chansey; cuando salga Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Krookodile o Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Puño Hielo, cambiar a Chandelure",
-      "variant": [
-        {
-          "detail": "Machamp o Eelektross → Usar Truco",
-          "variant": [
-            {
-              "detail": "Roca Afilada / Avalancha o Vendetta → Scrafty +3. / Usar A Bocajarro para eliminar a Metagross",
-              "variant": []
-            },
-            {
-              "detail": "Blastoise → Poliwrath +6 Atq / +2 Vel",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Blaziken → Excadrill +4 Atq / +2 Vel",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Poder Oculto, usar directamente Chandelure + 2 Píldoras de Ataque SP. / Usar Lanzallamas para barrer el equipo",
-      "variant": []
-    },
-    {
-      "detail": "Machamp, cambiar a Chandelure",
-      "variant": [
-        {
-          "detail": "Si no se retira → Usar Bola Sombra continuamente",
-          "variant": [
-            {
-              "detail": "Blastoise → Poliwrath +6 / +2. / Si cambia a Eelektross saca a Excadrill, luego a Chandelure y usar Truco para bloquear Puño Trueno, Excadrill +4 / +2",
-              "variant": []
-            },
-            {
-              "detail": "Eelektross → Cambiar a Excadrill, luego a Chandelure con Truco para bloquear Puño Trueno, Excadrill +4 / +2. Si entra Blastoise mientras te boosteas,entonces cambia Poliwrath +6 / +2",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Gliscor → Usar Truco para bloquear Terremoto, Cloyster +6 + Medicina Defensa",
-          "variant": []
-        },
-        {
-          "detail": "Golem → Usar Truco para bloquear terremoto, Cloyster +4",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Golem → Cloyster +4",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/bruno/muk.json
+++ b/src/data/johto/bruno/muk.json
@@ -2,11 +2,24 @@
   "id": "muk",
   "name": "Muk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRAMPA ROCAS",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Entra Chandelure +4, Vel +0. Usa Lanzallamas para barrer todo el equipo.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
+      "variant": [
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Muk usa Puya Nociva, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/poliwrath.json
+++ b/src/data/johto/bruno/poliwrath.json
@@ -2,11 +2,20 @@
   "id": "poliwrath",
   "name": "Poliwrath",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "USA PUÑO TRUENO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Entra Krookodile: Cambia a Cloyster y Rompecoraza a +6. /Usa Carámbano para Debilitar a Lucario, Metagross.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Krookodile o Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp, cambia a Gengar y usa Otra Vez. Luego cambia a Chansey; cuando salga Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/salamence.json
+++ b/src/data/johto/bruno/salamence.json
@@ -2,124 +2,45 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Revisa la habilidad 💡",
   "tricks": [
     {
-      "detail": "Metagross (Vidasfera) → Cambia a Chandelure",
+      "detail": "Si Salamence tiene Intimidación, usa Amortiguador y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "No se retira → Bola Sombra para eliminar, observa el siguiente movimiento👇🏻",
-          "variant": [
-            {
-              "detail": "Golem → Cambia a Metagross, se sacrifica, entra Chandelure y usa Truco para bloquear Terremoto, Cloyster +4",
-              "variant": []
-            },
-            {
-              "detail": "Machamp → Cambia a Scrafty, luego a Chandelure y usa Truco para bloquear Roca Afilada, Excadrill +4+2",
-              "variant": []
-            },
-            {
-              "detail": "Muk → Excadrill +4+2",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Contra Golem / Rhyperior → Truco para bloquear Terremoto, Cloyster +4",
-          "variant": []
-        }
-      ]
-    }, 
-    {
-      "detail": "Metagross (Restos) → Cambia a Chandelure",
-      "variant": [
-        {
-          "detail": "No se retira → Llamarada para eliminar, entra Blastoise, Poliwrath +6+2",
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Mantén Otra Vez cada vez que puedas.",
           "variant": []
         },
         {
-          "detail": "Machamp → Truco",
-          "variant": [
-            {
-              "detail": "Vendetta, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Blastoise, Poliwrath +6+2",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "Golem → Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "Steelix → Cloyster +6",
-      "variant": []
-    },
-    {
-      "detail": "Machamp → Cambia a Chandelure",
-      "variant": [
-        {
-          "detail": "No se retira → Truco",
-          "variant": [
-            {
-              "detail": "Blastoise, Poliwrath +6+2",
-              "variant": []
-            },
-            {
-              "detail": "Si sigue en campo, usa Lanzallamas para debilitarlo, entra Blastoise, Poliwrath +6+2",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Eelektross → Truco",
-          "variant": [
-            {
-              "detail": "Rayo, Excadrill +4+2",
-              "variant": []
-            },
-            {
-              "detail": "Blastoise, Poliwrath +6+2",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },    
-    {
-      "detail": "Terremoto → Cloyster +6 con píldora de critico",
-      "variant": []
-    },
-    {
-      "detail": "Onda Ígnea / Lanzallamas → Chandelure usa objeto para aumentar Ataque Especial 4+0 / Lanzallamas para barrer al equipo",
-      "variant": []
-    },
-    {
-      "detail": "Lanzallamas→ Revisar objeto",
-      "variant": [
-        {
-          "detail": "Vidasfera → Cambia a Chandelure y usa Truco para intercambiar objeto, Cloyster +4",
+          "detail": "Si sale Metagross, cambia a Chansey y usa Amortiguador. Si luego sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No es necesario usar Otra Vez.",
           "variant": []
         },
         {
-          "detail": "Gema Dragón → Chandelure usa Poder Oculto para eliminar, entra",
-          "variant": [
-            {
-              "detail": "Blastoise, Poliwrath +6+2",
-              "variant": []
-            },
-            {
-              "detail": "Aggron : Cloyster +4 + Especial X / Hitmontop Surf",
-              "variant": []
-            }
-          ]
+          "detail": "Si sale Blaziken directo, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No es necesario usar Otra Vez.",
+          "variant": []
         }
       ]
-    }   
+    },
+    {
+      "detail": "Si Salamence no tiene Intimidación, coloca Trampa Rocas.",
+      "variant": [
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hitmonlee, entra con Gengar y usa Bola Sombra. Si lo derrotas y sale Machamp, sigue con Bola Sombra; luego cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
+          "variant": []
+        },
+        {
+          "detail": "Si el rival cambia a Machamp, cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
   ]
 }

--- a/src/data/johto/bruno/seismitoad.json
+++ b/src/data/johto/bruno/seismitoad.json
@@ -2,11 +2,34 @@
   "id": "seismitoad",
   "name": "Seismitoad",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Bloquear Terremoto → luego Cloyster +4.",
-      "variant": []
+      "detail": "Opción ahorro:",
+      "variant": [
+        {
+          "detail": "Usa Amortiguador. Si sale Darmanitan, entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Opción estable:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Opción RNG:",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/slowbro.json
+++ b/src/data/johto/bruno/slowbro.json
@@ -2,67 +2,51 @@
   "id": "slowbro",
   "name": "Slowbro",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Steelix → revisa el objeto.",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Casco Dentado → Cloister 6.",
+          "detail": "Si sale Hitmonlee, entra con Gengar y usa Bola Sombra. Si lo derrotas y sale Machamp, continúa con Bola Sombra; luego cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
           "variant": []
         },
         {
-          "detail": "CINTA ELEGIDA → Cloyster +4 + Especial X / Si no usas la medicina, hay un 12.5% de probabilidad de que sea debilitado de un solo golpe",
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Machamp se queda, usa Maquinación hasta +4 y derrota a todos con Bola Sombra.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Aggron → Cloister 4+ con Especial X. Usa Surf para matar a Conkeldurr.",
-      "variant": []
-    },
-    {
-      "detail": "Escaldar → revisa el daño del ataque.",
+      "detail": "Ruta con Salamence y Aggron:",
       "variant": [
         {
-          "detail": "24.7%-29.1%【con alrededor de 40% de chance de quemar】 → revisa si Metagross queda quemado.",
+          "detail": "Si sale Salamence, usa Bola Sombra hasta que salga Aggron.",
           "variant": []
         },
         {
-          "detail": "Si está quemado → Poliwrath 6+2. Usa Puño Hielo para matar a Salamence.",
+          "detail": "Si Gengar derrota a Aggron con crítico, termina de barrer.",
           "variant": []
         },
         {
-          "detail": "Si no está quemado → cambia a Chandelure :",
+          "detail": "Si Aggron derrota a Gengar y no activa Cuerpo Maldito, entra con Volcarona, derrota a Aggron y frente al Slowbro rival usa Danza Aleteo x1.",
           "variant": []
         },
         {
-          "detail": "Si Slowbro no se va → Poliwrath 6+2. Usa Puño Hielo para matar a Salamence.",
-          "variant": []
-        },
-        {
-          "detail": "Contra Steelix → Truco para bloquear Terremoto, luego Cloyster +6.",
-          "variant": []
-        },
-        {
-          "detail": "Contra Salamence/Hitmontop → Truco para bloquear Terremoto, luego Cloister 6+ con crítico. Usa Carámbano para matar a Steelix.",
+          "detail": "Si Aggron derrota a Gengar y se activa Cuerpo Maldito, entra con Volcarona y usa Danza Aleteo x1.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Alrededor de 36%【con cerca de 54% de chance de crítico】 → pon Trampa Rocas :",
+      "detail": "Si sale Heracross, usa Amortiguador y luego Teletransporte hacia Gengar.",
       "variant": [
         {
-          "detail": "Si no se va → Poliwrath 6+2. // Si cambia a Staraptor , sacrifica a Poliwrath, Chandelure usa Poder oculto para debilitar rápido, entra Steelix, luego Cloister 4.",
-          "variant": []
-        },
-        {
-          "detail": "Si sale Steelix → Cloister 4.",
-          "variant": []
-        },
-        {
-          "detail": "Si sale Heracross → cambia a Chandelure y usa Truco para bloquear Roca Afilada, luego Excadrill 4+2+2 (con Defensa). Primero usa Defensa X para subir defensa.",
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +2 y Precisión X. Mantén Otra Vez de nuevo cuando sea necesario. 🔔 Heracross tiene Banda Focus. 🔔",
           "variant": []
         }
       ]

--- a/src/data/johto/bruno/staraptor.json
+++ b/src/data/johto/bruno/staraptor.json
@@ -2,19 +2,41 @@
   "id": "staraptor",
   "name": "Staraptor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Slowbro + revisar objeto",
   "tricks": [
     {
-      "detail": "A BOCAJARRO → Chandelure usa Lanzallamas para debilitar o matar, entra Krookodile, luego Cloyster +4 + Especial X // Usa Carámbano para matar a Lucario.",
-      "variant": []
+      "detail": "Cambia a Slowbro y revisa si Staraptor tiene Vidasfera.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidasfera, usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si se queda, usa Teletransporte hacia Chansey, coloca Trampa Rocas y vuelve con Teletransporte hacia Gengar. Usa Otra Vez, Maquinación hasta +2 y Precisión X. 🔔 Heracross tiene Banda Focus. 🔔",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Heracross, usa Protección, cambia a Chansey y espera a Steelix. Coloca Trampa Rocas y mantén Amortiguador hasta que vuelva a cambiar.",
+          "variant": []
+        },
+        {
+          "detail": "Si Heracross se queda, continúa usando Amortiguador.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Staraptor o Machamp, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "STEELIX → Cloyster +4 con medicina de Ataque Especial.",
-      "variant": []
-    },
-    {
-      "detail": "METAGROSS → Excadrill con Trampa Rocas y 4+2",
-      "variant": []
+      "detail": "Si Staraptor no tiene Vidasfera:",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo. Cuando salga Lucario, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2. Mantén los PS de Volcarona por encima del 17%.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/steelix.json
+++ b/src/data/johto/bruno/steelix.json
@@ -2,15 +2,28 @@
   "id": "steelix",
   "name": "Steelix",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Casco Dentado → Cloyster 6.",
-      "variant": []
-    },
-    {
-      "detail": "Cinta Elegida → Cloyster 4 + medicina de Ataque Especial. Si no usas la medicina de Sp. Atk, hay 12.5% de probabilidad de que Slowbro te reviente.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
+      "variant": [
+        {
+          "detail": "Si Steelix usa Terremoto, usa Encanto y luego Amortiguador hasta que salga Heracross.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Heracross, usa Amortiguador y luego Teletransporte para recibir A Bocajarro. Entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hitmonlee, entra con Gengar y usa Bola Sombra. Cuando lo derrotes y salga Machamp, continúa con Bola Sombra, luego cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Machamp directo, cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/bruno/torterra.json
+++ b/src/data/johto/bruno/torterra.json
@@ -2,11 +2,25 @@
   "id": "torterra",
   "name": "Torterra",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Bloquear Terremoto, luego Cloister 4.",
-      "variant": []
+      "detail": "Opción ahorro:",
+      "variant": [
+        {
+          "detail": "Usa Amortiguador. Si sale Darmanitan, entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Opción estable:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/absol.json
+++ b/src/data/johto/karen/absol.json
@@ -2,11 +2,16 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🦋 Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Bloquear a Seismitoad / Quagsire, luego Cloyster +4. // Surf contra Gengar",
-      "variant": []
+      "detail": "Entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+      "variant": [
+        {
+          "detail": "Usa Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/blastoise.json
+++ b/src/data/johto/karen/blastoise.json
@@ -2,15 +2,20 @@
   "id": "blastoise",
   "name": "Blastoise",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear a SEISMITOAD, luego Cloyster +4. Dos Poder Oculto para matar a Seismitoad. / Metagross Surf",
-      "variant": []
-    },
-    {
-      "detail": "Bloquear a QUAGSIRE, luego Cloyster +6. / Carámbano para Houndoom y Absol / Surf para Gengar",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol y entra con Volcarona.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Gigadrenado contra Absol. Frente a Houndoom no hay amenaza importante.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/electrode.json
+++ b/src/data/johto/karen/electrode.json
@@ -2,15 +2,20 @@
   "id": "electrode",
   "name": "Electrode",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Garchomp → entra Cloister +6 +Pildora Directo. / Si no, todo con ataques de Carámbano. Puede salir Feraligatr pero no hay peligro.",
-      "variant": []
-    },
-    {
-      "detail": "Rayo → entra Excadrill, pone Trampa Rocas 4+2. Si viene Garchomp, cambio a Chandelure y uso Truco, lo dejo bloqueado en Terremoto. Luego entra Cloister +6 +Pildora Directo. / Si no, barre con Carámbano.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas, usa Teletransporte y entra con Slowbro para usar Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Slowbro está paralizado y no puede usar Bostezo, cambia a Chansey, recupera vida al máximo y repite la operación.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/excadrill.json
+++ b/src/data/johto/karen/excadrill.json
@@ -2,17 +2,46 @@
   "id": "excadrill",
   "name": "Excadrill",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "OBSERVA SI TIENE GLOBO HELIO",
+  "initialMove": "💡 Observa qué objeto tiene 💡",
   "tricks": [
     {
-      "detail": "NO TIENE GLOBO HELIO, Truco para encerrar en Terremoto, Cloyster +4 (Houndoom muere de carámbano)",
-      "variant": []
-    },
-    {
-      "detail": "SI TIENE GLOBO HELIO, cambia a Cloyster e inmediatamente cambia a Chandelure, usa Truco para encerrar en Terremoto para así sacar a Cloyster y boostear +6",
+      "detail": "Si tiene Globo Helio:",
       "variant": [
         {
-          "detail": "Chandelure podría morir de un crítico de Avalancha, si esto llega a pasar haz lo siguiente) - Saca a Metagross para revivir a Chandelure y sacrifica al Metagross, Chandelure usa Truco, saca a Cloyster +6",
+          "detail": "Usa Encanto y coloca Trampa Rocas. Si Excadrill se queda, usa Amortiguador. Frente a Tyranitar, cambia a Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados, barre hasta Houndoom e ignora la amenaza.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Victreebel, cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Excadrill, sigue usando Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si no tiene Globo Helio:",
+      "variant": [
+        {
+          "detail": "Usa Encanto y coloca Trampa Rocas. Mantén Amortiguador hasta que el rival cambie.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Slowbro rival, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Mantén Otra Vez cuando sea necesario.",
+          "variant": []
+        },
+        {
+          "detail": "Si Excadrill entra mientras intentas boostearte, cambia a Slowbro y luego a Chansey. Usa Encanto, vuelve a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/karen/feraligatr.json
+++ b/src/data/johto/karen/feraligatr.json
@@ -2,19 +2,20 @@
   "id": "feraligatr",
   "name": "Feraligatr",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "❤️ Encanto ❤️",
   "tricks": [
     {
-      "detail": "GARCHOMP → Cloyster +6 + crítico. / Todo muere con Carámbano.",
-      "variant": []
-    },
-    {
-      "detail": "RHYDON → Cloyster +4. Usa Carámbano para matar a Houndoom.",
-      "variant": []
-    },
-    {
-      "detail": "CASCADA → Cloyster sube defensa +4 Especial X Si no temes al crítico, puedes no usar Especial X",
-      "variant": []
+      "detail": "Usa Encanto y revisa el daño recibido.",
+      "variant": [
+        {
+          "detail": "Si el daño es menor a 36%, coloca Trampa Rocas. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si el daño es mayor a 39%, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Cura la quemadura si ocurre.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/flareon.json
+++ b/src/data/johto/karen/flareon.json
@@ -2,11 +2,20 @@
   "id": "flareon",
   "name": "Flareon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA CHANDELURE",
+  "initialMove": "👻 Gengar + Slowbro 👻",
   "tricks": [
     {
-      "detail": "Cambiar a Chandelure y usar Bola Sombra; si entra Hydreigon, entrar con Scrafty +3. // Paliza para matar a Primeape (Banda Focus)",
-      "variant": []
+      "detail": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si el crítico de Typhlosion debilita a Poliwrath, entra con Gengar, usa Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/gallade.json
+++ b/src/data/johto/karen/gallade.json
@@ -2,21 +2,17 @@
   "id": "gallade",
   "name": "Gallade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Gengar + Slowbro 👻",
   "tricks": [
     {
-      "detail": "Truco, Rhydon →Cloister 4. Usa Carambano para matar a Houndoom.",
-      "variant": []
-    },
-    {
-      "detail": "Ataque Sorpresa → revisa si Chandelure murió :",
+      "detail": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Si murió → cambia a Scrafty y luego Metagross, contra Vileplume usa Truco para bloquear a Rhydon, luego Cloister 4. Usa Carambano para matar a Houndoom.",
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si no murió → Scrafty 4 o 2+ con Ataque. Usa Paliza para matar a Houndoom.",
+          "detail": "Cura la quemadura si ocurre antes de seguir barriendo.",
           "variant": []
         }
       ]

--- a/src/data/johto/karen/garchomp.json
+++ b/src/data/johto/karen/garchomp.json
@@ -2,11 +2,16 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear Terremoto, Cloyster +6 + Píldora para aumentar Críticos.Todo con ataques de Carámbano. Puede salir un Feraligatr, sin peligro.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Luego cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/gengar.json
+++ b/src/data/johto/karen/gengar.json
@@ -2,11 +2,20 @@
   "id": "gengar",
   "name": "Gengar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear a Quagsire, luego Cloyster +4. // Se necesita 2 Poder Oculto para matar a Quagsire",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol y entra con Volcarona.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/gyarados.json
+++ b/src/data/johto/karen/gyarados.json
@@ -2,58 +2,61 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "PUÑO TRUENO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si solo hiere a Gyarados → Ver si Gyarados recupera PS con Restos.",
+      "detail": "Coloca Trampa Rocas. Si Gyarados se queda, usa Amortiguador y espera el cambio.",
       "variant": [
         {
-          "detail": "NO tiene Restos → Cloyster +6. / Carámbano mata a Houndoom y Tyranitar.",
-          "variant": [
-            {
-              "detail": "Si entra Tyranitar mientras te boosteas, cambiar a Metagross y usar Truco, bloquear con Terremoto, Cloyster +6. / Carámbano mata a Houndoom.",
-              "variant": []
-            }       
-          ]
+          "detail": "Si sale Leafeon, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
         },
         {
-          "detail": "SI tiene Restos → Seguir usando Puño Trueno. Si entra Rhyperior, cambiar a Cloyster, luego a Metagross y usar Truco, bloquear con Terremoto, Cloyster +4. / Todo se mata con Carámbano.",
+          "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados, barre hasta Houndoom e ignora la amenaza.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Si Gyarados es derrotado de un golpe → Ver quién entra:",
+      "detail": "Ruta con Rhyperior:",
       "variant": [
         {
-          "detail": "Excadrill → Cambiar a Excadrill y luego a Chandelure.",
-          "variant": [
-            {
-              "detail": "Excadrill no se retira → Truco para bloquear con Terremoto, Cloyster +6. / Carámbano mata a Houndoom y Tyranitar.",
-              "variant": []
-            },
-            {
-              "detail": "Slowbro → Truco para bloquear Escaldar, Poliwrath +6 +4. / A Bocajarro mata a Excadrill. Si se quema, no curar, priorizar ataques super efectivos.",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Rhyperior → Cambiar a Excadrill, luego a Metagross y usar Truco, bloquear con Terremoto, Cloyster +4. / Todo se mata con Carámbano.",
+          "detail": "Usa Encanto y cambia a Slowbro.",
           "variant": []
         },
         {
-          "detail": "Houndoom → Cambiar a Chandelure, usar Truco y bloquear Pulso Umbrío o Persecución, luego Scrafty +2. / A Bocajarro mata a Rhyperior. // Si Chandelure entra por error frente a Rhyperior, usar Truco para bloquear con Terremoto, Cloyster +4. / Todo se mata con Carámbano.",
+          "detail": "Si Rhyperior se queda, usa Bostezo frente a Leafeon y luego entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, usa Bostezo, Protección y Bostezo otra vez frente a Leafeon. Luego entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Rhyperior → Cambiar a Excadrill, luego a Metagross y usar Truco, bloquear con Terremoto, Cloyster +4. / Todo se mata con Carámbano.",
-      "variant": []
+      "detail": "Ruta con Victreebel:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados después, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Quagsire → Cambiar a Cloyster, luego a Metagross y usar Truco, bloquear con Terremoto, Cloyster +4. / Todo se mata con Carámbano.",
+      "detail": "Si sale Excadrill, usa Encanto y Amortiguador frente a Tyranitar. Luego cambia a Poliwrath para derrotar a Tyranitar.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/honchkrow.json
+++ b/src/data/johto/karen/honchkrow.json
@@ -2,24 +2,20 @@
   "id": "honchkrow",
   "name": "Honchkrow",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Slowbro + Bostezo",
   "tricks": [
     {
-      "detail": "FUERZA BRUTA → cambia a Chandelure.",
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Houndoom.",
       "variant": [
         {
-          "detail": "NO SE VA → Truco para bloquear a Rhydon, luego Cloyster +4. // Usa Carámbano para matar a Houndoom.",
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "RHYPERIOR → Truco para bloquear Terremoto, luego Cloister 4. // Usa Carámbano para matar a Houndoom.",
+          "detail": "Cura la quemadura si ocurre antes de seguir barriendo.",
           "variant": []
         }
       ]
-    },   
-    {
-      "detail": "RHYPERIOR → Cloyster +6. Usa Carámbano para matar a Houndoom.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/karen/houndoom.json
+++ b/src/data/johto/karen/houndoom.json
@@ -2,97 +2,108 @@
   "id": "houndoom",
   "name": "Houndoom",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO / Si Houndoom ataca primero es Pañuelo Elegido",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lanzallamas → revisar objeto",
+      "detail": "Coloca Trampa Rocas. Si Houndoom se queda, revisa su objeto. Si falla el turno, usa Amortiguador.",
       "variant": [
         {
-          "detail": "Cinta Xperto → cambiar a Chandelure, ayudar a Metagross con Revivir o Cura Quemadura / usar Bola Sombra.",
-          "variant": [
-            {
-              "detail": "Hydreigon → Scrafty +3. / Paliza para Primeape",
-              "variant": []
-            }
-          ]
-        },    {
-          "detail": "Banda Focus / Vidasfera → cambiar a Chandelure y usar Truco.",
-          "variant": [
-            {
-              "detail": "Houndoom se queda → Scrafty +4 o +2 con X Ataque. / Paliza mata a Vileplume en 2 turnos",
-              "variant": []
-            },
-            {
-              "detail": "Feraligatr → Cloyster +4 + Defensa X (Primero la medicina)",
-              "variant": []
-            },
-            {
-              "detail": "Tyranitar → Scrafty +3. / Si Scrafty recibe Terremoto, cambiar a Cloyster +6",
-              "variant": []
-            },
-            {
-              "detail": "Rhyperior / Quagsire → Cloyster +4 / Si Cloyster se encuentra inesperadamente contra Gyarados → cambiar a Scrafty, usar Medicina Defensa X +3 / Cuidado con tu vida",
-              "variant": []
-            },
-            {
-              "detail": "Gyarados (Pañuelo Elegido) → cambiar a Poliwrath, luego cambiar a Scrafty. // Si Metagross está quemado, usar a Poliwrath para ayudar a quitar la quemadura (contra Slowbro), luego Scrafty +3",
-              "variant": [
-                {
-                  "detail": "Slowbro → Scrafty +3 / / Si tienes bajos PS usar Raíz Energía",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Gyarados (Restos) → Cloyster +4 con Medicina Defensa X. / / Primero usar medicina",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },  
-    {
-      "detail": "Llamarada (Pañuelo Elegido) → cambiar a Chandelure; ver qué movimiento usa Houndoom después. // Si Metagross falla Truco, no hay problema. ¡Chandelure no debe usar ningún movimiento!",
-      "variant": [
-        {
-          "detail": "Poder Oculto → Excadrill coloca Trampa Rocas, 4+2+2 (con Defensa Especial X)",
+          "detail": "Si tiene Vidasfera, usa Amortiguador dos veces. Si se queda, sacrifica a Politoed y entra con Poliwrath. Usa Ataque X y empieza a barrer.",
           "variant": []
         },
         {
-          "detail": "Llamarada / Vozarrón → Ayudar a Metagross con Revivir o Raíz Energía // Mirar la situación 👇🏻 ¡Chandelure no debe usar ningún movimiento!",
-          "variant": [
-            {
-              "detail": "Houndoom no se va → (Ayudar a Metagross a curarse hasta 90% o más) / un Poder Oculto para bajar PS / cambiar a Metagross frente a Gengar / Truco para bloquear a Quagsire / Cloyster +4",
-              "variant": []
-            },
-            {
-              "detail": "Blastoise → (Ayudar a Metagross a curarse hasta 83% o más) / cambiar a Poliwrath / cambiar a Metagross y usar Truco / bloquear a Quagsire / Cloyster +4",
-              "variant": []
-            }
-          ]
+          "detail": "Si no tiene Vidasfera, usa Amortiguador hasta que el rival cambie.",
+          "variant": []
         }
       ]
     },
     {
-      "detail": "Quagsire / Rhyperior → Cloyster +4 / Carámbano mata a Houndoom",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp → Cloyster +6 + Medicina Crítica. / Todo muere con Carámbano",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill → Mira el objeto.",
+      "detail": "Rutas con cambios directos:",
       "variant": [
         {
-          "detail": "Vidasfera → Cloyster +4. / Carámbano mata a Houndoom.",
+          "detail": "Si sale Leafeon, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
           "variant": []
         },
         {
-          "detail": "Globo Helio → Usa Truco para recuperarlo, luego vuelve a usar Truco para bloquear Terremoto, Cloyster +6. / Carámbano mata a Houndoom y Tyranitar.",
+          "detail": "Si sale Feraligatr, usa Encanto, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Honchkrow, Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Primeape, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade o Roserade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    }    
+    },
+    {
+      "detail": "Ruta con Gyarados o Victreebel:",
+      "variant": [
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados, barre hasta Houndoom e ignora la amenaza.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Victreebel, cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta con Excadrill:",
+      "variant": [
+        {
+          "detail": "Si Excadrill tiene Globo Helio, usa Encanto y Amortiguador frente a Tyranitar. Luego cambia a Poliwrath para derrotar a Tyranitar.",
+          "variant": []
+        },
+        {
+          "detail": "Si Excadrill no tiene Globo Helio, cambia a Slowbro y usa Bostezo. Si se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1, barre hasta Houndoom, luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mismagius, entra con Volcarona, usa Danza Aleteo x1 frente a Houndoom, luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta con Rhyperior:",
+      "variant": [
+        {
+          "detail": "Usa Encanto y cambia a Slowbro.",
+          "variant": []
+        },
+        {
+          "detail": "Si Rhyperior se queda, usa Bostezo frente a Leafeon y entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, usa Bostezo, Protección y Bostezo otra vez frente a Leafeon. Luego entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
+    }
   ]
 }

--- a/src/data/johto/karen/hydreigon.json
+++ b/src/data/johto/karen/hydreigon.json
@@ -2,11 +2,16 @@
   "id": "hydreigon",
   "name": "Hydreigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🥚 Chansey + Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Truco, si no se retira / encierra a Hydreigon, Scrafty 3. Usa paliza para matar a primeape",
-      "variant": []
+      "detail": "Chansey usa Amortiguador frente a Primeape.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. 🔔 Primeape tiene Banda Focus. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/leafeon.json
+++ b/src/data/johto/karen/leafeon.json
@@ -2,33 +2,42 @@
   "id": "leafeon",
   "name": "Leafeon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Tijera X → Cambia a Chandelure.",
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
       "variant": [
         {
-          "detail": "Contra Rhyperior → Usa Truco para bloquear con Terremoto, luego entra Cloyster +4.",
+          "detail": "Si Leafeon se queda, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
           "variant": []
         },
         {
-          "detail": "Si no se va → usa Lanzallamas para debilitar, mira quién entra abajo:",
-          "variant": [
-            {
-              "detail": "Si entra Rhydon → cambia a Excadrill, luego Chandelure usa Truco para bloquear Terremoto, luego Cloyster +4.",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Houndoom → cambia a Poliwrath para revivir a Chandelure, usa Truco para bloquear Juego Sucio, luego Scrafty +3.",
-              "variant": []
-            }
-          ]
-        }        
+          "detail": "Si sale Leafeon después de otra ruta, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
       ]
     },
     {
-      "detail": "Rhyperior → Cloyster +4",
-      "variant": []
+      "detail": "Ruta con Rhyperior:",
+      "variant": [
+        {
+          "detail": "Usa Encanto y cambia a Slowbro.",
+          "variant": []
+        },
+        {
+          "detail": "Si Rhyperior se queda, usa Bostezo frente a Leafeon y luego entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta con Gyarados:",
+      "variant": [
+        {
+          "detail": "Usa Bostezo, Protección y Bostezo otra vez frente a Leafeon. Luego entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/lucario.json
+++ b/src/data/johto/karen/lucario.json
@@ -2,15 +2,45 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si Cambia a Quagsire Cambia Excadrill 4+2 y al final Trampa Rocas (Si cambia a Salamence, cambia a Chandelure, Truco y luego cambia a Excadrill)",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa el movimiento o cambio rival.",
+      "variant": [
+        {
+          "detail": "Si usa Poder Oculto, cambia a Gengar y usa Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si Lucario se queda, Gengar usa Otra Vez y Maquinación hasta +6. 🔔 Lucario tiene Banda Focus. Barre con Bola Sombra. 🔔",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rapidash, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Spiritomb, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Si Spiritomb despierta, no es amenaza.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Lucario, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Si lucario se queda y usa Esfera Aural Cambia Chandelure usa Truco, y Cambia a Scrafty Danza Dragón a +4 o +2 + Ataque X.",
-      "variant": []
+      "detail": "Ruta con Salamence:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y mantén Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Spiritomb después de Bostezo y Protección, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Spiritomb despierto no es amenaza.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/luxray.json
+++ b/src/data/johto/karen/luxray.json
@@ -2,11 +2,20 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Chansey + Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Bloqueado en Rayo. Excadrill entra, pone Trampa Rocas con 4+2.",
-      "variant": []
+      "detail": "Chansey usa Amortiguador y luego coloca Trampa Rocas frente a un tipo Lucha.",
+      "variant": [
+        {
+          "detail": "Después cambia a Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/mismagius.json
+++ b/src/data/johto/karen/mismagius.json
@@ -2,26 +2,44 @@
   "id": "mismagius",
   "name": "Mismagius",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Garchomp → Cloyster +6 + Crítico. / Todo muere con Carámbano.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Mismagius se queda, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Si se mantiene, entra con Volcarona y usa Gigadrenado. Luego cambia a Chansey, usa Teletransporte hacia Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si quedas frente a Houndoom, sacrifica a Politoed y entra con Poliwrath. Usa Ataque X y empieza a barrer.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Excadrill → Cloyster +4. / Carámbano para Houndoom.",
-      "variant": []
+      "detail": "Ruta con Excadrill:",
+      "variant": [
+        {
+          "detail": "Usa Teletransporte hacia Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si Excadrill se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y ataca hasta quedar frente a Houndoom. Luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mismagius, entra con Volcarona, usa Danza Aleteo x1 frente a Houndoom, luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Hydreigon → Cambia a Chandelure y usa Truco, si Hydreigon se queda o bloqueas a Houndoom, Scrafty +3. / Paliza mata a Primeape.",
-      "variant": []
-    },
-    {
-      "detail": "Bola Sombra → Scrafty +3 / Paliza mata a Primeape.",
-      "variant": []
-    },
-    {
-      "detail": "Rayo → Excadrill Trampa Rocas, +4 +2.",
+      "detail": "Si sale Primeape, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/primeape.json
+++ b/src/data/johto/karen/primeape.json
@@ -2,15 +2,16 @@
   "id": "primeape",
   "name": "Primeape",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "Frente a Hydreigon, saco a Scrafty +3. / Paliza para Primeape",
-      "variant": []
-    },
-    {
-      "detail": "No se va, usó Truco para bloquearlo en Garra Umbría, saca a Scrafty +3",
-      "variant": []
+      "detail": "Cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+      "variant": [
+        {
+          "detail": "🔔 Primeape tiene Banda Focus. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/quagsire.json
+++ b/src/data/johto/karen/quagsire.json
@@ -2,6 +2,32 @@
   "id": "quagsire",
   "name": "Quagsire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Truco para bloquear con Terremoto, luego entra Cloyster +4. // Usa Poder Oculto (Planta) seguido de Carámbano para derrotar a Quagsire / Surf para Gengar y Houndoom, si Surf está bloqueado usar Carámbano",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, entra con Volcarona y usa Danza Aleteo x2. Volcarona aguanta Persecución de Absol; el límite extremo con crítico ronda el 50%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rhyperior, usa Encanto y cambia a Slowbro.",
+          "variant": []
+        },
+        {
+          "detail": "Si Rhyperior se queda, usa Bostezo y, frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Leafeon, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, usa Bostezo, Protección y Bostezo otra vez. Frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/johto/karen/rhyperior.json
+++ b/src/data/johto/karen/rhyperior.json
@@ -2,11 +2,32 @@
   "id": "rhyperior",
   "name": "Rhyperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquea Terremoto, Cloyster +4. Usa Carámbano para matar a Houndoom y Gallade",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Rhyperior se queda, usa Encanto y cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Si Rhyperior se queda, usa Bostezo y, frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Leafeon, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, usa Bostezo, Protección y otro Bostezo más. Frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Honchkrow, Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade o Roserade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/sableye.json
+++ b/src/data/johto/karen/sableye.json
@@ -2,15 +2,28 @@
   "id": "sableye",
   "name": "Sableye",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Rhyperior, Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "Pulso Umbrío → cambio a Chandelure contra Rhyperior, Truco bloquea Terremoto, Cloister +4. Dusclops no se va, entra Scrafty +2. / A Bocajarro mata a Rhyperior, a Dusclops hay que pegarle dos veces.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Sableye se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Leafeon, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rhyperior, usa Encanto y cambia a Slowbro.",
+          "variant": []
+        },
+        {
+          "detail": "Si Rhyperior se queda, usa Bostezo y, frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, usa Bostezo, Protección y otro Bostezo más. Frente a Leafeon, entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/salamence.json
+++ b/src/data/johto/karen/salamence.json
@@ -2,15 +2,20 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Quagsire, Cloister +4",
-      "variant": []
-    },
-    {
-      "detail": "Gran Llamarada (muy poca probabilidad) → Chandelure con Poder Oculto entra Houndoom, Scrafty +3. Swampert es firme, hay que pegarle varias veces para acabar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol y entra con Volcarona.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x2. Aguanta Persecución de Absol; el límite extremo con crítico ronda el 50%.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Danza Aleteo una vez y barre hasta Houndoom. Luego usa Danza Aleteo otra vez para quedar en total con Danza Aleteo x2 y termina de barrer.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/slowbro.json
+++ b/src/data/johto/karen/slowbro.json
@@ -2,32 +2,58 @@
   "id": "slowbro",
   "name": "Slowbro",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "EXCADRILL SIN GLOBO → Cloyster 4+. Usa Carámbano para matar a Houndoom.",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill con globo → Usa Truco para recuperarlo, luego otro Truco para bloquear con Terremoto. Cloyster 6+. Usa Carámbano para matar a Houndoom.",
-      "variant": []
-    },
-    {
-      "detail": "CASCADA → Haz Truco otra vez para bloquear a Excadrill, Cloyster 4+. Usa Carámbano para matar a Houndoom.",
-      "variant": []
-    },
-    {
-      "detail": "LANZALLAMAS → Revisa si Metagross se quema o no.",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "No se quemó → Scrafty +2 + Raíz Energía +1. Usa Paliza para matar a Houndoom.",
+          "detail": "Si usa Puño Drenaje, entra con Volcarona y usa Danza Aleteo x2.",
           "variant": []
         },
         {
-          "detail": "Se quemó → Cambia a Chandelure y usa Truco para bloquear a Tyranitar. Excadrill entra y pone Trampa Rocas con 4+2.",
+          "detail": "Si sale Tyranitar, entra con Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados y frente a Houndoom sigue atacando; no te derrota.",
           "variant": []
         }
       ]
-    }    
+    },
+    {
+      "detail": "Ruta con Excadrill:",
+      "variant": [
+        {
+          "detail": "Si tiene Globo Helio, usa Encanto y Amortiguador frente a Tyranitar. Luego cambia a Poliwrath para derrotar a Tyranitar.",
+          "variant": []
+        },
+        {
+          "detail": "Si no tiene Globo Helio, usa Teletransporte hacia Slowbro y luego Bostezo. Si Excadrill se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y ataca hasta que entre Houndoom. Luego usa Danza Aleteo una vez más y derrótalo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mismagius, entra con Volcarona, usa Danza Aleteo x1 y ataca hasta que entre Houndoom. Luego usa Danza Aleteo una vez más y derrótalo.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta con Victreebel:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados después, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
+    }
   ]
 }

--- a/src/data/johto/karen/tyranitar.json
+++ b/src/data/johto/karen/tyranitar.json
@@ -2,11 +2,28 @@
   "id": "tyranitar",
   "name": "Tyranitar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "bloquea Terremoto, Cloister + 6. Carámbano para matar a Houndoom.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y cambia a Poliwrath para derrotar a Tyranitar.",
+      "variant": [
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados, barre hasta Houndoom e ignora la amenaza.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Victreebel, cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/umbreon.json
+++ b/src/data/johto/karen/umbreon.json
@@ -2,11 +2,20 @@
   "id": "umbreon",
   "name": "Umbreon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Scrafty +3 // 2 Paliza derrotan a Garchomp (Si usas Puño Drenaje te harás daño)",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Umbreon usa Juego Sucio y se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si entra Houndoom, sacrifica a Politoed y entra con Poliwrath. Usa Ataque X y empieza a barrer.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/victreebel.json
+++ b/src/data/johto/karen/victreebel.json
@@ -2,11 +2,36 @@
   "id": "victreebel",
   "name": "Victreebel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Truco para bloquear Terremoto, luego Cloyster +6 // Carámbano mata a Houndoom",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Victreebel se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Excadrill, usa Encanto y Amortiguador frente a Tyranitar. Luego cambia a Poliwrath para derrotar a Tyranitar.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Gyarados, barre hasta Houndoom e ignora la amenaza.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Victreebel, cambia a Gengar y luego a Slowbro. Si Victreebel se queda, usa Bostezo; luego cambia a Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/vileplume.json
+++ b/src/data/johto/karen/vileplume.json
@@ -2,15 +2,32 @@
   "id": "vileplume",
   "name": "Vileplume",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Rhyperior / Excadrill → Cloyster +4. // Carámbano mata a Houndoom",
-      "variant": []
-    },
-    {
-      "detail": "Poder Oculto → Chandelure usa Lanzallamas para rematar, entra Slowbro, Poliwrath +2+6",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Honchkrow, Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Excadrill, usa Teletransporte hacia Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si Excadrill se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y barre hasta Houndoom. Luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mismagius, entra con Volcarona, usa Danza Aleteo x1 frente a Houndoom, luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/weavile.json
+++ b/src/data/johto/karen/weavile.json
@@ -2,24 +2,24 @@
   "id": "weavile",
   "name": "Weavile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO // SI TRUCO FALLA (POR RETROCESO), SEGUIR USANDO TRUCO",
+  "initialMove": "🥚 Amortiguador + 🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Carámbano, Patada Baja o Golpe Bajo → Cambiar a Chandelure.",
+      "detail": "Usa Amortiguador para recibir el golpe de hielo. Luego coloca Trampa Rocas frente a Excadrill.",
       "variant": [
         {
-          "detail": "Si aún no se retira → Usar Truco para intercambiar el objeto, luego sacar a Scrafty +4 o +2 con medicina de ataque. / Paliza o derrota al Houndoom.",
+          "detail": "Usa Teletransporte y envía a Slowbro para usar Bostezo.",
           "variant": []
         },
         {
-          "detail": "Excadrill → Usar Truco para bloquear con Terremoto, luego Cloyster +6. / Carámbano mata a Houndoom.",
+          "detail": "Si Excadrill se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y barre hasta Houndoom. Luego usa Danza Aleteo una vez más y termina el combate.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mismagius, entra con Volcarona, usa Danza Aleteo x1 frente a Houndoom, luego usa Danza Aleteo una vez más y termina el combate.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "EXCADRILL → Cloyster +4. / Carámbano mata a Houndoom.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/koga/ariados.json
+++ b/src/data/johto/koga/ariados.json
@@ -2,11 +2,24 @@
   "id": "ariados",
   "name": "Ariados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear Rhyperior, Cloyster +4. / Carámbano para todo",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Ariados no cambia, usa Amortiguador y revisa si entra Tangrowth.",
+      "variant": [
+        {
+          "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y luego Bostezo. Observa si Tangrowth acierta su ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth acierta, usa Teletransporte hacia Poliwrath. Usa Tambor hasta +6 Ataque, Puño Drenaje contra Tangrowth y, frente a Sharpedo, usa Velocidad X para +2 Velocidad y Puño Drenaje. 🔔 Sharpedo tiene Banda Focus. 🔔",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth falla, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/bisharp.json
+++ b/src/data/johto/koga/bisharp.json
@@ -2,15 +2,20 @@
   "id": "bisharp",
   "name": "Bisharp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Patada baja → Chandelure usa lanzallamas para debilitar o matar, entra Lapras, Poliwrath 6+2.",
-      "variant": []
-    },
-    {
-      "detail": "RHYPERIOR → Excadrill 6+2 y luego pon Trampa Rocas. Usa Terremoto para matar a Gengar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si entra Crobat.",
+      "variant": [
+        {
+          "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Gengar o Lapras.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/crobat.json
+++ b/src/data/johto/koga/crobat.json
@@ -2,96 +2,84 @@
   "id": "crobat",
   "name": "Crobat",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "ONDA ÍGNEA + BANDA FOCUS → Cambia a Chandelure y usa Truco",
+      "detail": "Coloca Trampa Rocas. Si Crobat se queda, observa qué ataque usa.",
       "variant": [
         {
-          "detail": "Crobat no se retira, entra Excadrill con +6 de Ataque y +2 de Velocidad. / Usa Terremoto para derrotar a Skuntank",
+          "detail": "Si usa Superdiente, cambia a Slowbro.",
           "variant": []
         },
         {
-          "detail": "Ampharos, entra Poliwrath +6 en Ataque y +4 en Velocidad",
+          "detail": "Si después sale Magmortar, usa Bostezo, sacrifica a Politoed y entra con Poliwrath. Usa Ataque X y empieza a barrer. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rhyperior, Slowbro usa Bostezo y recibe Megacuerno. Luego usa Protección y Bostezo hasta quedar frente a Gengar o Lapras. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Onda Ígnea + Vidasfera → Cambia a Chandelure // Si Crobat cambia directamente a Rhyperior o Stunfisk utiliza Truco, cambia a Cloyster+6 (Carámbano para Sharpedo)",
+      "detail": "Si Crobat usa Puya Nociva o Pájaro Osado, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Onda Ígnea acierta (Se activa el Abs. Fuego) // Usa Lanzallamas y observa qué Pokémon entra:",
-          "variant": [
-            {
-              "detail": "Rhyperior: cambia a Excadrill, luego a Chandelure y usa Truco para bloquear en Terremoto, luego entra Cloyster con +6. / Usa Carámbano para eliminar a Sharpedo",
-              "variant": []
-            },
-            {
-              "detail": "Tentacruel: cambia a Poliwrath, luego a Metagross para colocar Trampa Rocas, Poliwrath 6+2. / Usa primero la medicina de Velocidad. / Si queda congelado, descongela pues huevón! xd / Si crobat no a muerto utiliza otra velocidad X / A Bocajarro contra Skarmory",
-              "variant": []
-            },
-            {
-              "detail": "Electrode: cambia a Excadrill, luego a Chandelure, espera a que se autodestruya (entra Tentacruel), luego cambia a Metagross para colocar Trampa Rocas, Poliwrath 6+2. / Usa primero la medicina de Velocidad. Si Crobat no ha muerto, usar otra medicina de Velocidad",
-              "variant": []
-            },
-            {
-              "detail": "Floatzel: cambia a Poliwrath, luego a Chandelure y usa Truco",
-              "variant": [
-                {
-                  "detail": "Triturar, entra Scrafty con +3. / Usa Puño Drenaje + A Bocajarro para vencer a Scizor",
-                  "variant": []
-                },
-                {
-                  "detail": "Hidrobomba, entra Poliwrath 6+2",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Stunfisk: Excadrill +4 y +2",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Onda Ígnea falla (no se activa Absorbe Fuego) → Usar Truco:",
-          "variant": [
-            {
-              "detail": "Rhyperior o Stunfisk → entra Cloyster +6. / Usar Carámbano para eliminar a Sharpedo",
-              "variant": []
-            },
-            {
-              "detail": "Tentacruel → cambiar a Metagross para colocar Trampa Rocas, luego Poliwrath 6+4. / Usar medicina de Velocidad",
-              "variant": []
-            },
-            {
-              "detail": "Si Crobat no se retira → atacar con Lanzallamas, luego seguir el plan del escenario con Absorbe Fuego activado",
-              "variant": []
-            }
-          ]
+          "detail": "Si el rival se queda, entra con Volcarona, usa Danza Aleteo x1 y Psíquico. Frente a Electrode, vuelve a usar Danza Aleteo y termina de barrer.",
+          "variant": []
         }
       ]
     },
     {
-      "detail": "Lanzallamas [Zoroark disfrazado] → Chandelure usa Truco para intercambiar objetos, luego entra Scrafty con +3. / Usa Puño Drenaje + A Bocajarro para derrotar a Skarmory",
-      "variant": []
+      "detail": "Si Slowbro usa Bostezo frente a Zoroark, entra con Volcarona, usa Danza Aleteo x1 y Gigadrenado para derrotarlo.",
+      "variant": [
+        {
+          "detail": "Frente a Electrode o Tentacruel, usa Danza Aleteo una vez más y termina de barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona retrocede, cambia a Chansey, cura a Volcarona con Max Poción y repite la ruta.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Superdiente → entra Excadrill con Trampa Rocas, 4+2. // Terremoto para derrotar a Weezing / Nidoking. // Si luego entra Ditto al final del combate, cambia a Cloyster para derrotarlo // El daño de Superdiente se reduce y no te mata, ¡NO TE ASUSTES!",
-      "variant": []
+      "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte para sacar a Volcarona.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x1 y Gigadrenado. Frente a Electrode o Tentacruel, usa Danza Aleteo una vez más y termina de barrer.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Pájaro Osado → usa nuevamente Truco, bloquea a Rhyperior, // Luego Excadrill +6 y +2, coloca Trampa Rocas. / Terremoto para eliminar a Gengar",
-      "variant": []
-    },
-    {
-      "detail": "Nidoqueen → entra Cloyster +6. / Elimina todo con Carámbano // Si recibe daño de Lanzallamas, confirma que es Zoroark disfrazado y ajusta la estrategia según el patrón de ataque",
-      "variant": []
-    },
-    {
-      "detail": "RHYPERIOR → entra Excadrill +6 y+2, luego coloca Trampa Rocas. / Terremoto para derrotar a Gengar",
-      "variant": []
+      "detail": "Rutas por cambio rival:",
+      "variant": [
+        {
+          "detail": "Si sale Samurott, cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Ariados, usa Encanto y Amortiguador para forzar el cambio.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rhyperior, cambia a Slowbro y usa Bostezo. Luego usa Teletransporte hacia Poliwrath, usa Tambor hasta +6 Ataque y Puño Drenaje. Frente a Sharpedo, usa Velocidad X para +2 Velocidad y termina de barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y Bostezo. Observa si Tangrowth acierta: si acierta, usa Teletransporte hacia Volcarona; si falla, entra con Volcarona. En ambos casos, Volcarona usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Si Volcarona cae por crítico, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/ditto.json
+++ b/src/data/johto/koga/ditto.json
@@ -2,19 +2,20 @@
   "id": "ditto",
   "name": "Ditto",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "TRUCO FALLA (parálisis), cambia directo a Excadrill 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "PUÑO TRUENO → Excadrill 4+2, ¡no pongas Trampa Rocas!",
-      "variant": []
-    },
-    {
-      "detail": "NIDOKING → Cloyster 4, último Ditto, cambia a Poliwrath para rematar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Ditto se queda, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Si se sigue quedando, entra con Poliwrath, usa Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad. Usa Puño Drenaje contra Magmortar.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Sacrifica a Politoed, entra con Poliwrath y usa Ataque X. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/electrode.json
+++ b/src/data/johto/koga/electrode.json
@@ -2,33 +2,24 @@
   "id": "electrode",
   "name": "Electrode",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "NIDOQUEEN → Cloyster 6. / Mátalos a todos con Carambano. Si Cloyster recibe Fuego por error, confirma que es Zoroark y sigue la segunda línea.",
-      "variant": []
-    },
-    {
-      "detail": "Lanzallamas [Zoroark disfraz] → Chandelure usa Truco para cambiar objeto, Scrafty 3. / Usa Puño Drenaje + A Bocajarro para matar a Skarmory.",
-      "variant": []
-    },
-    {
-      "detail": "RAYO → Excadrill 6+2 / para huir de Nidoking, mira abajo 👇🏻",
+      "detail": "Coloca Trampa Rocas y revisa el movimiento de Electrode.",
       "variant": [
         {
-          "detail": "Cambia a Excadrill contra Nidoking → cambia a Chandelure para usar Truco y mira el movimiento:",
-          "variant": [
-            {
-              "detail": "Si usa Tierra Viva, Cloyster 6 / mátalos a todos con Carambano",
-              "variant": []
-            },
-            {
-              "detail": "Si usa Onda Tóxica, Scrafty 3 / usa Puño Drenaje + A Bocajarro para matar a Skarmory.",
-              "variant": []
-            }
-          ]
+          "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Gigadrenado para derrotar a Zoroark. Frente a Electrode o Tentacruel, usa Danza Aleteo una vez más.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona recibe retrocesos, cambia a Chansey, cura a Volcarona con Max Poción y repite la ruta.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Rayo, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2. Mantén los PS de Volcarona por encima del 50%; de lo contrario, Electrode puede usar Autodestrucción.",
+          "variant": []
         }
       ]
-    }    
+    }
   ]
 }

--- a/src/data/johto/koga/ferrothorn.json
+++ b/src/data/johto/koga/ferrothorn.json
@@ -2,15 +2,24 @@
   "id": "ferrothorn",
   "name": "Ferrothorn",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Nidoking → Cloyster +4, último Ditto, cambia a Poliwrath para rematar.",
-      "variant": []
-    },
-    {
-      "detail": "Swalot → Chandelure usa Truco para cambiar objeto, Excadrill 4+2, Terremoto para matar a Nidoking, si rompe el globo sigue barriendo, cuando salga Ditto cambia a Cloyster para rematar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Crobat, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Mantén Bostezo hasta tener a Magmortar enfrente.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed, entra con Poliwrath, usa Ataque X y empieza a barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/floatzel.json
+++ b/src/data/johto/koga/floatzel.json
@@ -2,32 +2,24 @@
   "id": "floatzel",
   "name": "Floatzel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "PUÑO TRUEÑO Y VER QUE PASA:",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Deja tocado al Floatzel → cambia a Chandelure contra Nidoking, usa Truco para encerrarlo en Terremoto o Tierra viva, Cloyster +4, último Ditto, cambia a Poliwrath para rematar.",
-      "variant": []
-    },
-    {
-      "detail": "Mata al Floatzel, entra Magmar → cambia a Chandelure y usa Truco, lo encierras en Rayo → Excadrill 4+2, Terremoto para matar a Nidoking, si rompe el globo sigue barriendo, cuando salga Ditto cambia a Cloyster para rematar.",
-      "variant": []
-    },
-    {
-      "detail": "Sale Stunfisk → cambia a Chandelure y usa Truco",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Si usa Tierra Viva, Cloyster 4",
+          "detail": "Si sale Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Sacrifica a Politoed, entra con Poliwrath, usa Ataque X y ataca. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Si usa Chispazo, Excadrill 2+2.// Terremoto para matar a Swalot afortunado (cuidado con Bostezo): no hace falta usar Truco, entra directo Excadrill 2+2.",
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si un crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Sale Nidoking → cambia a Excadrill, luego a Metagross para usar Truco, lo encierras en Tierra Viva, Cloyster 4, último Ditto, cambia a Poliwrath para rematar.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/koga/forretress.json
+++ b/src/data/johto/koga/forretress.json
@@ -2,11 +2,16 @@
   "id": "forretress",
   "name": "Forretress",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Truco para bloquear a Rhyperior/Nidoking",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Excadrill 4 + 2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Samurott, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/gengar.json
+++ b/src/data/johto/koga/gengar.json
@@ -2,15 +2,20 @@
   "id": "gengar",
   "name": "Gengar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "GASTA RECURSOS PERO RÁPIDO → Excadrill 6+2, luego pone Trampa Rocas. / Terremoto para matar a Gengar.",
-      "variant": []
-    },
-    {
-      "detail": "AHORRAR RECURSOS PERO LENTO → Excadrill hace Danza Espada una vez, luego pone Trampa Rocas, Cloyster +6.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Crobat, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Mantén Bostezo hasta que salga Gengar o Lapras.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/gliscor.json
+++ b/src/data/johto/koga/gliscor.json
@@ -2,11 +2,16 @@
   "id": "gliscor",
   "name": "Gliscor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Encerrar en Terremoto, Cloyster +6. Mátalos a todos con Carámbano",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Lucario, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/hypno.json
+++ b/src/data/johto/koga/hypno.json
@@ -2,19 +2,16 @@
   "id": "hypno",
   "name": "Hypno",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Para encerrar a Rhydon, elige lo que prefieras.",
-      "variant": []
-    },
-    {
-      "detail": "Más Rápido → Excadrill 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "Más barato → Excadrill pone Trampa Rocas, Cloyster 4.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Samurott, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/lanturn.json
+++ b/src/data/johto/koga/lanturn.json
@@ -2,19 +2,16 @@
   "id": "lanturn",
   "name": "Lanturn",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Escaldar → pon Trampa Rocas, Poliwrath 6+2",
-      "variant": []
-    },
-    {
-      "detail": "Rayo → Excadrill pone Trampa Rocas 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "Gliscor → Cloyster 6. / Mátalos a todos con Carámbano.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Lucario, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/lapras.json
+++ b/src/data/johto/koga/lapras.json
@@ -2,11 +2,20 @@
   "id": "lapras",
   "name": "Lapras",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Encerrar a Rhyperior, Excadrill 6+2 y luego poner Trampa Rocas. / Terremoto para matar a Gengar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Crobat, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Mantén Bostezo hasta que salga Gengar o Lapras.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/lucario.json
+++ b/src/data/johto/koga/lucario.json
@@ -2,11 +2,42 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Truco, para encerrar en Triturar, Scrafty +2. Dos Palizas seguidas para matar a Gliscor.",
-      "variant": []
+      "detail": "Opción rápida:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si Crobat pega crítico:",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Opción estable:",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar y usa Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Cambia a Slowbro y luego a Chansey para colocar Trampa Rocas.",
+          "variant": []
+        },
+        {
+          "detail": "Cuando salga Lucario, vuelve a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/magmortar.json
+++ b/src/data/johto/koga/magmortar.json
@@ -2,32 +2,24 @@
   "id": "magmortar",
   "name": "Magmortar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gran Llamarada → Truco para encerrar Rayo, Excadrill 4+2, Terremoto para matar a Nidoking, si rompe el globo sigue barriendo, cuando salga Ditto cambia a Cloyster para rematar. (NO PONGAS ROCAS)",
-      "variant": []
-    },
-    {
-      "detail": "Contra Ferrothorn → usa Lanzallamas para rematar y ve quién entra 👇🏻",
+      "detail": "Coloca Trampa Rocas. Si sale Crobat, cambia a Slowbro.",
       "variant": [
         {
-          "detail": "Sale Floatzel → cambia a Poliwrath, luego a Chandelure para usar Truco, encierra HidroBomba, Poliwrath 6+2 + revive Chandelure + cura todo. / Último Ditto, cambia a Chandelure para rematar.",
+          "detail": "Mantén Bostezo hasta que salga Magmortar.",
           "variant": []
         },
         {
-          "detail": "Si Nidoking hace CT y te mata, cambia a Metagross para usar Truco, encierra Terremoto, Cloyster 4 + revive Poliwrath.",
+          "detail": "Sacrifica a Politoed, entra con Poliwrath y usa Ataque X.",
           "variant": []
         },
         {
-          "detail": "Sale Swalot → cambia a Excadrill, luego a Chandelure para usar Truco, encierra Rayo, Excadrill 4+2, Terremoto para matar a Nidoking, espera a que Roca Afilada rompa el globo y sigue barriendo, cuando salga Ditto cambia a Cloyster para rematar. Si Roca Afilada falla, usa Danza Espada y espera a que acierte.",
+          "detail": "Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Sale Magmortar → Cambia a Excadrill, luego a Chandelure para usar Truco, encierra Rayo, Excadrill 4+2. Terremoto para matar a Nidoking, espera a que Roca Afilada rompa el globo y sigue barriendo, cuando salga Ditto cambia a Cloyster para rematar. Si Roca Afilada falla, usa Danza Espada y espera a que acierte.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/koga/muk.json
+++ b/src/data/johto/koga/muk.json
@@ -2,15 +2,20 @@
   "id": "muk",
   "name": "Muk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Puño Fuego → Truco para encerrar Puya Nociva / Sombra Vil, Excadrill 4+2.",
-      "variant": []
-    },
-    {
-      "detail": "Contra Rhydon o Rhyperior → Truco para encerrar Terremoto, Excadrill 4+2.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Samurott, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "En esta ruta no sale Ditto.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/nidoking.json
+++ b/src/data/johto/koga/nidoking.json
@@ -2,11 +2,24 @@
   "id": "nidoking",
   "name": "Nidoking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Encerrar Tierra Viva, Cloyster +4. / Último Ditto, cambia a Poliwrath y usa A Bocajarro para rematar.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Crobat, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo hasta que salga Magmortar.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed, entra con Poliwrath y usa Ataque X.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Puño Drenaje contra Magmortar. Si entra Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/nidoqueen.json
+++ b/src/data/johto/koga/nidoqueen.json
@@ -2,15 +2,24 @@
   "id": "nidoqueen",
   "name": "Nidoqueen",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Tierra Viva / después de Nidoking → Cloyster +6. / Debilita a todos con Carámbano. Si te queman por error, confirma que es Zoroark y sigue la segunda línea.",
-      "variant": []
-    },
-    {
-      "detail": "Lanzallamas [Zoroark disfrazado] → Chandelure usa Truco para cambiar objeto, Scrafty 3. / Usa Puño Drenaje + A Bocajarro para matar a Skarmory.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa el movimiento de Nidoqueen.",
+      "variant": [
+        {
+          "detail": "Si usa Tierra Viva o Bomba Lodo, usa Teletransporte hacia Slowbro y luego Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
+          "variant": []
+        },
+        {
+          "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Gigadrenado contra Zoroark. Barre hasta Electrode o Tentacruel y usa Danza Aleteo una vez más para terminar.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona retrocede, cambia a Chansey, cura a Volcarona al máximo y repite la ruta anterior.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/ninetales.json
+++ b/src/data/johto/koga/ninetales.json
@@ -2,15 +2,24 @@
   "id": "ninetales",
   "name": "Ninetales",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "LLAMARADA → Cambia a Chandelure y usa Truco para bloquear Rhyperior, Cloyster +4 // Elimina todo con Carámbano",
-      "variant": []
-    },
-    {
-      "detail": "RHYPERIOR → Cloyster +4. / Elimina todo con Carámbano",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Tangrowth, usa Teletransporte hacia Slowbro y luego Bostezo.",
+      "variant": [
+        {
+          "detail": "Observa si Latigazo acierta.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth acierta, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth falla, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/parasect.json
+++ b/src/data/johto/koga/parasect.json
@@ -2,29 +2,24 @@
   "id": "parasect",
   "name": "Parasect",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Chupa vidas → Lanzallamas para rematar, observa quién entra 👇🏻",
+      "detail": "Coloca Trampa Rocas. Si Parasect se queda, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Sale Rotom → Cambia a Poliwrath y luego a Chandelure, espera que cambie Voltiocambio, observa quién entra",
-          "variant": [
-            {
-              "detail": "Skuntank, Scrafty usa + Defensa X +3",
-              "variant": []
-            },
-            {
-              "detail": "Crobat, Truco para bloquear Veneno, Excadrill 6+2.",
-              "variant": []
-            }
-          ]
+          "detail": "Si todavía se queda, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario después de pasar por Poliwrath, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario directo, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
         }
       ]
-    },
-    {
-      "detail": "Contra Gliscor → Truco para bloquear Terremoto, Cloyster 6. / Usa carámbano para matar. Ahorrar: sin Truco, Excadrill pone Trampa Rocas 4+2.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/koga/rhyperior.json
+++ b/src/data/johto/koga/rhyperior.json
@@ -2,15 +2,24 @@
   "id": "rhyperior",
   "name": "Rhyperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Restos → Excadrill 6+2 y luego pone Trampa Rocas. / Terremoto para matar a Gengar",
-      "variant": []
-    },
-    {
-      "detail": "Chaleco Asalto → Cloyster +4. // Usa carámbano para matar // Sharpedo Banda Focus",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué pasa después.",
+      "variant": [
+        {
+          "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Hypno.",
+          "variant": []
+        },
+        {
+          "detail": "Si Rhyperior usa Terremoto, usa Encanto. Luego cambia a Slowbro, usa Bostezo y espera quedar frente a Gengar o Lapras. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y Bostezo. Observa si Tangrowth acierta: si acierta, usa Teletransporte hacia Volcarona; si falla, entra con Volcarona. En ambos casos, Volcarona usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/samurott.json
+++ b/src/data/johto/koga/samurott.json
@@ -2,17 +2,13 @@
   "id": "samurott",
   "name": "Samurott",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear a Rhyhorn, elige tú.",
+      "detail": "Coloca Trampa Rocas, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Rápido --> Excadrill 4+2",
-          "variant": []
-        },
-        {
-          "detail": "Ahorrar --> Excadrill pone Trampa Rocas, Cloyster 4",
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/scizor.json
+++ b/src/data/johto/koga/scizor.json
@@ -2,15 +2,20 @@
   "id": "scizor",
   "name": "Scizor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🦋 Cambia a Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Contra Stunfisk → Truco para bloquear Terremoto o Tierra Viva, Cloyster +4.",
-      "variant": []
-    },
-    {
-      "detail": "No cambia → Truco para bloquear Puño Bala, luego cambia a Metagross, Truco para bloquear a Stunfisk, Cloyster 4.",
-      "variant": []
+      "detail": "Cambia a Volcarona frente a Scizor.",
+      "variant": [
+        {
+          "detail": "Usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si un crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/sharpedo.json
+++ b/src/data/johto/koga/sharpedo.json
@@ -2,11 +2,24 @@
   "id": "sharpedo",
   "name": "Sharpedo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear Terremoto/Rhyperior, Cloyster +4. // Usa Carámbano para barrer TODO",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Tangrowth, usa Teletransporte hacia Slowbro y luego Bostezo.",
+      "variant": [
+        {
+          "detail": "Observa si Tangrowth acierta.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth acierta, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth falla, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/skarmory.json
+++ b/src/data/johto/koga/skarmory.json
@@ -2,20 +2,24 @@
   "id": "skarmory",
   "name": "Skarmory",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "NIDOQUEEN → Cloyster +6 // Elimina todo con Carámbano",
+      "detail": "Coloca Trampa Rocas y revisa el movimiento de Skarmory.",
       "variant": [
         {
-          "detail": "Si inesperadamente recibe Lanzallamas → Confirma que es Zoroark así que revisa la Estrategia de abajo.",
+          "detail": "Si usa Pico Taladro, cambia a Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
+          "variant": []
+        },
+        {
+          "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Gigadrenado contra Zoroark. Barre hasta Electrode o Tentacruel y usa Danza Aleteo una vez más para terminar.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona recibe retrocesos, cambia a Chansey, cura a Volcarona con Max Poción y repite la ruta.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "LANZALLAMAS (Zoroark Disfraz) → Chandelure usa Truco para intercambiar objeto, Scrafty +3 // Puño Drenaje + A Bocajarro para eliminar Skarmory",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/koga/skuntank.json
+++ b/src/data/johto/koga/skuntank.json
@@ -2,11 +2,20 @@
   "id": "skuntank",
   "name": "Skuntank",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Truco, Scrafty sube defensa +3, Paliza para eliminar a Gliscor",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Lucario, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "🔔 Skuntank tiene Pañuelo Elegido. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/starmie.json
+++ b/src/data/johto/koga/starmie.json
@@ -2,11 +2,20 @@
   "id": "starmie",
   "name": "Starmie",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "FLYGON → Truco para bloquear Terremoto, Cloyster +4 / Carámbano para Toxicroak y Crobat",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Toxicroak, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "🔔 Toxicroak tiene Banda Focus. 🔔",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/stunfisk.json
+++ b/src/data/johto/koga/stunfisk.json
@@ -2,11 +2,20 @@
   "id": "stunfisk",
   "name": "Stunfisk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🦋 Cambia a Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Bloquear Tierra Viva, Cloyster 4",
-      "variant": []
+      "detail": "Cambia a Volcarona. Si sale Scizor, prepara el sweep.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si un crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/swalot.json
+++ b/src/data/johto/koga/swalot.json
@@ -2,11 +2,20 @@
   "id": "swalot",
   "name": "Swalot",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🦋 Cambia a Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Bloquear a Whiscash / Stunkfish, Cloyster +4 / Carámbano a Swalot",
-      "variant": []
+      "detail": "Cambia a Volcarona. Si sale Scizor, prepara el sweep.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si un crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/tangrowth.json
+++ b/src/data/johto/koga/tangrowth.json
@@ -2,11 +2,24 @@
   "id": "tangrowth",
   "name": "Tangrowth",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto, cambia a Cloyster +4 (Sharpedo muere con Carámbano)",
-      "variant": []
+      "detail": "Coloca Trampa Rocas, usa Teletransporte hacia Slowbro y luego Bostezo.",
+      "variant": [
+        {
+          "detail": "Observa si Tangrowth acierta su ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth acierta, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si Tangrowth falla, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/tentacruel.json
+++ b/src/data/johto/koga/tentacruel.json
@@ -2,19 +2,41 @@
   "id": "tentacruel",
   "name": "Tentacruel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Escaldar → Coloca Trampa Rocas, entra Poliwrath 6+2. // Usa A Bocajarro para derrotar a Skarmory",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Tentacruel se queda, revisa qué movimiento usa.",
+      "variant": [
+        {
+          "detail": "Si usa Escaldar, cambia a Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
+          "variant": []
+        },
+        {
+          "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Gigadrenado. Frente a Electrode o Tentacruel, usa Danza Aleteo una vez más para barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona retrocede, cambia a Chansey, cura a Volcarona al máximo con Max Poción y repite la ruta.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Después de Nidoqueen → Entra Cloyster +6. // Usa Carámbano contra todo. // Sí fue derrotado inesperadamente por Lanzallamas, confirma que era un Zoroark disfrazado y observa estrategia de abajo.",
-      "variant": []
-    },
-    {
-      "detail": "Lanzallamas [Zoroark disfrazado] → Chandelure usa Truco para intercambiar objetos, luego entra Scrafty +3. // Puño Drenaje + A Bocajarro para derrotar a Skarmory",
-      "variant": []
+      "detail": "Si sale Crobat, usa Teletransporte para ver el movimiento.",
+      "variant": [
+        {
+          "detail": "Si usa Veneno X o Puya Nociva, cambia a Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
+          "variant": []
+        },
+        {
+          "detail": "Si revela que es Zoroark por Lanzallamas o Pulso Umbrío, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Gigadrenado. Frente a Electrode o Tentacruel, usa Danza Aleteo una vez más para barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona retrocede, cambia a Chansey, cura a Volcarona al máximo con Max Poción y repite la ruta.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/venomoth.json
+++ b/src/data/johto/koga/venomoth.json
@@ -2,11 +2,20 @@
   "id": "venomoth",
   "name": "Venomoth",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🦋 Cambia a Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Cambia a Cloyster +4. Estando Stunfisk encerrado en tierra viva. (Swalot muere con Carámbano)",
-      "variant": []
+      "detail": "Cambia a Volcarona. Si queda frente a Scizor, prepara el sweep.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si un crítico derrota a Volcarona, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/weezing.json
+++ b/src/data/johto/koga/weezing.json
@@ -2,20 +2,20 @@
   "id": "weezing",
   "name": "Weezing",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "TRUCO, para bloquear Rayo, Excadrill pone Trampa Rocas.",
+      "detail": "Coloca Trampa Rocas frente a Crobat, cambia a Slowbro y usa Bostezo constantemente hasta que salga Gengar o Lapras.",
       "variant": [
         {
-          "detail": "NO CAMBIA : Excadrill 6+2. / Terremoto para matar a Gengar.",
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "SALE LAPRAS : Poliwrath 6+2. / Terremoto para matar a Gengar.",
+          "detail": "Usa Puño Hielo contra Gengar.",
           "variant": []
         }
       ]
-    }    
+    }
   ]
 }

--- a/src/data/johto/lance/aerodactyl.json
+++ b/src/data/johto/lance/aerodactyl.json
@@ -2,17 +2,17 @@
   "id": "aerodactyl",
   "name": "Aerodactyl",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "STEELIX → Cloyster +4 / Poder Oculto Feraligatr",
-      "variant": []
-    },
-    {
-      "detail": "Terremoto → Excadrill +4+2 // Si ocurre una situación inesperada, ver más abajo:",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Excadrill frente a Steelix → Cambia a Chandelure y usa Truco para encerrarlo en Terremoto, luego Cloyster +4.",
+          "detail": "Si sale Lucario, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Si quieres ahorrar, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad. Lucario no tiene Pañuelo Elegido.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo otra vez, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Steelix.",
           "variant": []
         }
       ]

--- a/src/data/johto/lance/ampharos.json
+++ b/src/data/johto/lance/ampharos.json
@@ -2,46 +2,24 @@
   "id": "ampharos",
   "name": "Ampharos",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Rayo → Observa si el rival tiene Vidasfera:",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Con Vidasfera → Usa Truco para encerrarlo en Rayo, luego Excadrill +4+2 + Trampa Rocas // Si Truco falla, Metagross usa Cura Total, Luego vuelve a usar Truco, entra Excadrill 4+2+Trampa Rocas. // Terremoto para Arcanine",
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Sin Vidasfera → Excadrill entra con +6+2",
-          "variant": []
-        }
-      ]
-    },    
-    {
-      "detail": "Frente a Tyranitar → Cambia a Scrafty y observa el movimiento:",
-      "variant": [
-        {
-          "detail": "Triturar → Scrafty +3",
+          "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo. Luego cambia a Chansey, usa Amortiguador y espera a Metagross. Usa Teletransporte hacia Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
           "variant": []
         },
         {
-          "detail": "Terremoto → Excadrill +6+2",
+          "detail": "Si sale Feraligatr, usa Encanto. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },    
-    {
-      "detail": "Frente a Metagross → Usa Lanzallamas para debilitarlo, Entra Tyranitar, Cambia a Scrafty y observa el movimiento:",
-      "variant": [
-        {
-          "detail": "Triturar → Scrafty +3",
-          "variant": []
-        },
-        {
-          "detail": "Terremoto → Excadrill +6+2",
-          "variant": []
-        }
-      ]
-    }    
+    }
   ]
 }

--- a/src/data/johto/lance/arbok.json
+++ b/src/data/johto/lance/arbok.json
@@ -2,11 +2,16 @@
   "id": "arbok",
   "name": "Arbok",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO PARA ENCERRAR A GARCHOMP/ FLYGON TERREMOTO",
+  "initialMove": "Slowbro + Bostezo",
   "tricks": [
     {
-      "detail": "Cloyster +4",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Eelektross.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/arcanine.json
+++ b/src/data/johto/lance/arcanine.json
@@ -2,50 +2,28 @@
   "id": "arcanine",
   "name": "Arcanine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Gengar + Trampa Rocas 👻",
   "tricks": [
     {
-      "detail": "ENVITE ÍGNEO → Truco",
+      "detail": "Gengar usa Otra Vez. Luego cambia a Chansey y después a Dragonite para colocar Trampa Rocas.",
       "variant": [
         {
-          "detail": "ENVITE ÍGNEO (SEGUNDA VEZ) → Usar Truco hasta que cambie de movimiento o cambie de poke",
-          "variant": [
-            {
-              "detail": "ARCANINE NO RE RETIRA / AMPHAROS → Excadrill +2 + Trampa Rocas +Velocidad X. → Terremoto para derrotar a Arcanine",
-              "variant": []
-            },
-            {
-              "detail": "Hydreigon → cambia a Metagross para poner Trampa Rocas, luego Scrafty +2",
-              "variant": []
-            },
-            {
-              "detail": "SALAMANCE → Cambiar a Metagross para poner Trampa Rocas, luego Scrafty +2",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "VOLTIOCRUEL→ Excadrill 4+2",
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "FERALIGATR → Ver objeto:",
-          "variant": [
-            {
-              "detail": "VIDASFERA → Poliwrath 6+2+2 (Defensa especial) → Necesita Puño Hielo // Si recibe un golpe crítico, cura con raíz energía y sigue barriendo",
-              "variant": []
-            },
-            {
-              "detail": "PAÑ. ELEGIDO → Cambiar a Metagross para poner Trampa Rocas, luego Poliwrath 6+2",
-              "variant": []
-            }
-          ]
+          "detail": "Si sale Scizor, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona cae por crítico, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Feraligatr, usa Encanto. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
         }
       ]
-    },
-    {
-      "detail": "STEELIX → Truco para encerrar en Terremoto → Cloyster +4",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/charizard.json
+++ b/src/data/johto/lance/charizard.json
@@ -2,11 +2,24 @@
   "id": "charizard",
   "name": "Charizard",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO PARA ENCERRAR EN LLAMARADA",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Cambia a Chandelure y luego a Scrafty, frente a Tyranitar, Excadrill 6 + 2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Tyranitar y cambia a Poliwrath para derrotarlo.",
+      "variant": [
+        {
+          "detail": "Después entra con Chansey y usa Amortiguador.",
+          "variant": []
+        },
+        {
+          "detail": "Espera a que entre Metagross, usa Teletransporte hacia Slowbro y luego Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/dragonite.json
+++ b/src/data/johto/lance/dragonite.json
@@ -2,172 +2,66 @@
   "id": "dragonite",
   "name": "Dragonite",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gema Dragón + Puño Fuego → Chandelure (Truco) para bloquear a Feraligatr. Poliwrath 6+2+2 (Defensa Especial). Necesita Puño Hielo. Si Poliwrath recibe un golpe crítico, usar Raíz Grande para curarse y continuar barriendo.",
-      "variant": []
-    },
-    {
-      "detail": "Restos + Puño Fuego → Colocar Trampa Rocas, luego cambiar a Chandelure y usar Truco.",
+      "detail": "Coloca Trampa Rocas. Si Dragonite no cambia, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Kingdra/Feraligatr → Poliwrath 6+2, no necesita Carámbano.",
+          "detail": "Si sale Scizor, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Arcanine → Excadrill 4+2. En prueba, revisar el registro de combate.",
+          "detail": "Si sale Flygon, usa Protección y Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Gyarados → Cloyster +4 + Medicina de Defensa. Usar primero la medicina.",
-          "variant": []
-        }
-      ]
-    },   
-    {
-      "detail": "Llamarada → Cambiar a Chandelure y usar Poder Oculto. Si Dragonite no se retira, seguir atacando.",
-      "variant": [
-        {
-          "detail": "Sale Scrafty → Cambiar a Metagross para colocar Trampa Rocas. // Si Metagross falla al colocar Trampa Rocas, usar Excadrill para hacerlo. // Si Scrafty no se va o si entra Infernape, cambiar a Chandelure y usar Truco. 👇🏻",
-          "variant": [
-            {
-              "detail": "Triturar → Evaluar los PS de Dragonite:",
-              "variant": [
-                {
-                  "detail": "Si no está a PS completo → Scrafty +3.",
-                  "variant": []
-                },
-                {
-                  "detail": "Si está a PS completo → usar Protec. Esp (Esto ayuda a que no bajen las estadísticas de tu equipo) y sacrificar, luego Poliwrath 2+2. / Priorizar ataques de alta potencia y eficaces.",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Puño Trueno → Excadrill 4+2.",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Sale Feraligatr → Cambiar a Metagross para colocar Trampa Rocas y sacrificarlo. Luego entra Chandelure con Truco, bloquear Cascada, y Poliwrath 6+2. // Si no se pudo colocar Trampa Rocas, no importa. Usar medicina de Defensa Especial. // Si recibe un golpe crítico significativo usar Raíz Energía.",
+          "detail": "Si sale Eelektross, usa Teletransporte o sacrifica a Politoed. Luego entra con Gengar, usa Maquinación y barre con Bola Sombra.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "TRUENO → Cambiar a Excadrill",
+      "detail": "Ruta con Scizor y evaluación de daño:",
       "variant": [
         {
-          "detail": "Si Dragonite no se va → Excadrill coloca Trampa Rocas, entra Lapras, Poliwrath 6+2.",
+          "detail": "Usa Teletransporte y revisa cuánto daño hace Scizor.",
           "variant": []
         },
         {
-          "detail": "Contra Steelix → Cambiar a Chandelure y usar Truco para bloquear Terremoto. Luego Excadrill coloca Trampa Rocas + 2+2. // Si cambia a Lapras, Poliwrath 6+2.",
+          "detail": "Si el daño es cercano al 60%, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si el daño es cercano al 90%, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona cae por crítico, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Fuerza Bruta → Revisar el objeto.",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Si tiene Restos → Cambiar a Chandelure:",
-          "variant": [
-            {
-              "detail": "Si Dragonite no se va → Bola Sombra para revelar a Kangaskhan, Cloyster +4.",
-              "variant": []
-            },
-            {
-              "detail": "Contra Kangaskhan → Cloyster +4.",
-              "variant": []
-            },
-            {
-              "detail": "Contra Haxorus o Metagross → Truco para bloquear Terremoto, Cloyster +4.",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Cinta Elegida → Colocar Trampa Rocas, luego cambiar a Chandelure y usar Truco.",
-          "variant": [
-            {
-              "detail": "Si entra Aerodactyl → Excadrill + Defensa X + 4 + 2.",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Feraligatr → Poliwrath 6+2.",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },    
-    {
-      "detail": "Garchomp / Steelix / Kangaskhan → Cloyster +4.",
-      "variant": []
-    },
-    {
-      "detail": "Metagross → Revisar el objeto.",
-      "variant": [
-        {
-          "detail": "Si lleva Gema Acero → Cloyster +4.",
+          "detail": "Si sale Tyranitar, entra con Poliwrath para derrotarlo. Después cambia a Chansey y usa Amortiguador. Espera a Metagross, usa Teletransporte hacia Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si lleva Vidasfera → Chandelure usa Lanzallamas para debilitar. Entra Tyranitar, cambiar a Scrafty y observar el movimiento:",
-          "variant": [
-            {
-              "detail": "Si usa Triturar → Scrafty 3.",
-              "variant": []
-            },
-            {
-              "detail": "Si usa Terremoto → Excadrill 6+2.",
-              "variant": []
-            }
-          ]
-        }       
-      ]
-    },
-    {
-      "detail": "Ampharos → Cambiar a Excadrill.",
-      "variant": [
-        {
-          "detail": "Si Ampharos no se retira → Excadrill 4+2. / Usar Terremoto para derrotar a Arcanine.",
+          "detail": "Si sale Infernape, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Contra Dragonite → Un solo Cabeza Hierro para romper la habilidad, luego cambiar a Chandelure y usar Poder Oculto para rematar. Evaluar quién entra después:",
-          "variant": [
-            {
-              "detail": "Si entra Arcanine → Excadrill 4+2 + usar medicina fuerte para curarse.",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Feraligatr → Cambiar a Metagross para colocar Trampa Rocas y sacrificarlo. Chandelure usa Truco para bloquear Cascada, Poliwrath 6+2. // Si entra Ampharos, salir con Excadrill 4+2.",
-              "variant": []
-            }
-          ]
-        }       
-      ]
-    },
-    {
-      "detail": "Hydreigon → Cambiar a Chandelure y usar Truco.",
-      "variant": [
-        {
-          "detail": "Si Hydreigon no se va → Scrafty usa medicina de Defensa Especial +3. / Usar Puño Drenaje para derrotar a Lucario. // Scrafty es derrotado por crítico de Lucario → Chandelure usa Truco para bloquear Pulso Umbrío, revivir a Scrafty, Scrafty 3.",
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si entra Feraligatr → Poliwrath 6+2+2 (Defensa Especial). Necesita Puño Hielo. Si recibe golpe crítico de Lucha Especial, usar Raíz Energía para curarse y continuar barriendo.",
+          "detail": "Si sale Feraligatr, Chansey usa Encanto. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Tyranitar → Excadrill 6+2.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/eelektross.json
+++ b/src/data/johto/lance/eelektross.json
@@ -2,11 +2,16 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE Y USA TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Bloquear Rayo, luego entra Excadrill con +6 +2.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Luego usa Teletransporte o sacrifica a Politoed.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar frente a Dragonite, usa Maquinación y barre al equipo con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/electivire.json
+++ b/src/data/johto/lance/electivire.json
@@ -2,11 +2,20 @@
   "id": "electivire",
   "name": "Electivire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "TRUCO → luego Excadrill pone Trampa Rocas 4+2.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
+      "variant": [
+        {
+          "detail": "Si usa Tajo Cruzado, cambia a Slowbro y usa Bostezo. Luego usa Protección y Bostezo otra vez. Frente a Lucario, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Infernape, cambia a Slowbro y usa Bostezo frente a Electivire. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/feraligatr.json
+++ b/src/data/johto/lance/feraligatr.json
@@ -2,119 +2,66 @@
   "id": "feraligatr",
   "name": "Feraligatr",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "DRAGONITE → Cambia a Chandelure y observa el movimiento:",
+      "detail": "Coloca Trampa Rocas. Si Feraligatr se queda, revisa el movimiento.",
       "variant": [
         {
-          "detail": "Puño Fuego → Usa Truco para bloquear con Feraligatr, luego entra Poliwrath con +6 y +2+2 (Def. Esp.). Si recibe un golpe crítico de Esfera Aural y queda debilitado, usa Raíz Grande para curarse y seguir barriendo (prevención contra prioridad)",
+          "detail": "Cascada: cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Llamarada → Usa Poder Oculto al punto; si Dragonite no cambia, sigue atacando",
-          "variant": [
-            {
-              "detail": "Sale Scrafty → Cambia a Metagross para colocar Trampa Rocas. Si Scrafty no se retira, o si sale Infernape, cambia a Chandelure y usa Truco.👇🏻",
-              "variant": [
-                {
-                  "detail": "Triturar → Según la vida de Dragonite:",
-                  "variant": [
-                    {
-                      "detail": "Si no tiene los PS completos → Scrafty +3",
-                      "variant": []
-                    },
-                    {
-                      "detail": "Si tiene PS completos → usa Protec. Esp. (Píldora para que el equipo no baje estadísticas) para sacrificarse y luego entra Poliwrath con +2+2. // Prioriza movimientos eficaces",
-                      "variant": []
-                    }
-                  ]
-                },
-                {
-                  "detail": "Puño Trueno → Excadrill +4+2",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Sale Feraligatr → Cambia a Metagross para colocar trampas, sacrificarlo, luego entra Chandelure y usa Truco para bloquear con Cascada, luego entra Poliwrath con +6+2. // Si no pudiste colocar trampas, no importa, solo usa una medicina de Def. Esp. // Si recibe crítico de Esfera Aural, usa Raíz Energía para curarse",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "STEELIX → Depende del objeto:",
-      "variant": [
-        {
-          "detail": "Casco Dentado → Cloyster +4 // Lucario muere con Carámbano",
+          "detail": "Fuerza Bruta: usa Teletransporte para revisar. Si vuelve a usar Fuerza Bruta, Slowbro usa Bostezo frente a Ampharos. Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Baya Chiri → Metagross coloca Trampa Rocas, luego Excadrill con +2 Ataque, No necesitas velocidad. Si luego entra Lapras, ignóralo: ya estás completamente potenciado",
+          "detail": "Otro movimiento: cambia a Poliwrath, luego a Slowbro y usa Bostezo frente a Ampharos. Después entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "METAGROSS → Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "AMPHAROS → Excadrill coloca Trampa Rocas +4+2. / Terremoto mata a Arcanine",
+      "detail": "Ruta con Scizor:",
       "variant": [
         {
-          "detail": "Dragonite → Usa Cabeza Hierro para romper la habilidad, luego cambia a Chandelure y remata con Poder Oculto, observa qué sale después👇🏻",
-          "variant": [
-            {
-              "detail": "Arcanine → (Chandelure ayuda a Excadrill a quitar la quemadura), Excadrill coloca Trampa Rocas +4+2 y se cura con Raíz Energía",
-              "variant": []
-            },
-            {
-              "detail": "Feraligatr → cambia a Metagross (Trampa Rocas), sacrifica, Chandelure usa Truco para bloquear en Cascada, Poliwrath +6+2",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "HYDREIGON → Cambia a Chandelure y usa Truco",
-      "variant": [
-        {
-          "detail": "Si Hydreigon no se va, Scrafty usa medicina de Def. Esp. y se potencia a +3. / Puño Drenaje derrota a Lucario // Si Scrafty fue derrotado por Lucario → Chandelure usa Truco para bloquear con Pulso Umbrío, revive a Scrafty, Scrafty entra con +3",
+          "detail": "Usa Teletransporte y evalúa el daño.",
           "variant": []
         },
         {
-          "detail": "Si entra Feraligatr, Poliwrath +6+2+2 (Def. Esp.) Si Poliwrath recibe un crítico de Esfera Aural, usa Raíz Grande para curarse y seguir barriendo",
+          "detail": "Daño cercano al 60%: envía a Slowbro, usa Bostezo y luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Daño cercano al 90%: entra con Volcarona, usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona cae por crítico, usa la ruta de Slowbro con Bostezo y Poliwrath con Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "TYRANITAR → Excadrill +6+2",
-      "variant": []
-    },
-    {
-      "detail": "SCRAFTY → Cambia a Chandelure contra Infernape, usa Truco para bloquear con Puño Trueno, luego entra Excadrill con +4+2 y trampa rocas",
-      "variant": []
-    },
-    {
-      "detail": "FLYGON / GARCHOMP → Cambia a Chandelure (resiste Llamarada), usa Truco para intercambiar objeto, luego entra Excadrill, Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "TERREMOTO → Excadrill +4+2",
-      "variant": []
-    },
-    {
-      "detail": "ESCALDAR → Coloca Trampa Rocas, luego Poliwrath +6+2+6 (gracias a Absorbe Agua se cura completamente)",
-      "variant": []
-    },
-    {
-      "detail": "CASCADA → Poliwrath +6+2+2 (Def. Esp.). // Si hay Lucario con Banda Focus, y recibe un crítico de Esfera Aural, usa Raíz Grande para curarse y seguir barriendo",
-      "variant": []
+      "detail": "Rutas por cambio rival:",
+      "variant": [
+        {
+          "detail": "Haxorus: cambia a Slowbro y usa Bostezo. Frente a Scizor, entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Dragonite: cambia a Slowbro y usa Bostezo. Contra Scizor usa la ruta de Poliwrath. Contra Flygon usa Protección y Bostezo antes de entrar con Poliwrath. Usa Puño Drenaje contra Steelix.",
+          "variant": []
+        },
+        {
+          "detail": "Lucario: cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Para ahorrar, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad. Lucario no tiene objeto elegido.",
+          "variant": []
+        },
+        {
+          "detail": "Infernape: cambia a Slowbro y usa Bostezo frente a Electivire. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/flygon.json
+++ b/src/data/johto/lance/flygon.json
@@ -2,15 +2,20 @@
   "id": "flygon",
   "name": "Flygon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto → Excadrill +4+2 y luego coloca Trampa Rocas",
-      "variant": []
-    },
-    {
-      "detail": "Llamarada → Chandelure usa Truco para intercambiar objeto, luego Excadrill +4+2 y coloca Trampa Rocas",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Lucario, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Para ahorrar, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad. Lucario no tiene objeto elegido.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo, y entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/garchomp.json
+++ b/src/data/johto/lance/garchomp.json
@@ -2,11 +2,16 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Slowbro + Bostezo",
   "tricks": [
     {
-      "detail": "Terremoto → Cloyster +4.",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Eelektross.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/gyarados.json
+++ b/src/data/johto/lance/gyarados.json
@@ -2,19 +2,20 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Puño Trueno derrota, espera a ver qué entra 👇🏻",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Garchomp → Cambia a Chandelure para sacrificarlo, entra Metagross con Truco, bloquea con Terremoto, Cloyster +6 // Surf para debilitar a Metagross.",
-      "variant": []
-    },
-    {
-      "detail": "Eelektross → Cambia a Chandelure y usa Truco para bloquear con Rayo, Excadrill +4+2",
-      "variant": []
-    },
-    {
-      "detail": "Tyranitar → Cambia a Cloyster +6 // Surf para debilitar a Metagross.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y usa Teletransporte hacia Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo y luego Teletransporte hacia Gengar.",
+          "variant": []
+        },
+        {
+          "detail": "Gengar usa Maquinación y ataca para barrer.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/haxorus.json
+++ b/src/data/johto/lance/haxorus.json
@@ -2,19 +2,20 @@
   "id": "haxorus",
   "name": "Haxorus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Gengar + Bola Sombra",
   "tricks": [
     {
-      "detail": "METAGROSS / KANGASKHAN → Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "Dragonite → Chandelure usa Bola Sombra, entra Kangaskhan, Cloyster +4",
-      "variant": []
-    },
-    {
-      "detail": "TERREMOTO → Cloyster +4",
-      "variant": []
+      "detail": "Cambia a Gengar y úsalo como sacrificio atacando con Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Luego Slowbro usa Bostezo frente a Scizor.",
+          "variant": []
+        },
+        {
+          "detail": "Entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/hydreigon.json
+++ b/src/data/johto/lance/hydreigon.json
@@ -2,21 +2,21 @@
   "id": "hydreigon",
   "name": "Hydreigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE Y TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Pulso Umbrío, Scrafty usa + Defensa Especial X y sube a +4 // Si Chandelure muere, cambia el +4 por +3, luego usar Puño Drenaje + Paliza para derrotar a Dragonite // Paliza + Puño Drenaje para Lucario",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty es derrotado por Lucario con un golpe crítico:",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Metagross usa Truco : Si sale Ampharos: Excadrill 4+2",
+          "detail": "Si sale Feraligatr, usa Encanto. Luego cambia a Slowbro, usa Bostezo y entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Dragonite: Poliwrath 6, usar Raíz Grande para curarse y luego subir +2 Velocidad",
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Primeape, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
           "variant": []
         }
       ]

--- a/src/data/johto/lance/infernape.json
+++ b/src/data/johto/lance/infernape.json
@@ -2,6 +2,24 @@
   "id": "infernape",
   "name": "Infernape",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Chandelure y usar Truco para bloquear en Puño Trueno, luego Excadrill con Trampa Rocas entra y se potencia con +4 en ataque y +2 en velocidad.",
-  "tricks": []
+  "initialMove": "👻 Gengar + Trampa Rocas 👻",
+  "tricks": [
+    {
+      "detail": "Gengar usa Otra Vez. Luego cambia a Chansey y después a Dragonite.",
+      "variant": [
+        {
+          "detail": "Coloca Trampa Rocas frente a Infernape.",
+          "variant": []
+        },
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/johto/lance/kangaskhan.json
+++ b/src/data/johto/lance/kangaskhan.json
@@ -2,6 +2,16 @@
   "id": "kangaskhan",
   "name": "Kangaskhan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia directamente a Cloyster con +6. // Si el rival cambia a Metagross, cambiar a Metagross propio y usar Truco para bloquear en Terremoto, luego volver a usar Cloyster con +4.",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/johto/lance/kingdra.json
+++ b/src/data/johto/lance/kingdra.json
@@ -2,15 +2,20 @@
   "id": "kingdra",
   "name": "Kingdra",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si usa Surf coloca Trampa Rocas, Luego cambia a Poliwrath 2 Tambores, 1 Velocidad X.(Si no Lograste Poner Trampa Rocas + Defensa X a Poliwrath).",
-      "variant": []
-    },
-    {
-      "detail": "Si cambia a Steelix Cambia a Cloyster +4",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si sale Scizor.",
+      "variant": [
+        {
+          "detail": "Si sale Scizor, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona cae por crítico, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/lapras.json
+++ b/src/data/johto/lance/lapras.json
@@ -2,38 +2,17 @@
   "id": "lapras",
   "name": "Lapras",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Steelix → Metagross pone Trampa Rocas, Excadrill 2+0 (Si sale Lapras no importa, ya tienes todas las mejoras hechas)",
-      "variant": []
-    },
-    {
-      "detail": "Donphan → Excadrill 6+2",
-      "variant": []
-    },
-    {
-      "detail": "Rayo + Baya → Excadrill 6+2",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Tyranitar → Scrafty +4 o +2 y ATK X",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Rayo + Gafas Elegidas → Excadrill 4+2",
-      "variant": []
-    },
-    {
-      "detail": "Surf → Revisa el objeto",
-      "variant": [
-        {
-          "detail": "Baya Atania → Poliwrath 6+2",
+          "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo. Luego cambia a Chansey y usa Amortiguador. Espera a Metagross, usa Teletransporte hacia Slowbro, usa Bostezo y entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Gafas Elegidas → Pone Trampa Rocas, Poliwrath 6+2",
+          "detail": "Si sale Scizor, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/lance/lucario.json
+++ b/src/data/johto/lance/lucario.json
@@ -2,111 +2,37 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Cambia a Gengar 👻",
   "tricks": [
     {
-      "detail": "LUCARIO NO CAMBIA → Usar Truco con Chandelure para ver el movimiento.",
+      "detail": "Si usa A Bocajarro, Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Pulso Umbrío → Scrafty con +5 o +3 + ATQ X",
+          "detail": "Luego cambia a Slowbro y usa Bostezo frente a Flygon.",
           "variant": []
         },
         {
-          "detail": "Triturar → Scrafty con +3. / Usar Paliza + Puño Drenaje para vencer a Steelix. (Esto es para que no llegue a rango de Baya Chiri) / Aerodactyl banda focus",
+          "detail": "Cambia a Chansey y coloca Trampa Rocas. Después vuelve a Slowbro, usa Bostezo y entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "DRAGONITE → Chandelure lanza un Poder Oculto (Hielo), verificar si acierta Cometa Draco.",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Si acierta y Chandelure es debilitado → Sacar Metagross y colocar Trampa Rocas.",
-          "variant": [
-            {
-              "detail": "Scrafty → Cambiar a Poliwrath, revivir a Chandelure, usar Truco para bloquear en Triturar, luego Scrafty con +2.",
-              "variant": []
-            },
-            {
-              "detail": "Ampharos → Cambiar a Excadrill, luego a Metagross y usar Truco para bloquear en Rayo, Excadrill +4+2 (pendiente de testeo).",
-              "variant": []
-            },
-            {
-              "detail": "Hydreigon → Revivir a Chandelure, usar Truco con Chandelure para bloquear en Pulso Umbrío, luego Scrafty con +3. (priorizar Puño Drenaje, pendiente de testeo).",
-              "variant": []
-            },
-            {
-              "detail": "Dragonite no cambia → Revivir a Chandelure, cambiar entre Scrafty y Chandelure:",
-              "variant": [
-                {
-                  "detail": "Si entra Arcanine → Excadrill +4+2",
-                  "variant": []
-                },
-                {
-                  "detail": "Si entra Feraligatr → Usar Truco con Chandelure para bloquear en Cascada, luego Poliwrath +6+2.",
-                  "variant": []
-                }        
-              ]
-            }
-          ]
-        },
-        {
-          "detail": "SI ACIERTA Y NO DEBILITA → Seguir usando Poder Oculto (Hielo)",
-          "variant": [
-            {
-              "detail": "Si entra Arcanine o Electivire → Excadrill con +4+2 + Trampa Rocas",
-              "variant": []
-            },
-            {
-              "detail": "FERALIGATR → Cambiar a Metagross, usar Truco para bloquear en Cascada, luego Poliwrath +6+2+6 / No es necesario Puño Hielo.",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Si Cometa Draco falla → Seguir usando Poder Oculto (Hielo) y ver quién entra.",
-          "variant": [
-            {
-              "detail": "Si entra Arcanine → Excadrill +4+2",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Feraligatr → Cambiar a Metagross, usar Truco para bloquear en Cascada, luego Poliwrath +6+2 (con +2 Defensa Especial). Si Poliwrath es dañado por un golpe crítico de Pulso Dragón, usar Raíz Grande para curarse y continuar el sweep.",
-              "variant": []
-            }      
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "Contra Hydreigon → Usar Truco para bloquear en Pulso Umbrío, Scrafty con +4 y medicina de Defensa Especial. Si Chandelure cae, hacerlo con +3. // Si Scrafty es derrotado por un crítico de Lucario → Metagross usa Truco:",
-      "variant": [
-        {
-          "detail": "Si entra Ampharos → Excadrill con +4+2",
+          "detail": "Si sale Infernape, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si entra Dragonite → Poliwrath con +6 y curación con Raíz Grande, luego +2",
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque. Usa Puño Drenaje contra Lucario y Ampharos.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Feraligatr, sacrifica a Gengar con Bola Sombra. Luego Slowbro usa Bostezo y entra con Poliwrath usando Tambor hasta +6 Ataque. Usa Puño Drenaje para mantener la salud.",
           "variant": []
         }
       ]
-    },    
-    {
-      "detail": "Contra Scrafty rival → Cambiar a Metagross y usar Truco para bloquear en Triturar, luego cambiar a Excadrill.",
-      "variant": [
-        {
-          "detail": "Si Scrafty no cambia → Colocar Trampa Rocas, usar Protec. Esp, luego Poliwrath +2+2 (priorizar movimientos de alta potencia).",
-          "variant": []
-        },
-        {
-          "detail": "Contra Infernape → Cambiar a Chandelure y usar Truco para bloquear en Puño Trueno, luego Excadrill con +4+2.",
-          "variant": []
-        }
-      ]
-    },    
-    {
-      "detail": "Contra Ampharos → Usar Truco para bloquear en Rayo, luego Excadrill con +4+2, usar TRAMPA ROCAS. Terremoto derrota a Arcanine.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/metagross.json
+++ b/src/data/johto/lance/metagross.json
@@ -2,41 +2,41 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Poder Oculto → Chandelure usa Lanzallamas para debilitar, entra Tyranitar, cambia a Scrafty para ver movimiento:",
+      "detail": "Coloca Trampa Rocas y revisa qué movimiento o cambio aparece.",
       "variant": [
         {
-          "detail": "Triturar → Scrafty +3",
+          "detail": "Si usa Puño Meteoro, usa Teletransporte hacia Slowbro y usa Bostezo.",
           "variant": []
         },
         {
-          "detail": "Terremoto → Excadrill +6+2",
+          "detail": "Si quedas frente a Tyranitar, envía a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si aparece Hierba Lazo, Ampharos, Scizor, Dragonite o Lapras, entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross, usa Teletransporte hacia Gengar. Gengar usa Maquinación y barre con Bola Sombra.",
           "variant": []
         }
       ]
-    },   
+    },
     {
-      "detail": "Terremoto → Observa objeto Rival:",
+      "detail": "Ruta con Scizor o Tyranitar:",
       "variant": [
         {
-          "detail": "Gema Acero → Cloyster +4",
+          "detail": "Si sale Scizor, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Casco Dentado → Excadrill +4+0",
-          "variant": []
-        },
-        {
-          "detail": "Restos → Excadrill +6+2",
+          "detail": "Si sale Tyranitar, cambia a Poliwrath y usa Puño Drenaje para derrotarlo. Luego cambia a Chansey, usa Amortiguador y espera a Metagross. Usa Teletransporte hacia Slowbro, usa Bostezo y entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },    
-    {
-      "detail": "Garchomp → Cloyster +4l:",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/scizor.json
+++ b/src/data/johto/lance/scizor.json
@@ -2,80 +2,28 @@
   "id": "scizor",
   "name": "Scizor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "SI NO SE RETIRA → Usar Lanzallamas para matar.",
+      "detail": "Coloca Trampa Rocas y evalúa el daño de Scizor.",
       "variant": [
         {
-          "detail": "Feraligatr → Seguir usando Lanzallamas y observar el resultado:",
-          "variant": [
-            {
-              "detail": "Feraligatr ataca primero y deja a Chandelure con poca vida → Cambiar a Metagross para colocar Trampa Rocas, luego entrar con Poliwrath +6 ataque y +2 velocidad.",
-              "variant": []
-            },
-            {
-              "detail": "Feraligatr ataca primero y debilita completamente a Chandelure → Sacar a Metagross y usar Truco:",
-              "variant": [
-                {
-                  "detail": "Si entra Steelix o Metagross, luego Cloyster +4.",
-                  "variant": []
-                },
-                {
-                  "detail": "Si el rival no se cambia, Excadrill +4 ataque y +2 velocidad.",
-                  "variant": []
-                }
-              ]
-            },
-            {
-              "detail": "Si Feraligatr ataca después y debilita o daña a Chandelure → Cambiar a Metagross y usar Truco:",
-              "variant": [
-                {
-                  "detail": "Si entra Steelix, poner Trampa Rocas y luego Excadrill 2+2.",
-                  "variant": []
-                },
-                {
-                  "detail": "Cascada, poner Trampa Rocas y luego Poliwrath +6 ataque y +2 velocidad. // (Si entra Lapras después, no importa: ya estás completamente potenciado).",
-                  "variant": []
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "detail": "Haxorus → Cambiar a Cloyster, luego a Chandelure, usar Truco para bloquear con Terremoto, luego Cloyster +4.",
+          "detail": "Si el daño es cercano al 90%, usa Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
           "variant": []
         },
         {
-          "detail": "Lapras → Cambiar a Metagross para colocar Trampa Rocas, luego Poliwrath +6 ataque y +2 velocidad.",
+          "detail": "Si Volcarona cae por crítico, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si el daño es cercano al 60%, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si cae por crítico y no alcanzaste a colocar Trampa Rocas, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "ENTRA FERALIGATR DESPUES DE IDA Y VUELTA → Cambiar a Metagross para colocar Trampa Rocas, luego Poliwrath +6 ataque y +2 velocidad.",
-      "variant": []
-    },
-    {
-      "detail": "STEELIX → Usar Truco para bloquear con Terremoto, luego cambiar a Metagross para colocar Trampa Rocas, luego Excadrill +2 ataque y sin boost de velocidad. // (Si entra Lapras, ignorarlo: ya puedes barrer al equipo).",
-      "variant": []
-    },
-    {
-      "detail": "METAGROSS → Usar Truco y observar el objeto:",
-      "variant": [
-        {
-          "detail": "Gema Acero → luego Cloyster +4.",
-          "variant": []
-        },
-        {
-          "detail": "Casco Dentado → luego Excadrill +4 ataque sin velocidad.",
-          "variant": []
-        }
-      ]
-    },   
-    {
-      "detail": "Kangaskhan → Cloyster +4.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/scrafty.json
+++ b/src/data/johto/lance/scrafty.json
@@ -2,28 +2,20 @@
   "id": "scrafty",
   "name": "Scrafty",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Dragonite → Colocar Trampa Rocas, dejarlo debilitar para que Poliwrath recupere todos los PS, luego entra con +2 en Ataque y +2 en Velocidad; prioriza siempre los movimientos de mayor potencia. // Si Poliwrath ha sido quemado, usar Cura Total para eliminar el estado y evitar el daño de habilidades de prioridad.",
-      "variant": []
-    },
-    {
-      "detail": "Triturar → Cambiar a Excadrill.",
+      "detail": "Coloca Trampa Rocas frente a Primeape.",
       "variant": [
         {
-          "detail": "Scrafty no se retira → Colocar Trampa Rocas, usar Protec. Esp., luego entra Poliwrath con +2 en Ataque y +2 en Velocidad; prioriza siempre movimientos de mayor potencia, se requiere la Gema Hielo para asegurar el KO.",
+          "detail": "Luego cambia a Slowbro y usa Bostezo frente a Electivire.",
           "variant": []
         },
         {
-          "detail": "Contra Infernape → Cambiar a Chandelure, usar Truco para bloquear Puño Trueno, luego entra Excadrill, +4 +2 Trampa Rocas",
+          "detail": "Entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Puño Drenaje → Cambiar a Chandelure, usar Truco para bloquear Puño Trueno, luego entra Excadrill a completar +4 +2 Trampa Rocas",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/steelix.json
+++ b/src/data/johto/lance/steelix.json
@@ -2,15 +2,41 @@
   "id": "steelix",
   "name": "Steelix",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO Y MIRA EL OBJETO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "BAYA LICHI / CASCO DENTADO → entra Cloyster +4.// Carámbano mata a Lucario",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué ocurre.",
+      "variant": [
+        {
+          "detail": "Si usa Terremoto, usa Encanto y luego Amortiguador. Espera a Scizor y usa Teletransporte para evaluar el daño.",
+          "variant": []
+        },
+        {
+          "detail": "Si el daño de Scizor es cercano al 60%, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si el daño de Scizor es cercano al 90%, entra con Volcarona, usa Danza Aleteo x1 y Especial X. Mantén los PS por encima del 51%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Volcarona cae por crítico, cambia a Slowbro y usa Bostezo. Luego entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "BAYA CHIRI → Metagross pone Trampa Rocas, luego Excadrill 2+0. Si sale Lapras, ignóralo, sigue barriendo.",
-      "variant": []
+      "detail": "Rutas por cambio rival:",
+      "variant": [
+        {
+          "detail": "Si sale Lucario, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Para ahorrar, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad. Lucario no tiene objeto elegido.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo, y entra con Poliwrath usando Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/tyranitar.json
+++ b/src/data/johto/lance/tyranitar.json
@@ -2,6 +2,24 @@
   "id": "tyranitar",
   "name": "Tyranitar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Excadrill +6 +2",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas y cambia a Poliwrath para derrotar a Tyranitar.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Chansey y usa Amortiguador. Si los PS están bajos, usa Max Poción.",
+          "variant": []
+        },
+        {
+          "detail": "Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Entra con Poliwrath usando la ruta de Politoed y Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/johto/will/absol.json
+++ b/src/data/johto/will/absol.json
@@ -1,29 +1,19 @@
 {
-    "id": "absol",
-    "name": "Absol",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "CAMBIA A CHANDELURE",
-    "tricks": [
-      {
-        "detail": "TAJO UMBRÍO → Entrar con Scrafty → Scrafty +3 → Bronzong necesita dos Puño Drenaje para ser derrotado",
-        "variant": []
-      },
-      {
-        "detail": "A BOCAJARRO → Chandelure usa Truco para intercambiar objetos → Luego entrar con Scrafty → Scrafty +2 → Bronzong necesita dos Puño Drenaje para ser derrotado",
-        "variant": []
-      },
-      {
-        "detail": "BRONZONG → Chandelure usa Lanzallamas para debilitar:",
-        "variant": [
-          {
-            "detail": "Si entra Absol → Scrafty +2",
-            "variant": []
-          },
-          {
-            "detail": "Si entra Empoleon → Poliwrath +6 +2 / Si te congela, descongela con Cura Total o una Baya dependiendo de tus Ps",
-            "variant": []
-          }
-        ]
-      }
-    ]
-  }
+  "id": "absol",
+  "name": "Absol",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "👻 Gengar +4 + Precisión X 👻",
+  "tricks": [
+    {
+      "detail": "Entra con Gengar, usa Maquinación hasta +4 y luego Precisión X.",
+      "variant": [
+        {
+          "detail": "No uses Otra Vez en esta ruta."
+        },
+        {
+          "detail": "Cuando Gengar esté listo, barre con la cobertura correspondiente."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/altaria.json
+++ b/src/data/johto/will/altaria.json
@@ -1,34 +1,38 @@
 {
-    "id": "altaria",
-    "name": "Altaria",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "TRUCO",
-    "tricks": [
-      {
-        "detail": "LLAMARADA: Cambia Scrafty +Def. Esp X + 2 +Raiz Energia Si estas en rojo. + 1 Danza Dragón. (Crítico de Llamarada baja 46.2%)",
-        "variant": [
-          {
-            "detail": "Si Altaria mata a Scrafty Por Criticó Cambia Chandelure usa una vez Lanzallamas, luego entra Poliwrath frente a Empoleon, cambia a Chandelure y usa Truco para Encerrar en Cascada,cambia Poliwrath 2 Veces tambor + Velocidad X. / Puño Hielo para matar a Alakazam.",
-            "variant": []
-          }
-        ]
-      },
-      {
-        "detail": "LANZALLAMAS Es [Zorua Disfrazado] : Cambia a Chandelure usa Truco para cambiar el ítem, luego cambia Scrafty +4.(Si Metagross murió o está quemado, haz otra Danza Dragón Extra.)",
-        "variant": []
-      },
-      {
-        "detail": "CLEFABLE: cambia a Chandelure.",
-        "variant": [
-          {
-            "detail": "Lucario o Gardevoir, usa Truco para Encerrar en Triturar, Pulso Umbrío o Bola Sombra, Scrafty +2.",
-            "variant": []
-          },
-          {
-            "detail": "Si Clefable no se va, Scrafty 1 + usa Raíz Energía para curar y boostear otra vez.",
-            "variant": []
-          }
-        ]
-      }
-    ]
-  }
+  "id": "altaria",
+  "name": "Altaria",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🥚 Amortiguador 🥚",
+  "tricks": [
+    {
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Stantler, cambia a Gengar y usa Otra Vez. Cuando salga Alakazam, elige ruta estable o ruta RNG."
+        },
+        {
+          "detail": "Ruta estable: cambia a Chansey, usa Teletransporte y entra con Slowbro. Usa Bostezo, luego Protección para dormir a Alakazam. Después usa Bostezo frente a Roserade, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Ruta RNG: entra con Slowbro, usa Bostezo y luego Protección. Cuando salga Roserade, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Lucario, cambia a Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Usa Maquinación hasta +6 y Precisión X. Mantén Otra Vez cuando sea necesario."
+        }
+      ]
+    },
+    {
+      "detail": "Si Lucario usa un movimiento de fuego, probablemente es Zoroark.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez sobre el movimiento de fuego y luego entra con Poliwrath para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/bronzong.json
+++ b/src/data/johto/will/bronzong.json
@@ -1,16 +1,30 @@
 {
-    "id": "bronzong",
-    "name": "Bronzong",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "Chandelure usa Lanzallamas para debilitar y revelar al Pokémon rival",
-    "tricks": [
-      {
-        "detail": "ABSOL: cambia a Scrafty +2",
-        "variant": []
-      },
-      {
-        "detail": "EMPOLEON: cambia a Poliwrath 6+2",
-        "variant": []
-      }
-    ]
-  }
+  "id": "bronzong",
+  "name": "Bronzong",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🥚 Amortiguador 🥚",
+  "tricks": [
+    {
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Absol, entra con Gengar, usa Maquinación hasta +4 y Precisión X. 🔔 Absol tiene Pañuelo Elegido. 🔔"
+        },
+        {
+          "detail": "Si entra Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2."
+        }
+      ]
+    },
+    {
+      "detail": "Si Flareon se queda, derrota a Flareon y revisa el siguiente cambio.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, usa Bola Sombra y luego sacrifica a Politoed. Entra con Poliwrath para usar Tambor hasta +6 Ataque. 🔔 Absol tiene Pañuelo Elegido. 🔔"
+        },
+        {
+          "detail": "Si vuelve Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🔔 Usa Cascada contra Bronzong. 🔔"
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/chansey.json
+++ b/src/data/johto/will/chansey.json
@@ -1,12 +1,16 @@
 {
-    "id": "chansey",
-    "name": "Chansey",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "CAMBIA A SCRAFTY",
-    "tricks": [
-      {
-        "detail": "Scrafty +1 → 2 Puño drenaje para derrotar a chansey",
-        "variant": []
-      }
-    ]
-  }
+  "id": "chansey",
+  "name": "Chansey",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/claydol.json
+++ b/src/data/johto/will/claydol.json
@@ -1,7 +1,22 @@
 {
-    "id": "claydol",
-    "name": "Claydol",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "Excadrill y usas Trampa Rocas, entra Mantine, cambia a Chandelure y usa Truco, lo deja bloqueado en Escaldar, cambia a Poliwrath 6+2",
-    "tricks": []
-  }
+  "id": "claydol",
+  "name": "Claydol",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas. Si Claydol se queda, aguanta con Defensa Especial X y usa Amortiguador frente a Girafarig.",
+      "variant": [
+        {
+          "detail": "Cuando entre Girafarig, cambia a Gengar y usa Otra Vez."
+        },
+        {
+          "detail": "Luego cambia a Slowbro frente a Mantine y usa Bostezo frente a Magnezone."
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/clefable.json
+++ b/src/data/johto/will/clefable.json
@@ -1,28 +1,25 @@
 {
-    "id": "clefable",
-    "name": "Clefable",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "CAMBIA A CHANDELURE",
-    "tricks": [
-      {
-        "detail": "MOV. SÍSMICO O EL SEGUNDO CLEFABLE→ Entra Scrafty +2. / Si está envenenado, primero curar el estado. Mov. Sísmico hace siempre 100 PS de daño; si te deja con más de 100, puedes curarte con Raíz Energía y seguir potenciando.",
-        "variant": []
-      },
-      {
-        "detail": "LLAMARADA → Usar Truco para bloquear a Umbreon o a Clefable con Hierba Lazo, luego entra Scrafty +2.",
-        "variant": []
-      },
-      {
-        "detail": "Lanzallamas [Zoroark disfrazado] → Usar Truco para bloquear Pulso Noche, luego entra Scrafty +2 (Si Chandelure Murió Un Danza Dragón extra)",
-        "variant": []
-      },
-      {
-        "detail": "CLEFABLE SE QUEDA saca a Scrafty y a +2.",
-        "variant": []
-      },
-      {
-        "detail": "GOLURK → Truco para bloquear en Terremoto, Excadrill 4+2, usa Terremoto para derrotar a Drowzee.",
-        "variant": []
-      }
-    ]
-  }
+  "id": "clefable",
+  "name": "Clefable",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🥚 Amortiguador 🥚",
+  "tricks": [
+    {
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +6 y Precisión X. Mantén Otra Vez cada vez que puedas."
+        },
+        {
+          "detail": "Si el movimiento principal no sirve contra Xatu, usa la cobertura especial dos veces."
+        },
+        {
+          "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X. Mantén Otra Vez cada vez que puedas."
+        },
+        {
+          "detail": "Si Lucario revela que es Zoroark, usa Otra Vez sobre su movimiento y entra con Poliwrath para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/electivire.json
+++ b/src/data/johto/will/electivire.json
@@ -1,20 +1,30 @@
 {
-    "id": "electivire",
-    "name": "Electivire",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "USA TRAMPA ROCAS",
-    "tricks": [
-      {
-        "detail": "BLISSEY / CHANSEY → Scrafty +1 / Dos Puño drenaje para derrotar a Blissey/Chansey",
-        "variant": []
-      },
-      {
-        "detail": "UMBREON → Scrafty +2",
-        "variant": []
-      },
-      {
-        "detail": "LANZALLAMAS → Chandelure usa Truco para cambiar objeto, Excadrill 4+2 / Terremoto para derrotar a Umbreon",
-        "variant": []
-      }
-    ]
-  }
+  "id": "electivire",
+  "name": "Electivire",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas. Si Electivire se queda, revisa su objeto y si el golpe fue crítico.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidasfera y el golpe no fue crítico, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        },
+        {
+          "detail": "Si tiene Vidasfera y el golpe fue crítico, toma una Max Poción. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        },
+        {
+          "detail": "Si no tiene Vidasfera, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. No es necesario usar Otra Vez."
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lucario durante la ruta de Gengar, alterna Poliwrath y Gengar para reposicionar.",
+      "variant": [
+        {
+          "detail": "Después entra con Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/empoleon.json
+++ b/src/data/johto/will/empoleon.json
@@ -1,42 +1,33 @@
 {
-    "id": "empoleon",
-    "name": "Empoleon",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "TRUCO",
-    "tricks": [
-      {
-        "detail": "GOLURK → Excadrill 4+2",
-        "variant": []
-      },
-      {
-        "detail": "BLISSEY / CHANSEY → Scrafty +1 / a bocajarro para matar a Blissey // Paliza vs Jynx",
-        "variant": []
-      },
-      {
-        "detail": "BRONZONG → Chandelure",
-        "variant": [
-          {
-            "detail": "Contra Empoleon → Truco para bloquear Escaldar, Poliwrath 6+2,",
-            "variant": []
-          },
-          {
-            "detail": "Contra Tropius → Truco para bloquear Poder Oculto, Scrafty +2",
-            "variant": []
-          }
-        ]
-      },
-      {
-        "detail": "VIDASFERA → Poliwrath 2 defensa especial x +2 +6, lo mata Mismagius con Encanto,",
-        "variant": [
-          {
-            "detail": "Hydreigon → Chandelure usa Truco para bloquear Poder Oculto, Scrafty +2",
-            "variant": []
-          }
-        ]
-      },
-      {
-        "detail": "GAFAS ELEGIDAS → Poliwrath 6+2 / A bocajarro para matar a Umbreon",
-        "variant": []
-      }
-    ]
-  }
+  "id": "empoleon",
+  "name": "Empoleon",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas. Si Empoleon se queda, revisa su ataque.",
+      "variant": [
+        {
+          "detail": "Si usa Surf, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si usa Hidrobomba, usa Teletransporte hacia Slowbro. Usa Bostezo, luego Protección; cuando salga Clefable, vuelve a usar Bostezo. Después sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🔔 Usa Cascada contra Hypno. 🔔"
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No es necesario usar Otra Vez."
+    },
+    {
+      "detail": "Si entra Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
+    },
+    {
+      "detail": "Si entra Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
+      "variant": [
+        {
+          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol o Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/espeon.json
+++ b/src/data/johto/will/espeon.json
@@ -1,12 +1,19 @@
 {
-    "id": "espeon",
-    "name": "Espeon",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "USA TRAMPA ROCAS",
-    "tricks": [
-      {
-        "detail": "Umbreon → Scrafty +2",
-        "variant": []
-      }
-    ]
-  }
+  "id": "espeon",
+  "name": "Espeon",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "Slowbro + Bostezo",
+  "tricks": [
+    {
+      "detail": "Entra con Slowbro y usa Bostezo para presionar el cambio.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Chansey y coloca Trampa Rocas. Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        },
+        {
+          "detail": "Si mientras colocas Trampa Rocas el rival no cambia, usa Amortiguador hasta que cambie. Después sigue la ruta anterior."
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/johto/will/exeggutor.json
+++ b/src/data/johto/will/exeggutor.json
@@ -2,11 +2,29 @@
   "id": "exeggutor",
   "name": "Exeggutor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CLOYSTER",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Bronzong, luego cambia a Poliwrath contra Empoleon, Poliwrath 6+2",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No es necesario usar Otra Vez."
+        },
+        {
+          "detail": "Si entra Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2."
+        }
+      ]
+    },
+    {
+      "detail": "Si Flareon se queda, derrótalo y revisa el siguiente cambio.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/flareon.json
+++ b/src/data/johto/will/flareon.json
@@ -2,31 +2,16 @@
   "id": "flareon",
   "name": "Flareon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "Cambia a Gengar +2",
   "tricks": [
     {
-      "detail": "ENVITE ÍGNEO → Usa Truco",
+      "detail": "Cambia a Gengar y usa Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Drapion, Scrafty +2",
-          "variant": []
+          "detail": "Si Flareon se queda, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X."
         },
         {
-          "detail": "Empoleon, Poliwrath 6+2",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "BRONZONG → Usa Llamarada para eliminarlo",
-      "variant": [
-        {
-          "detail": "Drapion, Scrafty +2",
-          "variant": []
-        },
-        {
-          "detail": "Empoleon, Poliwrath +6+2",
-          "variant": []
+          "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     }

--- a/src/data/johto/will/gardevoir.json
+++ b/src/data/johto/will/gardevoir.json
@@ -2,26 +2,16 @@
   "id": "gardevoir",
   "name": "Gardevoir",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "LANZALLAMAS [Zoroark disfrazado] → Truco para bloquear en Pulso Umbrío, Scrafty +2",
-      "variant": []
-    },
-    {
-      "detail": "CLEFABLE → Cambia a Scrafty y observa el movimiento",
+      "detail": "Usa Amortiguador y revisa si entra Lucario.",
       "variant": [
         {
-          "detail": "Si no es Pulso Umbrío → Scrafty +2 / Si está envenenado, cura primero.",
-          "variant": []
+          "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +6 y Precisión X."
         },
         {
-          "detail": "Ataques físicos te hacen 100 de daño fijo, si tienes menos de 100 PS usa Raíz Energía y sigue subiendo stats",
-          "variant": []
-        },
-        {
-          "detail": "Si es Pulso Umbrío [poca probabilidad] → Cambia a Chandelure y usa Truco para bloquear en Pulso Umbrío, Scrafty +2",
-          "variant": []
+          "detail": "Si la cobertura principal queda limitada, usa Onda Certera para cubrir a Xatu."
         }
       ]
     }

--- a/src/data/johto/will/girafarig.json
+++ b/src/data/johto/will/girafarig.json
@@ -2,24 +2,18 @@
   "id": "girafarig",
   "name": "Girafarig",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "CLAYDOL CON TERREMOTO / PSÍQUICO → Excadrill lanza Trampa Rocas (entra Mantine), cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2",
+      "detail": "Coloca Trampa Rocas y cambia a Gengar para usar Otra Vez.",
       "variant": [
         {
-          "detail": "Opción 1: Si aparece Claydol mientras te boosteas cambia a Excadrill 4+2, si vuelve a cambiar a Mantine vuelve con Poliwrath 6+2 (Experimental, falta testear)",
-          "variant": []
+          "detail": "Luego cambia a Slowbro y usa Bostezo. Cuando salga Mantine, vuelve a usar Bostezo."
         },
         {
-          "detail": "Opción 2: Si aparece Claydol mientras te boosteas cambia a Scrafty +3 (Experimental, falta testear)",
-          "variant": []
+          "detail": "Cuando salga Magnezone, deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
-    },
-    {
-      "detail": "MAGNEZONE → Excadrill lo derrota, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/will/golduck.json
+++ b/src/data/johto/will/golduck.json
@@ -2,11 +2,21 @@
   "id": "golduck",
   "name": "Golduck",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "USA TRAMPA ROCAS",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "entra Umbreon → Scrafty +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si Golduck usa Tajo Cruzado.",
+      "variant": [
+        {
+          "detail": "Si usa Tajo Cruzado, usa Teletransporte. Si Golduck se queda, entra con Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        },
+        {
+          "detail": "Si entra Lucario, puedes pasar por Poliwrath y luego volver a Gengar. Usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        },
+        {
+          "detail": "Si Lucario entra directo, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/golurk.json
+++ b/src/data/johto/will/golurk.json
@@ -2,15 +2,18 @@
   "id": "golurk",
   "name": "Golurk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "RESTOS → Excadrill 4+2 / Hypno Terremoto",
-      "variant": []
-    },
-    {
-      "detail": "CINTA XPERTA → Excadrill 4+2 y vuelve a lanzar Trampa Rocas, entra Slowbro, cambia a Poliwrath, luego cambia a Scrafty +1 Defensa Especial X +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa el porcentaje de daño recibido.",
+      "variant": [
+        {
+          "detail": "Si el daño ronda 50%, y el crítico ronda 75%, toma una Max Poción. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad."
+        },
+        {
+          "detail": "Si el daño ronda 35%, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/grumpig.json
+++ b/src/data/johto/will/grumpig.json
@@ -2,11 +2,15 @@
   "id": "grumpig",
   "name": "Grumpig",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Entra Blissey, Scrafty +1, A bocajarro para matar a Blissey",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si entra Electivire.",
+      "variant": [
+        {
+          "detail": "Si entra Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/hypno.json
+++ b/src/data/johto/will/hypno.json
@@ -2,15 +2,18 @@
   "id": "hypno",
   "name": "Hypno",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "Politoed cae",
   "tricks": [
     {
-      "detail": "GOLURK, Excadrill 4+2, Terremoto para matar a Drowzee / Musharna",
-      "variant": []
-    },
-    {
-      "detail": "HYPNO NO CAMBIA Y SE QUEDA ENCERRADO EN MOV. SÍSMICO. Saca a chandelure usa bola sombra y debilitarlo luego cambia a metagross y sacrifica para entrar con chandelure y truco. Improvisa xD",
-      "variant": []
+      "detail": "Deja caer a Politoed y entra con Poliwrath.",
+      "variant": [
+        {
+          "detail": "Usa Tambor hasta +6 Ataque."
+        },
+        {
+          "detail": "🔔 Usa Cascada contra Hypno. 🔔"
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/jolteon.json
+++ b/src/data/johto/will/jolteon.json
@@ -2,19 +2,18 @@
   "id": "jolteon",
   "name": "Jolteon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO PARA BLOQUEAR EN RAYO, LUEGO CAMBIA EXCADRILL",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "NO CAMBIA: Trampa Rocas con Excadrill y 4+2",
-      "variant": []
-    },
-    {
-      "detail": "GOLURK: cambia a Chandelure, usa Truco para bloquear en Terremoto, entra Excadrill con +2 de Ataque y lanza Trampa Rocas. // Si luego entra Slowbro, cambia a Poliwrath, luego cambia a Scrafty con +2 en Defensa Especial y usa Danza Dragón (+2).",
-      "variant": []
-    },
-    {
-      "detail": "FALLA TRUCO POR PARÁLISIS: se sacrifica, entra Chandelure, usa Truco para bloquear en Rayo, luego entra Excadrill con Trampa Rocas y +2 de Ataque.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si entra Golurk.",
+      "variant": [
+        {
+          "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad."
+        },
+        {
+          "detail": "Barre con Bola Sombra."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/jynx.json
+++ b/src/data/johto/will/jynx.json
@@ -2,11 +2,15 @@
   "id": "jynx",
   "name": "Jynx",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "CHANSEY → Scrafty +1, A bocajarro para matar a Chansey, Luego Puño Drenaje para recuperar vida",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si entra Electivire.",
+      "variant": [
+        {
+          "detail": "Si entra Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/liepard.json
+++ b/src/data/johto/will/liepard.json
@@ -2,11 +2,18 @@
   "id": "liepard",
   "name": "Liepard",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "bloquear a Golurk, Excadrill 4+2 y lanza Trampa Rocas, Si entra Slowbro, cambia a Poliwrath, luego a Scrafty +2(SpD)+2.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si entra Golurk.",
+      "variant": [
+        {
+          "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad."
+        },
+        {
+          "detail": "Barre con Bola Sombra."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/lucario.json
+++ b/src/data/johto/will/lucario.json
@@ -2,11 +2,30 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Chandelure y Truco",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si Lucario no cambia y utiliza Triturar / Roca Afilada / Otro movimiento al que Scrafty sea resistente cambia a Scrafty +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Lucario usa A Bocajarro, revisa el objeto y si lograste poner las rocas.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidasfera y colocaste Trampa Rocas, usa Teletransporte. Si usa Triturar o Puño Bala, pasa por Poliwrath y luego entra con Gengar. Usa Otra Vez, Maquinación hasta +4 y Precisión X."
+        },
+        {
+          "detail": "Si tiene Vidasfera y usa A Bocajarro o Velocidad Extrema, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
+        },
+        {
+          "detail": "Si tiene Vidasfera y no colocaste Trampa Rocas, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
+        },
+        {
+          "detail": "Si no tiene Vidasfera, usa Teletransporte. Luego entra con Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra."
+    },
+    {
+      "detail": "Si aparece un segundo Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
     }
   ]
 }

--- a/src/data/johto/will/magnezone.json
+++ b/src/data/johto/will/magnezone.json
@@ -2,11 +2,26 @@
   "id": "magnezone",
   "name": "Magnezone",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A EXCADRILL",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Excadrill derrota a Magnezone, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Magnezone se queda, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Si aún se queda, cambia a Slowbro y usa Bostezo. Slowbro aguanta Rayo por la Banda Focus."
+        },
+        {
+          "detail": "Entra con Volcarona, usa Danza Aleteo x1 y derrota a Magnezone con Psíquico o Lanzallamas. Luego, frente a Typhlosion, deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
+    },
+    {
+      "detail": "Si entra Girafarig, cambia a Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro frente a Mantine y usa Bostezo frente a Magnezone. Deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/mantine.json
+++ b/src/data/johto/will/mantine.json
@@ -2,19 +2,21 @@
   "id": "mantine",
   "name": "Mantine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "USA TRAMPA ROCAS",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "NO CAMBIA → Cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2",
-      "variant": []
-    },
-    {
-      "detail": "MAGNEZONE → Excadrill lo derrota, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2",
-      "variant": []
-    },
-    {
-      "detail": "GOLURK→ Cambia a Excadrill y luego a Chandelure, contra Mantine usa Truco para bloquear Escaldar, Poliwrath 6+2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Mantine se queda, usa Amortiguador para mantener a Chansey sana.",
+      "variant": [
+        {
+          "detail": "Si entra Girafarig, cambia a Gengar y usa Otra Vez."
+        },
+        {
+          "detail": "Luego cambia a Slowbro frente a Mantine y usa Bostezo frente a Magnezone."
+        },
+        {
+          "detail": "Deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/slowbro.json
+++ b/src/data/johto/will/slowbro.json
@@ -2,24 +2,21 @@
   "id": "slowbro",
   "name": "Slowbro",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "LANZALLAMAS → Chandelure 2+2 / Lanzallamas para avanzar en el equipo",
+      "detail": "Coloca Trampa Rocas y revisa si entra Golurk.",
       "variant": [
         {
-          "detail": "Si el rival cambia a Golurk, usa Truco, luego entra Excadrill +4 +2 y vuelve a colocar Trampa Rocas.",
-          "variant": []
+          "detail": "Si entra Golurk, cambia a Gengar y usa Otra Vez."
         },
         {
-          "detail": "Si el rival cambia a Slowbro, entra Scrafty +1 en Defensa Especial + 1 Danza Dragón + Raíz Energía + 1 Danza Dragón / Liepard tiene banda Focus pero no te mata",
-          "variant": []
+          "detail": "Usa Maquinación hasta +4 y Velocidad X para +2 Velocidad."
+        },
+        {
+          "detail": "Continúa atacando con Bola Sombra."
         }
       ]
-    },
-    {
-      "detail": "GOLURK → Excadrill 4+2 y lanza Trampa Rocas, (si entra Drowzee), cambia a Poliwrath, luego a Scrafty 2(SpD)+2",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/will/typhlosion.json
+++ b/src/data/johto/will/typhlosion.json
@@ -2,19 +2,15 @@
   "id": "typhlosion",
   "name": "Typhlosion",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE, LUEGO SACA A METAGROSS, COLOCA ROCAS Y OBSERVA",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "MANTINE NO SE RETIRA → Chandelure usa Truco para bloquearlo con Escaldar, luego entra Poliwrath +6 At. +2 Vel. // Si cambia a Claydol después de Tambor, matalo con Puño Hielo, saldrá Magnezone, cambia a Excadrill y matalo con terremoto, luego saldrá Mantine, cambia a Poliwrath y boostea +6+2",
-      "variant": []
-    },
-    {
-      "detail": "MAGNEZONE → Excadrill lo derrota, luego entra Mantine, cambia a Chandelure y usa Truco para bloquear con Escaldar, luego entra Poliwrath +6 At. +2 Vel.",
-      "variant": []
-    },
-    {
-      "detail": "CLAYDOL → Cambia a Excadrill, luego a Chandelure, te enfrentas a Mantine, usa Truco para bloquear Escaldar, luego entra Poliwrath +6 At. +2 Vel.",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y prepara la entrada segura de Poliwrath.",
+      "variant": [
+        {
+          "detail": "Entra con Poliwrath y usa Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/umbreon.json
+++ b/src/data/johto/will/umbreon.json
@@ -2,11 +2,21 @@
   "id": "umbreon",
   "name": "Umbreon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRAMPA ROCAS",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Sale Scrafty +2",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X."
+        },
+        {
+          "detail": "Si entra Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. 🔔 Lucario tiene Banda Focus. 🔔"
+        },
+        {
+          "detail": "Si Umbreon se queda, cambia a Slowbro y usa Bostezo. Luego deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/xatu.json
+++ b/src/data/johto/will/xatu.json
@@ -2,126 +2,49 @@
   "id": "xatu",
   "name": "Xatu",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "CLAYDOL CON PSÍQUICO → Excadrill coloca Trampa Rocas, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath +6+2",
-      "variant": []
-    },
-    {
-      "detail": "GOLURK→ Revisa el objeto",
+      "detail": "Coloca Trampa Rocas. Si Xatu se queda, revisa su objeto.",
       "variant": [
         {
-          "detail": "RESTOS → Excadrill 4+2 / Terremoto para matar a Hypno",
-          "variant": []
+          "detail": "Si tiene Llamasfera, usa Amortiguador hasta que salga Golurk. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
         },
         {
-          "detail": "CINTA XPERTO → Excadrill +4+2 y vuelve a poner Trampa Rocas, Si cambia a Slowbro mientras te boosteas, entra Poliwrath, luego cambia a Scrafty con +2 en Defensa Especial.",
-          "variant": []
+          "detail": "Si no tiene Llamasfera, cambia a Slowbro y usa Bostezo. Cuando salga Magnezone, usa Protección y cambia a Chansey. Cuando salga Girafarig, coloca Trampa Rocas. Luego usa Gengar con Otra Vez, cambia a Slowbro frente a Mantine y usa Bostezo. Después entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     },
     {
-      "detail": "MAGNEZONE → Excadrill lo derrota, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath 6+2.",
-      "variant": []
-    },
-    {
-      "detail": "BRONZONG → Cambia a Chandelure",
+      "detail": "Si entra Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Contra Empoleon → Truco para bloquear Escaldar, Poliwrath 6+2,",
-          "variant": []
-        },
-        {
-          "detail": "Contra Tropius → Truco para bloquear Poder Oculto, Scrafty +2 (Bronzong necesita dos golpes)",
-          "variant": []
+          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol o Bronzong, entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     },
     {
-      "detail": "UMBREON → Lanza Trampa Rocas, Scrafty +2",
-      "variant": []
+      "detail": "Si entra Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No es necesario usar Otra Vez."
     },
     {
-      "detail": "CLEFABLE → Cambia a Chandelure, según la situación 👇🏻",
+      "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Mantén Otra Vez cuando sea necesario."
+    },
+    {
+      "detail": "Si entra Lucario, usa Teletransporte y revisa su objeto.",
       "variant": [
         {
-          "detail": "Mov. sísmico → Scrafty +1, cura con Raíz Energía y sube otro +1",
-          "variant": []
+          "detail": "Si tiene Vidasfera, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X. Mantén Otra Vez cuando sea necesario."
         },
         {
-          "detail": "Lanzallamas [Zoroark disfrazado] → Truco para cambiar objeto, Scrafty +2",
-          "variant": []
+          "detail": "Si no tiene Vidasfera, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Mantén Otra Vez cuando sea necesario."
         },
         {
-          "detail": "Contra LUCARIO / GARDEVOIR → Truco para bloquear Triturar/Pulso Umbrío, Scrafty +2",
-          "variant": []
+          "detail": "Si revela que es Zoroark por un movimiento de tipo Fuego, usa Otra Vez y entra con Poliwrath para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad."
         }
       ]
     },
     {
-      "detail": "BLISSEY O CHANSEY → Scrafty +1 / A bocajarro para matar a Blissey o Chansey // Luego cura con Puño Drenaje",
-      "variant": []
-    },
-    {
-      "detail": "VIDASFERA + ONDA ÍGNEA → Chandelure usa Bola Sombra para debilitar",
-      "variant": [
-        {
-          "detail": "Si sale Umbreon → Cambia a Metagross y lanza Trampa Rocas, Scrafty +2, Si no puede poner Trampa Rocas con Metagross, usa Excadrill para ponerlas",
-          "variant": []
-        },
-        {
-          "detail": "Si sale Lucario → Cambia a Scrafty, luego a Chandelure con Truco para bloquear Triturar, Scrafty +2",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "RESTOS + ONDA ÍGNEA → Scrafty +2 / 2 puño drenaje para matar a Kecleon / Clefeable",
-      "variant": []
-    },
-    {
-      "detail": "GAFAS ELEGIDAS + ONDA ÍGNEA → Cambia a Chandelure",
-      "variant": [
-        {
-          "detail": "Si no cambia → Bola Sombra para debilitar o matar, entra Hydreigon, Scrafty +2 // (Bronzong necesita dos golpes)",
-          "variant": []
-        },
-        {
-          "detail": "Contra Bronzong → lanzallamas para debilitar o matar:",
-          "variant": [
-            {
-              "detail": "Si sale Hydreigon, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Si sale Empoleon, Poliwrath 6+2",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "CHALECO ASALTO + ONDA ÍGNEA → Cambia a Scrafty",
-      "variant": [
-        {
-          "detail": "No se retira → Scrafty usa Defensa Especial X luego +4 / Usa Puño Drenaje para eliminar Magnezone / Si Metagross está quemado, ayudar a eliminar la quemadura / Si Onda Ígnea baja mucha vida curar con Raíz Energía",
-          "variant": []
-        },
-        {
-          "detail": "Magnezone → Excadrill usa Terremoto para eliminarlo, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath +6+4",
-          "variant": []
-        },
-        {
-          "detail": "Claydol → Excadrill coloca Trampa Rocas, entra Mantine, cambia a Chandelure y usa Truco para bloquear Escaldar, Poliwrath +6+4 // Si claydol no se retira, Scrafty +3",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "LANZALLAMAS [disfraz de Zoroark] → Chandelure usa Truco para intercambiar objeto, Scrafty +2 (requiere pruebas)",
-      "variant": []
+      "detail": "Si entra Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Mantén Otra Vez cuando sea necesario."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Releases the completed Johto strategy updates from `develop` into `main`.
- Includes completed strategy rewrites for:
  - Will
  - Koga
  - Bruno
  - Karen
  - Lance
- Keeps the existing JSON strategy structure intact.

## Notes
- This release updates Johto strategy data only.
- No visual assets are changed in this release.
- After merge, GitHub Pages should deploy the updated `main` branch.