### PR TITLE
Update Hoenn Fatima strategies

### DIFF
--- a/src/data/hoenn/fatima/arcanine.json
+++ b/src/data/hoenn/fatima/arcanine.json
@@ -2,11 +2,16 @@
   "id": "arcanine",
   "name": "Arcanine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Amortiguador💡",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "A bocajarro ➜ Gengar Otra vez +4 +2",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Raichu, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/banette.json
+++ b/src/data/hoenn/fatima/banette.json
@@ -2,15 +2,20 @@
   "id": "banette",
   "name": "Banette",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨USAR TRAMPA ROCAS🪨en honchkrow mira abajo ",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Método 1 ➜ Amortiguador ; cambiar a Dragonite Danza Dragón x1; Máxima Poción ; Danza Dragón x1; antes de presionar, mantener línea de PS en 150hp si falta salud, usar medicina",
-      "variant": []
-    },
-    {
-      "detail": "Método 2 ➜ cambiar a Gengar  Otra Vez  cambiar a chansey  hacia Hydreigon; Gengar +4 no velo  usar x defensa ; Hydreigon se bloquea solo en Llamarada ; Gengar  aguantar Golpe Crítico; ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Honchkrow.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath cuando aparezca Hydreigon.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Ataque X con Poliwrath y completa la ruta. Usa Puño Hielo para eliminar a Honchkrow.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/chandelure.json
+++ b/src/data/hoenn/fatima/chandelure.json
@@ -2,11 +2,20 @@
   "id": "chandelure",
   "name": "Chandelure",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lucario ➜ Chandelure +2 +2 (pañuelo)",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Para ahorrar objetos, puedes subir a Maquinación hasta +6 con Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/dusknoir.json
+++ b/src/data/hoenn/fatima/dusknoir.json
@@ -2,103 +2,58 @@
   "id": "dusknoir",
   "name": "Dusknoir",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Mira Que Habilidad tiene 💡",
+  "initialMove": "💡 Revisa si tiene Presión 💡",
   "tricks": [
     {
-      "detail": "Presión ➜ ASEGURAR Trampa rocas ",
-      "variant": []
+      "detail": "Si tiene Presión, coloca Trampa Rocas. Si Dusknoir se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Gengar para revisar el movimiento.",
+          "variant": [
+            {
+              "detail": "A Bocajarro: Gengar usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+              "variant": []
+            },
+            {
+              "detail": "Patada Salto Alta: Gengar usa Maquinación hasta +2 y se sacrifica frente a Houndoom. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Si hay quemadura, usa Restaurar Todo.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Honchkrow, sacrifica a Politoed. Poliwrath barre hasta Hydreigon, usa Ataque X y sigue barriendo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo frente a Raichu. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hydreigon, usa Teletransporte. Si Hydreigon se queda, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Honchkrow  ➜ cambiar a Jirachi Otra Vez; Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Chandelure",
-      "variant": []
-    },
-    {
-      "detail": "A bocajarro  ➜ Chandelure +2 +2 ; NO usar Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta  ➜ cambiar a Chansey ; cambiar a Gengar ; cambiar a Chansey Amortiguador ",
-      "variant": []
-    },
-    {
-      "detail": "Luxray ➜ Gengar  Otra Vez  +4  0 Velocidad; usar x2 defensa ",
-      "variant": []
-    },
-    {
-      "detail": "Mawile ➜ Dragonite usar x defensa; Danza Dragón x1; usar x ataque; si hay poca vida usar Máxima Poción ",
-      "variant": []
-    },
-    {
-      "detail": "Arcanine ➜ Amortiguador ; Gengar Otra Vez  +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Terremoto  ➜ Dragonite Otra Vez ; Danza Dragón x3 ; terremoto para  Froslass ",
-      "variant": []
-    },
-    {
-      "detail": "Mawile (repetido) ➜ Dragonite usar x defensa; Danza Dragón x1; usar x ataque; si hay poca vida usar Máxima Poción ",
-      "variant": []
-    },
-    {
-      "detail": "Puño Hielo  ➜ Amortiguador ; ver ruta de Se queda ?'",
-      "variant": []
-    },
-    {
-      "detail": "Frente a Mawile ➜ cambiar a Dragonite x defensa; +1; usar x ataque; curar con cuidado; terremoto debilita a Froslass",
-      "variant": []
-    },
-    {
-      "detail": "(Niebla) ➜ abrir Pantalla de Luz ; Amortiguador  para forzar cambio del rival ; ver rutas anteriores según el Pokémon que entre",
-      "variant": []
-    },
-    {
-      "detail": "Sin Presión ➜ abrir Pantalla de Luz ; frente a Lucario cambiar a Gengar  Zoroark",
-      "variant": []
-    },
-    {
-      "detail": "A bocajarro ➜ Gengar  Otra Vez (Encore) +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Gengar fortalecido  huye hacia Dusknoir ➜ cambiar a Jirachi Otra Vez  Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Gengar fortalecido  huye hacia Dusknoir real ➜ Dragonite Otra Vez ; Danza Dragón x2",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta  ➜ Gengar Otra Vez ; tener Pantalla de Luz activa; Hydreigon golpea a Gengar pero no cae ",
-      "variant": []
-    },
-    {
-      "detail": "Gengar Pot  ➜ cambiar a Chansey ASEGURAR trampa rocas",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir Real  ➜ cambiar a Jirachi; cambiar a Dragonite Otra Vez; Danza Dragón x2 ; cambio directo a Dragonite tiene probabilidad de recibir Puño Hielo ",
-      "variant": []
-    },
-    {
-      "detail": "Hydreigon ➜ Bola Sombra ; Jirachi Otra Vez ; Chandelure +2 +2 ; Bola Sombra rompe Banda Focus de Hydreigon; lanza llamas ",
-      "variant": []
-    },
-    {
-      "detail": "Se Queda  ➜ Bola Sombra ",
-      "variant": []
-    },
-    {
-      "detail": "Hydreigon (ruta alternativa) ➜ Jirachi Otra Vez ; Chandelure +2 +2 ; si Gengar cae por crítico , cambiar directo a Jirachi Otra Vez; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Debilitar si Hydreigon entra  ➜ Bola Sombra; cambiar a Dragonite; cambiar a Jirachi Otra Vez; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Si no tiene Presión, es Zoroark disfrazado de Dusknoir.",
+      "variant": [
+        {
+          "detail": "Coloca Trampa Rocas frente a Lucario y revisa la posición de Lucario en el equipo rival.",
+          "variant": []
+        },
+        {
+          "detail": "Lucario en posición 2 con A Bocajarro: cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Lucario en posición 3 con Patada Salto Alta: cambia a Slowbro y usa Bostezo frente al Dusknoir falso. Usa Protección y Bostezo si sale Hydreigon. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/froslass.json
+++ b/src/data/hoenn/fatima/froslass.json
@@ -2,11 +2,24 @@
   "id": "froslass",
   "name": "Froslass",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz💡",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mawile ➜ Dragonite usar x defensa; Danza Dragón x1 ; usar x ataque ; si tiene poca vida  usar Máxima Poción ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Froslass se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hydreigon, usa Teletransporte. Si Hydreigon permanece, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Mawile, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/honchkrow.json
+++ b/src/data/hoenn/fatima/honchkrow.json
@@ -2,15 +2,20 @@
   "id": "honchkrow",
   "name": "Honchkrow",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Roca 🪨 Jirachi Otra Vez ",
+  "initialMove": "Slowbro + Bostezo",
   "tricks": [
     {
-      "detail": "Fuerza Bruta ➜ Dragonite Danza Dragón x2 ; aguantar Golpe Crítico ; curar",
-      "variant": []
-    },
-    {
-      "detail": "Hydreigon ➜ Dragonite Danza Dragón x2 ; esperar a que se bloquee solo ; antes de presionar, volver a tener más de la mitad de la vida ",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Honchkrow permanece, o si sale Hydreigon o Lucario, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje para mantener una buena línea de salud.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Banette, cambia a Chansey y coloca Trampa Rocas frente a Honchkrow. Luego sacrifica a Politoed y entra con Poliwrath. Usa Puño Hielo contra Honchkrow; cuando entre Hydreigon, usa Ataque X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/houndoom.json
+++ b/src/data/hoenn/fatima/houndoom.json
@@ -2,15 +2,20 @@
   "id": "houndoom",
   "name": "Houndoom",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas 🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Honchkrow ➜ cambiar a Jirachi; Dragonite Otra Vez (Encore); Danza Dragón x2",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Gengar  Otra Vez ; Rayo  debilitar ; cambiar a Chansey Amortiguador ; atraer a Luxray ; Gengar  Otra Vez +4 no velo  usar x defensa",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Honchkrow, sacrifica a Politoed y entra con Poliwrath. Usa Puño Hielo contra Honchkrow; cuando entre Hydreigon, usa Ataque X y termina la ruta.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/hydreigon.json
+++ b/src/data/hoenn/fatima/hydreigon.json
@@ -2,59 +2,28 @@
   "id": "hydreigon",
   "name": "Hydreigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨trampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Honchkrow ➜ cambiar a Jirachi Otra Vez ; Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Onda Certera  ➜ verificar objeto ",
-      "variant": []
-    },
-    {
-      "detail": "Vida Esfera ➜ Pantalla de Luz  + Amortiguador  para forzar el cambio del rival",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir  ➜ cambiar a Jirachi; cambiar a Dragonite Otra Vez ; Danza Dragón x3 ; Sombra Vil  Chandelure hace 52%; esperar y curar",
-      "variant": []
-    },
-    {
-      "detail": "Mawile ➜ Dragonite usar x defensa ; Danza Dragón x1; usar x ataque ; si hay poca vida usar Máxima Poción  ( Terremoto para Froslass)",
-      "variant": []
-    },
-    {
-      "detail": "Rotom Lavado  ➜ cambiar a Chansey; cambiar a Jirachi; frente a Dusknoir Dragonite Otra Vez ; Danza Dragón x3 ",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir ➜ Dragonite Otra Vez ; Danza Dragón x3 ; rezar estabilidad ; primero cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Gengar ",
-      "variant": []
-    },
-    {
-      "detail": "A bocajarro  ➜ cambiar a Chansey; Pantalla de Luz; Chandelure +2 +2 ; (Pañuelo)",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta  ➜ cambiar a Gengar ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Hydreigon ➜ Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir  ➜ Dragonite Otra Vez ; Danza Dragón x3 ",
-      "variant": []
-    },
-    {
-      "detail": "Mawile  ➜ Dragonite usar x defensa; Danza Dragón x1; usar x ataque ; si hay poca vida usar Máxima Poción ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa el movimiento o cambio rival.",
+      "variant": [
+        {
+          "detail": "Si usa Onda Certera, usa Teletransporte. Si Hydreigon permanece, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Honchkrow, sacrifica a Politoed y entra con Poliwrath. Usa Puño Hielo contra Honchkrow; si entra Hydreigon, usa Ataque X y completa la ruta.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/lucario.json
+++ b/src/data/hoenn/fatima/lucario.json
@@ -2,43 +2,32 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambia a Gengar y Mira la situacion 💡",
+  "initialMove": "💡 Cambia a Slowbro 💡",
   "tricks": [
     {
-      "detail": "Se queda  ➜ para ver la habilidad ",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta  ➜ Gengar  Otra Vez ; debilitar ",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir ➜ Dragonite Otra Vez; Danza Dragón x2 ; huye hacia Meganium para continuar fortalecimiento ",
-      "variant": []
-    },
-    {
-      "detail": "Houndoom ➜ cambiar a Chansey  ASEGURAR Trampa rocas",
-      "variant": []
-    },
-    {
-      "detail": "Luxray ➜ Gengar  Otra Vez  +4 no velo; usar x2 defensa ",
-      "variant": []
-    },
-    {
-      "detail": "A bocajarro  ➜ cambiar a Chansey ; ver quién entra:",
-      "variant": []
-    },
-    {
-      "detail": "Hydreigon ➜ ASEGURAR trampa roca; frente a Lucario usar Chandelure +2 +2; Pañuelo elegido se bloquea solo; huye hacia columna de hielo  para resistir daño y fortalecerse",
-      "variant": []
-    },
-    {
-      "detail": "Honchkrow ➜ cambiar a Jirachi; ASEGURAR Trampa rocas; Otra Vez ; Dragonite +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Arcanine ➜ cambiar a Chandelure; cambiar a Chansey; Gengar  Otra Vez  +4 +2 ",
-      "variant": []
+      "detail": "Cambia a Slowbro y revisa el movimiento o cambio rival.",
+      "variant": [
+        {
+          "detail": "Si usa A Bocajarro, cambia a Chansey y coloca Trampa Rocas frente a Lucario. Luego cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Patada Salto Alta, usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Elimina la quemadura antes de barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Honchkrow, usa Bostezo. Si Honchkrow permanece, o si sale Hydreigon o Lucario, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje para mantener una buena línea de salud.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Banette, cambia a Chansey y coloca Trampa Rocas frente a Honchkrow. Luego sacrifica a Politoed y entra con Poliwrath. Presiona hasta Hydreigon y usa Ataque X. Usa Puño Hielo contra Honchkrow.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Arcanine, Slowbro usa Bostezo frente a Raichu. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/luxray.json
+++ b/src/data/hoenn/fatima/luxray.json
@@ -2,11 +2,20 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 Gengar Otra Vez +4 x defensa no velo ",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "-",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Defensa X.",
+          "variant": []
+        },
+        {
+          "detail": "Si Luxray usa Fuerza Bruta y sale crítico, usa primero Max Poción y luego barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/mandibuzz.json
+++ b/src/data/hoenn/fatima/mandibuzz.json
@@ -2,11 +2,16 @@
   "id": "mandibuzz",
   "name": "Mandibuzz",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡PANTALLA LUZ💡",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Arcanine → Gengar Otra Vez  +4 +2",
-      "variant": []
+      "detail": "Cambia a Slowbro frente a Arcanine y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Raichu, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/mawile.json
+++ b/src/data/hoenn/fatima/mawile.json
@@ -2,6 +2,16 @@
   "id": "mawile",
   "name": "Mawile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Dragonite usar x defensa ; Danza Dragón x1 ; usar x ataque ; si los PS bajan de 35, usar Máxima Poción ; no aguantar Golpe Crítico ; aguantar un golpe de Bisharp 💡",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/fatima/meganium.json
+++ b/src/data/hoenn/fatima/meganium.json
@@ -2,39 +2,20 @@
   "id": "meganium",
   "name": "Meganium",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Arcanine ➜ Amortiguador ; Gengar Otra Vez +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Mandibuzz ➜ Rayo ; cambiar a Chansey contador atraer a Arcanine contador ; se queda arcanine; Gengar +2 +2  usando x defensa",
-      "variant": []
-    },
-    {
-      "detail": "Meganium ➜ Gallade Otra Vez  +2 +2 ; Sombra Vil hace 75%; rezar estabilidad; usar x defensa ",
-      "variant": []
-    },
-    {
-      "detail": "Mandibuzz  ➜ Espada Santa ",
-      "variant": []
-    },
-    {
-      "detail": "Arcanine ➜ cambiar a Chandelure; cambiar a Chansey contador ; atraer a Arcanine; se queda ; Gengar +4 +2  usando x defensa",
-      "variant": []
-    },
-    {
-      "detail": "Se queda  ➜ Gengar +4 +2  usando x defensa",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Gengar  Otra Vez ; debilitar; cambiar a Chansey Amortiguador ; frente a Luxray cambiar a Chansey  y luego a Gengar",
-      "variant": []
-    },
-    {
-      "detail": "Luxray ➜ Gengar Otra Vez +4 no velo ; usar x2 defensa ; ( priorizar velocidad  +2 +0 +2 )",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo frente a Raichu. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/mismagius.json
+++ b/src/data/hoenn/fatima/mismagius.json
@@ -2,11 +2,20 @@
   "id": "mismagius",
   "name": "Mismagius",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas 🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lucario ➜ cambiar a Gengar  Otra Vez  debilitar ; cambiar a Chansey  Amortiguador ; frente a Luxray Gengar  Otra Vez  +4 no velo  usar x defensa ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/ninetales.json
+++ b/src/data/hoenn/fatima/ninetales.json
@@ -2,19 +2,16 @@
   "id": "ninetales",
   "name": "Ninetales",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz💡",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Lucario ➜ Gengar  Otra Vez ; Maquinación ",
-      "variant": []
-    },
-    {
-      "detail": "Permanecer  ➜ +2 Velocidad ; presionar hasta completar ; ( cuidado con Banda Focus  de Lucario )",
-      "variant": []
-    },
-    {
-      "detail": "Tropius ➜ Dragonite Otra Vez ; Danza Dragón x1 ; usar x ataque; / Danza Dragón x3 ; Garra Dragón  para Dusknoir; resistir a Lucario",
-      "variant": []
+      "detail": "Usa Amortiguador frente a Lucario y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/raichu.json
+++ b/src/data/hoenn/fatima/raichu.json
@@ -2,11 +2,16 @@
   "id": "raichu",
   "name": "Raichu",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla Luz💡",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Arcanine ➜ Gengar  Otra Vez ; bostezo manual +4 +2 +2 ; usar x defensa ",
-      "variant": []
+      "detail": "Cambia a Slowbro frente a Arcanine y usa Bostezo frente a Raichu.",
+      "variant": [
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/regice.json
+++ b/src/data/hoenn/fatima/regice.json
@@ -2,11 +2,20 @@
   "id": "regice",
   "name": "Regice",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨(chandelure banda focus y lucario pañuelo)",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lucario ➜ cambiar a Chandelure; +2 +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Para ahorrar objetos, puedes subir a Maquinación hasta +6 con Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/rotom_agua.json
+++ b/src/data/hoenn/fatima/rotom_agua.json
@@ -2,23 +2,24 @@
   "id": "rotom_agua",
   "name": "Rotom Agua",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz💡",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Politoed ➜ Dragonite usar x defensa ; Danza Dragón x1  usar x ataque si hay poca vida usar Máxima Poción",
-      "variant": []
-    },
-    {
-      "detail": "Permanecer  ➜ cambiar a Dragonite",
-      "variant": []
-    },
-    {
-      "detail": "Mawile ➜ Terremoto ",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir ➜ cambiar a Jirachi; Dragonite Otra Vez ; Danza Dragón x3",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Rotom Agua se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hydreigon, usa Teletransporte. Si Hydreigon permanece, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Mawile, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/sableye.json
+++ b/src/data/hoenn/fatima/sableye.json
@@ -2,11 +2,20 @@
   "id": "sableye",
   "name": "Sableye",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Tramparocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lucario ➜ cambiar a Chandelure;  +2  +2 ; Tiene Pañuelo ; Poder Oculto Hielo  para Hydreigon",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Para ahorrar objetos, puedes subir a Maquinación hasta +6 con Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/umbreon.json
+++ b/src/data/hoenn/fatima/umbreon.json
@@ -2,11 +2,24 @@
   "id": "umbreon",
   "name": "Umbreon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡PantallaLuz Amortiguador 💡 ",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Politoed  ➜ Dragonite usar x defensa ; Danza Dragón x1  usar x ataque ; si los PS son bajos , usar Máxima Poción ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Umbreon se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hydreigon, usa Teletransporte. Si Hydreigon permanece, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Mawile, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Rewrites the Hoenn Fatima strategy files with clearer and more consistent Spanish instructions.
- Normalizes old shorthand boost notation into explicit actions.
- Keeps the existing JSON structure intact: `id`, `name`, `image`, `initialMove`, `tricks`, and `variant`.

## Scope
Only files under `src/data/hoenn/fatima` are updated.

## Validation
- Confirmed the branch is 0 commits behind `develop`.
- Confirmed the PR only touches 20 Hoenn Fatima JSON files.
- Checked for common old shorthand residues like `+2 +2`, `+4 +2`, and `TrampaRocas`.

## Notes
- No visual assets are changed.
- No `main` or deploy changes are included in this PR.