### PR TITLE
Update Hoenn Sixto strategies

### DIFF
--- a/src/data/hoenn/sixto/absol.json
+++ b/src/data/hoenn/sixto/absol.json
@@ -2,51 +2,112 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨",
+  "initialMove": "💡 Cambia a Slowbro 💡",
   "tricks": [
     {
-      "detail": "Sin Vidasfera  ➜ cambiar a Gengar  Otra Vez  +4 +2 ; (contra Gengar veloz, ver abajo)",
-      "variant": []
+      "detail": "Si Absol tiene Vidasfera, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si usa Tajo Umbrío, cambia a Chansey y usa Encanto frente a Garchomp. Luego coloca Trampa Rocas, cambia a Slowbro y usa Bostezo frente a Magnezone. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Electivire, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Electivire o Toxicroak.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, cambia a Chansey y coloca Trampa Rocas.",
+          "variant": [
+            {
+              "detail": "Si luego sale Absol, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Barre con Bola Sombra.",
+              "variant": []
+            },
+            {
+              "detail": "Si luego sale Luxray, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Excadrill sin Globo Helio  al azar ➜ rezar por estabilidad , ver abajo",
-      "variant": []
-    },
-    {
-      "detail": "Fortalecerse y huir hacia Excadrill ➜ cambiar a Dragonite, cambiar a Jirachi Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Globo Helio  ➜ Galladee +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Sin Globo Helio  ➜ Dragonite +2 )",
-      "variant": []
-    },
-    {
-      "detail": "Absol Pañuelo elegido  ➜ Dragonite aguanta x Defensa Danza Dragón x3 / Gengar  +6 +0 +2  (querer hacer daño);( Gengar +6 al azar, para matar a  (crafty)",
-      "variant": []
-    },
-    {
-      "detail": "Cambiar Gengar  ante Hariyama ➜ cambiar a huevo, cambiar a Gengar Otra Vez; frente a Aggron puede aguantar mucho, cambiar a Dragonite Otra Vez , Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Shiftry ➜ Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Vidasfera (Life Orb) ➜ cambiar a Jirachi Otra Vez (Encore), cambiar a Chandelure +2 +2 (22)",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp ➜ Otra Vez (Encore) para bloquear en Colmillo Ígneo (fire fang); Chandelure +2 +2 (22)",
-      "variant": []
-    },
-    {
-      "detail": "Electivire ➜ Otra Vez (Encore) para bloquear en Fuego; cambiar a Chandelure +2 +2 (22)",
-      "variant": []
+      "detail": "Si Absol no tiene Vidasfera, usa Teletransporte y revisa el movimiento.",
+      "variant": [
+        {
+          "detail": "Si usa Tajo Umbrío, Chansey coloca Trampa Rocas. Si el golpe es crítico, usa Max Poción antes de cambiar a Gengar.",
+          "variant": [
+            {
+              "detail": "Cuando recibas A Bocajarro, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Persecución, envía a Chansey, luego cambia a Gengar, usa Otra Vez y Bola Sombra. Después cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si el rival se queda, usa Protección y Bostezo frente a Huntail o Excadrill. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Huntail, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Luxray, envía a Chansey y usa Amortiguador.",
+          "variant": [
+            {
+              "detail": "Si vuelve Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Magnezone, envía a Chansey y coloca Trampa Rocas.",
+          "variant": [
+            {
+              "detail": "Si sale Darmanitan, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+              "variant": []
+            },
+            {
+              "detail": "Si vuelve Absol, Gengar usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Salamence con Intimidación, envía a Chansey y usa Amortiguador.",
+          "variant": [
+            {
+              "detail": "Si vuelve Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Salamence sin Intimidación, envía a Chansey, sacrifica a Politoed y usa Puño Hielo con Poliwrath.",
+          "variant": [
+            {
+              "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Hariyama, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/aggron.json
+++ b/src/data/hoenn/sixto/aggron.json
@@ -2,11 +2,20 @@
   "id": "aggron",
   "name": "Aggron",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Aggron → Cambia a Jirachi luego Cambia a Dragonite usa Otra Vez +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas, sacrifica a Politoed y entra con Poliwrath para absorber el golpe y derrotar a Aggron.",
+      "variant": [
+        {
+          "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Mantén los PS por encima del 23%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hariyama, Poliwrath usa Ataque X y termina con Cascada contra Hariyama.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/crawdaunt.json
+++ b/src/data/hoenn/sixto/crawdaunt.json
@@ -2,11 +2,20 @@
   "id": "crawdaunt",
   "name": "Crawdaunt",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨(scolipede y excadrill banda focus )",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Se queda → Chandelure +2 +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Ruta rápida: usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta de ahorro: usa Maquinación hasta +6 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/darmanitan.json
+++ b/src/data/hoenn/sixto/darmanitan.json
@@ -2,15 +2,25 @@
   "id": "darmanitan",
   "name": "Darmanitan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Fuerza Bruta  ➜ Gengar  +6  NO usar Otra Vez ",
-      "variant": []
+      "detail": "Ruta rápida: cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+      "variant": [
+        {
+          "detail": "Ataca siempre con el movimiento súper eficaz para avanzar el combate.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Buscando superar velocidad  ➜ ASEGURAR (NAIL) Chandelure +2 +2 ; si no se puede asegurar trampa rocas al azar ; Gyarados y Absol apostar por Arcanine si no se puede asegurar )",
-      "variant": []
+      "detail": "Ruta de ahorro: cambia a Gengar y usa Maquinación hasta +6. No uses Otra Vez.",
+      "variant": [
+        {
+          "detail": "Barre con Bola Sombra cuando ya estés preparado.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/electivire.json
+++ b/src/data/hoenn/sixto/electivire.json
@@ -2,11 +2,16 @@
   "id": "electivire",
   "name": "Electivire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gengar Otra Vez +2 y Pushea",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/excadrill.json
+++ b/src/data/hoenn/sixto/excadrill.json
@@ -1,24 +1,25 @@
-  {
+{
   "id": "excadrill",
   "name": "Excadrill",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨.",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sin Globo Helio Absol/Luxray ➜ cambiar a Gengar Otra Vez ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Sin Globo Helio : Excadrill ➜ Jirachi Otra Vez; Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Con Globo Helio ➜ cambiar a Gengar  debilitar  a Mienshao",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ cambiar a Dragonite Cambia a Jirachi Otra Vez Gallade +4 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar y usa Bola Sombra contra Mienshao. Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2. Usa Gigadrenado contra Absol.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Absol no tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Luxray, usa Amortiguador y espera quedar frente a Absol o Crawdaunt. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/garchomp.json
+++ b/src/data/hoenn/sixto/garchomp.json
@@ -2,19 +2,29 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Absol ➜ Gengar  Otra Vez ; cambiar a Jirachi; usar a Chandelure hasta que salga Gyarados",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp ➜ Jirachi Otra Vez; Dragonite Danza Dragón x2 ; resistir Colmillo Ígneo  y eliminar quemadura ",
-      "variant": []
-    },
-    {
-      "detail": "Se Queda  ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Chandelure +2 +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa la ruta rival.",
+      "variant": [
+        {
+          "detail": "Si usa Colmillo Ígneo, usa Encanto y Amortiguador frente a Absol. Luego cambia a Gengar, usa Maquinación hasta +2 y barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, puedes resolver con ruta rápida o de ahorro.",
+          "variant": [
+            {
+              "detail": "Ruta rápida: cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+              "variant": []
+            },
+            {
+              "detail": "Ruta de ahorro: cambia a Gengar, usa Maquinación hasta +6 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/golurk.json
+++ b/src/data/hoenn/sixto/golurk.json
@@ -2,15 +2,34 @@
   "id": "golurk",
   "name": "Golurk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Tramparocas🪨",
+  "initialMove": "🔔 Opciones para resolver 🔔",
   "tricks": [
     {
-      "detail": "Puño Drenaje  y se queda  ➜ cambiar a Gengar; Bola Sombra",
-      "variant": []
+      "detail": "Ruta rápida: coloca Trampa Rocas y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Ataca siempre con el movimiento súper eficaz.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Debilitar  o frente a Darmanitan ➜ Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Ruta de ahorro: usa Encanto y Amortiguador para estabilizar el combate.",
+      "variant": [
+        {
+          "detail": "Coloca Trampa Rocas frente a Darmanitan. Luego cambia a Gengar, usa Maquinación hasta +6 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si usas Amortiguador frente a Darmanitan, cambia a Gengar y usa Otra Vez con Maquinación hasta +2 para derrotarlo.",
+      "variant": [
+        {
+          "detail": "Frente a Absol, cambia a Chansey y luego vuelve a Gengar para usar Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/gyarados.json
+++ b/src/data/hoenn/sixto/gyarados.json
@@ -2,63 +2,59 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Intimidacion mira abajo 💡",
+  "initialMove": "💡 Revisa la habilidad 💡",
   "tricks": [
     {
-      "detail": "Intimidación  ➜ ASEGURAR Trampa rocas y  frente a Absol ; Gengar Otra Vez  +2 no velo",
-      "variant": []
+      "detail": "Si tiene Intimidación, coloca Trampa Rocas.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar y usa Maquinación hasta +2. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Luxray, cambia a Gengar y usa Maquinación hasta +4. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Autoestima  ➜ ASEGURAR Trampa rocas",
-      "variant": []
-    },
-    {
-      "detail": "Darmanitan ➜ cambiar a Gengar  +6 no velo  (drama pañuelo)",
-      "variant": []
-    },
-    {
-      "detail": "Golurk ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Toxicroak ➜ cambiar a Gengar  Otra Vez  +4 no velo; y ataca  tras Otra Vez",
-      "variant": []
-    },
-    {
-      "detail": "Se queda con Acua Cola ➜ cambiar a Jirachi Rayo ; si es enfrentamiento directo no hace falta Rayo",
-      "variant": []
-    },
-    {
-      "detail": "Electivire / Absol ➜ Otra Vez ; cambiar a Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ cambiar a Gengar  Otra Vez (Encore) +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Gallade +4 +2 , primero asegurar x velocidad ",
-      "variant": []
-    },
-    {
-      "detail": "Maquinación  y huye hacia Mightyena ➜ ataca ",
-      "variant": []
-    },
-    {
-      "detail": "Magnezone ➜ cambiar a huevo  Pantalla de Luz ; cambio pesado ",
-      "variant": []
-    },
-    {
-      "detail": "Luxray ➜ cambiar a huevo; cambiar a Gengar Otra Vez ; frente a Excadrill, ver las variantes de Excadrill",
-      "variant": []
-    },
-    {
-      "detail": "Luxray ➜ Gengar  Otra Vez ; cambiar a Jirachi ante Excadrill; Jirachi Otra Vez ; Gallade +4 +2 , primero asegurar x velocidad",
-      "variant": []
+      "detail": "Si no tiene Intimidación, coloca Trampa Rocas y revisa el movimiento o cambio rival.",
+      "variant": [
+        {
+          "detail": "Si usa Acua Cola, usa Amortiguador frente a Absol. Luego cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Darmanitan, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Ataca siempre con el movimiento súper eficaz. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si Bostezo fuerza la salida de un atacante especial, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si usa Tajo Umbrío, revisa si Slowbro sobrevive.",
+              "variant": [
+                {
+                  "detail": "Si Slowbro sobrevive, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Golpe Bajo no es amenaza.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si Slowbro cae, cambia a Chansey. Luego entra con Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Luxray, usa Amortiguador y espera a Absol. Luego cambia a Gengar, usa Maquinación hasta +2 y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/hariyama.json
+++ b/src/data/hoenn/sixto/hariyama.json
@@ -2,23 +2,28 @@
   "id": "hariyama",
   "name": "Hariyama",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Hariyama se queda  ➜ cambiar a Jirachi Protección",
-      "variant": []
-    },
-    {
-      "detail": "Salamence ➜ Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ Chandelure +2 +2 ; (absol pañuelo)  Bola Sombra debilita a Hariyama",
-      "variant": []
-    },
-    {
-      "detail": "Aggron ➜ cambiar a Jirachi Otra Vez; Gallade +4 +2  hacia Jirachi; probabilidad de recibir golpe de roca ( nota: pendiente de optimización )",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Aggron, sacrifica a Politoed y entra con Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas. Mantén los PS por encima del 23%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Hariyama se queda, usa Ataque X con Poliwrath y luego Cascada contra Hariyama.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/huntail.json
+++ b/src/data/hoenn/sixto/huntail.json
@@ -2,19 +2,20 @@
   "id": "huntail",
   "name": "Huntail",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Absol ➜ cambiar a Gengar Otra Vez  +2 ataca y su cambia a   Garchomp",
-      "variant": []
-    },
-    {
-      "detail": "Mienshao ➜ Gengar  rematalo ",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Gallade +4 +2, primero asegurar x velocidad ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Ataca con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar y usa Bola Sombra. Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2. Usa Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/luxray.json
+++ b/src/data/hoenn/sixto/luxray.json
@@ -2,43 +2,37 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🔔 Revisa la habilidad 🔔",
   "tricks": [
     {
-      "detail": "Intimidación : Frente a Absol ➜ cambiar a Gengar  Otra Vez ; revisar objeto",
-      "variant": []
+      "detail": "Si tiene Intimidación, usa Amortiguador y revisa la ruta rival.",
+      "variant": [
+        {
+          "detail": "Si usa Fuerza Bruta, coloca Trampa Rocas. Frente a Absol, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Absol Pañuelo elegido  ➜ cambiar a Gengar; cambiar a Dragonite frente a Scrafty Danza Dragón x2  + x ataque ",
-      "variant": []
-    },
-    {
-      "detail": "Absol con Mal de Ojo  ➜ Gengar +4 no velo y atacar ",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ Gengar ; cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Dragonite Danza Dragón x2 ; probar grado de fuerza ; rezar por estabilidad +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty ➜ Chansey ; cambiar a Chandelure frente a Scizor para eliminarlo ; cambiar a chansey Amortiguador  frente a Absol; cambiar a Gengar; cambiar a Dragonite ante Scrafty Danza Dragón x2 + Atk X",
-      "variant": []
-    },
-    {
-      "detail": "Vidasfera  con Fuerza Bruta  ➜ cambiar a Gengar Otra Vez ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ Otra Vez ; Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Scizor ➜ lanzallamas frente a Tentacruel; cambiar a chansey Amortiguador  frente a Absol; cambiar a Gengar; cambiar a Dragonite ante Scrafty Danza Dragón x2 + Atk X",
-      "variant": []
-    },
-    {
-      "detail": "Sin Intimidación  ➜ Gengar  Otra Vez  +2 no velo ; atacar",
-      "variant": []
+      "detail": "Si no tiene Intimidación, elige una ruta para resolver.",
+      "variant": [
+        {
+          "detail": "Ruta segura: coloca Trampa Rocas, entra con Gengar, usa Otra Vez y Maquinación hasta +2 para derrotar a Luxray. Frente a Absol, pasa por Chansey y vuelve a Gengar con Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta alternativa: cambia a Slowbro y usa Bostezo frente a Gyarados. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/magnezone.json
+++ b/src/data/hoenn/sixto/magnezone.json
@@ -2,23 +2,20 @@
   "id": "magnezone",
   "name": "Magnezone",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Tramparocas🪨 y mira que item tiene ",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Globo Helio  ➜ ASEGURAR trampa rocas  frente a Darmanitan; Gengar  +6 0 velo ; NO usar Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Sin Globo Helio  ➜ ASEGURAR Trampa rocas frente a Absol; cambiar a Gengar Otra Vez ; cambiar a Jirachi; no recibir Absorbe Fuego frente a Gyarados ; cambiar a Chansey ",
-      "variant": []
-    },
-    {
-      "detail": "Huye hacia Magnezone ➜ cambio a chansey ",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp ➜ Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Darmanitan, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Ataca siempre con el movimiento súper eficaz.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Ataca siempre con el movimiento súper eficaz.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/mandibuzz.json
+++ b/src/data/hoenn/sixto/mandibuzz.json
@@ -2,11 +2,20 @@
   "id": "mandibuzz",
   "name": "Mandibuzz",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mienshao➜ Gengar Bola sombra sale ➜ Excadril ➜ Dragonite ➜ Jirachi otra vez , Gallade +4 +2  ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Mienshao.",
+      "variant": [
+        {
+          "detail": "Gengar derrota a Mienshao con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2. Usa Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/mienshao.json
+++ b/src/data/hoenn/sixto/mienshao.json
@@ -2,23 +2,20 @@
   "id": "mienshao",
   "name": "Mienshao",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Gengar otra vez para que se muera ",
+  "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "Excadrill ➜ Chansey  ASEGURAR Trampa rocas  quedarse y usar Amortiguador ",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ cambiar a Gengar ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ Otra Vez ; Gallade +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Si Persecución  debilita a Gengar  ➜ Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Cambia a Gengar y derrota a Mienshao con Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Frente a Mandibuzz o Spiritomb, cambia a Chansey y coloca Trampa Rocas.",
+          "variant": []
+        },
+        {
+          "detail": "Frente a Absol, entra con Volcarona, usa Danza Aleteo x2 y Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/mightyena.json
+++ b/src/data/hoenn/sixto/mightyena.json
@@ -2,11 +2,16 @@
   "id": "mightyena",
   "name": "Mightyena",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨USA TRAMPA ROCAS🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Absol ➜ Gengar Otra Vez +2 no velo ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/salamence.json
+++ b/src/data/hoenn/sixto/salamence.json
@@ -2,31 +2,33 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Mira Que Habilidad Tiene💡",
+  "initialMove": "💡 Revisa la habilidad 💡",
   "tricks": [
     {
-      "detail": "Intimidación ➜ Pantalla de Luz ",
-      "variant": []
+      "detail": "Si tiene Intimidación, usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Huye hacia Absol ➜ Dragonite; asegurar x defensa ; Danza Dragón x2 ; x ataque  ",
-      "variant": []
-    },
-    {
-      "detail": "Sin Intimidación  ➜ ASEGURAR Trampa rocas  ; cambiar a Jirachi Otra Vez; Chandelure +2 +2 ; Chandelure +2; Bola Sombra  objetivo aleatorio",
-      "variant": []
-    },
-    {
-      "detail": "Probando sin Intimidación  ➜ ASEGURAR trampa rocas ; cambiar a Gengar  Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Se queda  ➜ Click hasta debilitar; ver instrucciones abajo",
-      "variant": []
-    },
-    {
-      "detail": "Aggron ➜ cambiar a Jirachi; cambiar a Dragonite Otra Vez ; Danza Dragón x2 ",
-      "variant": []
+      "detail": "Si no tiene Intimidación, coloca Trampa Rocas, sacrifica a Politoed y entra con Poliwrath. Usa Puño Hielo para derrotar a Salamence.",
+      "variant": [
+        {
+          "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas. Mantén los PS por encima del 23%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hariyama, Poliwrath usa Ataque X. Usa Cascada contra Hariyama.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/scizor.json
+++ b/src/data/hoenn/sixto/scizor.json
@@ -2,23 +2,20 @@
   "id": "scizor",
   "name": "Scizor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " 💡cambia a chande y matalo 💡",
+  "initialMove": "🦋 Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Tentacruel ➜ cambiar a chansey Pantalla de Luz ; frente a Absol cambiar a Gengar  Rayo  cambia a Jirachi Otra Vez; Chandelure no puede  si falta uno entre Tentacruel y Scrafty",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty huye hacia Salamence ➜ continuar con Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Se bloquea en Puño Drenaje Pañuelo ➜ Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ Chansey Contador ; frente a Scrafty Gengar  Otra Vez  +2 +2  + Otra Vez (Encore)",
-      "variant": []
+      "detail": "Entra con Volcarona, usa Danza Aleteo x2 y Especial X.",
+      "variant": [
+        {
+          "detail": "Usa Gigadrenado contra Luxray.",
+          "variant": []
+        },
+        {
+          "detail": "Haz Danza Aleteo x2: si solo haces una Danza Aleteo, Absol con Pañuelo Elegido puede superar a Volcarona en velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/scolipede.json
+++ b/src/data/hoenn/sixto/scolipede.json
@@ -2,15 +2,20 @@
   "id": "scolipede",
   "name": "Scolipede",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨 AMORTIGUADOR  directo ➜ Aguantar presión (Cuidado con Scolipede/Excadrill banda focus)",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Rezar por estabilidad  ➜ Gengar  Otra Vez ; Maquinación ; presionar hasta Excadrill ; cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Buscando velocidad  ➜ Dragonite Danza Dragón x2 ; NO usar Otra Vez ; Scolipede Banda Focus ; cuidado con tu vida  ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Scolipede no cambia, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6. Absol no tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Luxray, usa Amortiguador y espera quedar frente a Absol o Crawdaunt. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/scrafty.json
+++ b/src/data/hoenn/sixto/scrafty.json
@@ -2,31 +2,20 @@
   "id": "scrafty",
   "name": "Scrafty",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Absol ➜ cambiar a Gengar ; cambiar a Jirachi frente a Scrafty Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Salamence ➜ luego usar Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty con Puño Drenaje  ➜ Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Scizor ➜ cambiar a Chandelure para debilitarlo; frente a Absol ver instrucciones arriba",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ cambiar a Jirachi Protección frente a Salamence; Otra Vez; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Tentacruel ➜ cambiar a Chansey Amortiguador  frente a Absol",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/shiftry.json
+++ b/src/data/hoenn/sixto/shiftry.json
@@ -2,15 +2,30 @@
   "id": "shiftry",
   "name": "Shiftry",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampasRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Aggron ➜ cambiar a Jirachi; cambiar a Dragonite Otra Vez ; Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Absol (pañuelo elegido) ➜ Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Absol, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si entra Aggron, sacrifica a Politoed y entra con Poliwrath para derrotarlo.",
+          "variant": [
+            {
+              "detail": "Si luego entra Shiftry, cambia a Volcarona, usa Danza Aleteo x2 y Lanzallamas contra Shiftry. Contra el resto de plantas, usa Psíquico. Mantén los PS por encima del 23%.",
+              "variant": [
+                {
+                  "detail": "Si entra Hariyama, Poliwrath usa Ataque X y ataca. Usa Cascada contra Hariyama.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/spiritomb.json
+++ b/src/data/hoenn/sixto/spiritomb.json
@@ -2,19 +2,20 @@
   "id": "spiritomb",
   "name": "Spiritomb",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mienshao ➜ Gengar Otra Vez  debilitar ",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Gallade +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ Gengar  Otra Vez +2 no velo ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar y usa Maquinación hasta +4.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mienshao, Gengar lo derrota con Bola Sombra. Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/tentacruel.json
+++ b/src/data/hoenn/sixto/tentacruel.json
@@ -2,19 +2,20 @@
   "id": "tentacruel",
   "name": "Tentacruel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz 💡",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Pantalla de Luz frente a Absol ➜ cambiar a Dragonite; usar x defensa ; Danza Dragón x3 ; x ataque; curar hasta 20% ",
-      "variant": []
-    },
-    {
-      "detail": "Scizor ➜ lanzallamas scizor",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty ➜ Dragonite +4 +2 ; si no hay suficiente  curar ; ante bajada de defensa , asegurar con x defensa ",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/toxicroak.json
+++ b/src/data/hoenn/sixto/toxicroak.json
@@ -2,15 +2,16 @@
   "id": "toxicroak",
   "name": "Toxicroak",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "Gengar  Otra Vez  +4 no velo ; Otra Vez; ataca ",
-      "variant": []
-    },
-    {
-      "detail": "Huye hacia Mightyena ➜ cambiar a chansey ASEGURAR trampa rocas; atraer movimiento lucha ; Gengar  Otra Vez  +0 +2 ",
-      "variant": []
+      "detail": "Cambia a Gengar, usa Maquinación hasta +4 y luego usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Toxicroak tiene Banda Focus. Barre con Bola Sombra después de preparar a Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Rewrites the Hoenn Sixto strategy files with clearer and more consistent Spanish instructions.
- Normalizes raw boost notation such as `+2 +2`, `+4 +2`, and `+6` into explicit actions.
- Keeps the existing JSON structure intact: `id`, `name`, `image`, `initialMove`, `tricks`, and `variant`.

## Scope
Only files under `src/data/hoenn/sixto` are updated.

## Notes
- No visual assets are changed.
- No `main` or deploy changes are included in this PR.