### PR TITLE
Fix remaining Hoenn Sixto strategies

### DIFF
--- a/src/data/hoenn/sixto/cacturne.json
+++ b/src/data/hoenn/sixto/cacturne.json
@@ -2,13 +2,22 @@
   "id": "cacturne",
   "name": "Cacturne",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🔔 Opciones para resolver 🔔",
   "tricks": [
     {
-      "detail": "Puño dranaje → Cambia a Gengar usa Otra Vez 6+2",
+      "detail": "Ruta rápida: coloca Trampa Rocas, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
       "variant": [
         {
-          "detail": "Darmanitan → Chandelure 2+2",
+          "detail": "Ataca siempre con el movimiento súper eficaz para avanzar el combate.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta de ahorro: usa Encanto y Amortiguador para estabilizar el combate.",
+      "variant": [
+        {
+          "detail": "Coloca Trampa Rocas frente a Darmanitan. Luego cambia a Gengar, usa Maquinación hasta +6 y barre con Bola Sombra. No uses Otra Vez.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/sixto/metagross.json
+++ b/src/data/hoenn/sixto/metagross.json
@@ -2,21 +2,20 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa rocas 🪨(huntail Banda Focus)",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Absol/Luxray ➜ Gengar Otra Vez +2 no velo ",
+      "detail": "Coloca Trampa Rocas frente a Absol y cambia a Gengar.",
       "variant": [
         {
-          "detail": "-",
+          "detail": "Gengar usa Maquinación hasta +2 y barre con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "-",
+          "detail": "Huntail tiene Banda Focus; mantén la ruta preparada antes de intentar cerrar el combate.",
           "variant": []
         }
       ]
     }
-  
   ]
 }

--- a/src/data/hoenn/sixto/sableye.json
+++ b/src/data/hoenn/sixto/sableye.json
@@ -2,31 +2,37 @@
   "id": "sableye",
   "name": "Sableye",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Aggron ➜ Jirachi Protección ; Gallade Otra Vez  +4 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Absol, cambia a Gengar y usa Otra Vez. Revisa el objeto de Absol.",
+      "variant": [
+        {
+          "detail": "Si Gengar es más rápido que Absol, usa la ruta rápida: Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta de ahorro: usa Maquinación hasta +6 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si Absol usa A Bocajarro primero, usa Maquinación hasta +4 con Gengar. No uses Otra Vez; Absol tiene Pañuelo Elegido.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Absol ➜ Amortiguador ; revisar objeto",
-      "variant": []
-    },
-    {
-      "detail": "Pañuelo elegido  ➜ Chandelure +2 +2 ; Bola Sombra debilita a Hariyama",
-      "variant": []
-    },
-    {
-      "detail": "Vidasfera  ➜ Gengar  Otra Vez  +6 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Magnezone ➜ cambiar a jirachi  ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Si sale Aggron, sacrifica a Politoed y entra con Poliwrath para usar Puño Drenaje.",
+      "variant": [
+        {
+          "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hariyama, Poliwrath usa Ataque X y termina con Cascada contra Hariyama.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/sharpedo.json
+++ b/src/data/hoenn/sixto/sharpedo.json
@@ -2,23 +2,20 @@
   "id": "sharpedo",
   "name": "Sharpedo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Frente a Absol ➜ Gengar  Otra Vez ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp ➜ Jirachi Otra Vez; bloquear en Colmillo Ígneo ; Chandelure +2 +2 (22); estrategia arriesgada : Dragonite Danza Dragón x3 ; Jirachi y Dragonite NO usar Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Chandelure huye hacia Gyarados ➜ Dragonite Danza Dragón x3 ; NO usar Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Magnezone ➜ cambiar a Chandelure Pantalla de Luz; contador",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Ruta rápida: usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta de ahorro: usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad. Mantén Otra Vez cuando sea necesario hasta terminar de boostearte y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fixes the remaining Hoenn Sixto strategy files that were missed in the previous Sixto update.
- Cleans up old raw boost notation and outdated shorthand text.
- Keeps the existing JSON structure intact.

## Scope
Only these files are updated:
- `src/data/hoenn/sixto/cacturne.json`
- `src/data/hoenn/sixto/metagross.json`
- `src/data/hoenn/sixto/sableye.json`
- `src/data/hoenn/sixto/sharpedo.json`

## Notes
- No visual assets are changed.
- No `main` or deploy changes are included.