### PR TITLE
Update Hoenn Dracon strategies

### DIFF
--- a/src/data/hoenn/dracon/aggron.json
+++ b/src/data/hoenn/dracon/aggron.json
@@ -2,11 +2,20 @@
   "id": "aggron",
   "name": "Aggron",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Contador💡",
+  "initialMove": "💡 Encanto + Amortiguador 💡",
   "tricks": [
     {
-      "detail": "Gallade ➜ cambiar a Jirachi; cambiar a Gengar  Otra Vez +4  0 Velocidad ; luego Otra Vez  sacrificio Banda Focus  para Gallade / Chansey ; si los HP son bajos  se puede entrar a golpear; jugada arriesgada  puede cambiar directamente a Gengar",
-      "variant": []
+      "detail": "Usa Encanto y luego Amortiguador para estabilizar el combate.",
+      "variant": [
+        {
+          "detail": "Frente a Gallade, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Gallade tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/altaria.json
+++ b/src/data/hoenn/dracon/altaria.json
@@ -2,15 +2,20 @@
   "id": "altaria",
   "name": "Altaria",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Uso de movimiento Fuego  ➜ cambiar a Chandelure; cambiar a Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Gengar Otra Vez  +4 0 Velocidad ; cambiar a (run to) Altaria o Lapras para continuar fortaleciendo ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar y usa Maquinación hasta +4.",
+          "variant": []
+        },
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/ampharos.json
+++ b/src/data/hoenn/dracon/ampharos.json
@@ -2,31 +2,33 @@
   "id": "ampharos",
   "name": "Ampharos",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Feraligatr ➜ contador ; verificar quién entra después",
-      "variant": []
-    },
-    {
-      "detail": "Salamence / Sceptile ➜ cambiar a Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Haxorus ➜ Amortiguador ; cambiar a Gengar  Otra Vez ; +4  +2 ; si baja la defensa  permanecer; ( usar Banda Focus  contra Haxorus)",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Gengar ",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta  ➜ Gengar x especial +2 Velocidad ; NO usar Otra Vez ; si no hay golpe crítico  no es amenaza; mantener estabilidad y usar X Velocidad",
-      "variant": []
-    },
-    {
-      "detail": "A Bocajarro  ➜ Gengar  Otra Vez  +4 0 Velocidad ; cambiar a  Ampharos / Altaria; luego usar Maquinación  una vez",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Haxorus, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Ataca hasta que aparezca Lucario. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Gengar para revisar el movimiento.",
+          "variant": [
+            {
+              "detail": "Patada Salto Alta: puedes arriesgar usando Maquinación y barrer directo, o jugar seguro cambiando a Slowbro, luego a Chansey y volver a Gengar.",
+              "variant": []
+            },
+            {
+              "detail": "A Bocajarro: Gengar usa Maquinación hasta +4 y barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile. Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/eelektross.json
+++ b/src/data/hoenn/dracon/eelektross.json
@@ -2,23 +2,20 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨 (gallade Banda focus)",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Fuerza Bruta  ➜ Amortiguador  frente a Gallade ; cambiar a Gengar  Otra Vez  +4  0 Velocidad ; (tiene banda focus  Gallade) ",
-      "variant": []
-    },
-    {
-      "detail": "Puño Drenaje  ➜ Gengar  Otra Vez ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Lapras ➜ Rayo  frente a Nidoking; Otra Vez   Chandelure +2 +2",
-      "variant": []
-    },
-    {
-      "detail": "Salamence ➜ Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa el movimiento rival.",
+      "variant": [
+        {
+          "detail": "Si usa Puño Drenaje, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Fuerza Bruta, mantén Amortiguador y espera a Gallade. Frente a Gallade, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Gallade tiene Banda Focus.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/empoleon.json
+++ b/src/data/hoenn/dracon/empoleon.json
@@ -2,15 +2,20 @@
   "id": "empoleon",
   "name": "Empoleon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gallade ➜ Gengar Otra Vez +6 +2 (banda focus gallade)",
-      "variant": []
-    },
-    {
-      "detail": "",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Gallade.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo frente a Empoleon.",
+          "variant": []
+        },
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/feraligatr.json
+++ b/src/data/hoenn/dracon/feraligatr.json
@@ -2,39 +2,28 @@
   "id": "feraligatr",
   "name": "Feraligatr",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Amortiguador💡",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gallade➜ Gengar  Otra Vez  +4 0 Velocidad; luego Otra Vez (banda focus Gallade)",
-      "variant": []
-    },
-    {
-      "detail": "Se queda  ➜ para observar movimiento ",
-      "variant": []
-    },
-    {
-      "detail": "Fuerza Bruta ➜ Amortiguador  esperar a Gallade ; Gengar  Otra Vez  +4 0 Velocidad ; luego Otra Vez  (sacrificio Banda Focus  Gallade) ",
-      "variant": []
-    },
-    {
-      "detail": "Cascada  ➜ Contador ",
-      "variant": []
-    },
-    {
-      "detail": "Gallade➜ cambiar a Jirachi; cambiar a Gengar Otra Vez  +4 0 Velocidad ; (luego Otra Vez  y mata a gallade tiene banda focus )",
-      "variant": []
-    },
-    {
-      "detail": "vs floatzel Mienshao ➜ Gengar  Otra Vez  +4 0 Velocidad ",
-      "variant": []
-    },
-    {
-      "detail": "Ampharos ➜ Gengar  Otra Vez ; cambiar a Jirachi frente a Sceptile; Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Vuelo violento  ➜ Jirachi Otra Vez (Encore); Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa el movimiento o cambio rival.",
+      "variant": [
+        {
+          "detail": "Si usa Cascada, usa Teletransporte hacia Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Triturar, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Sceptile, entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade o Roserade, sacrifica a Politoed. Luego Slowbro mantiene Bostezo frente a Salamence y usa Teletransporte para entrar con Poliwrath y usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/floatzel.json
+++ b/src/data/hoenn/dracon/floatzel.json
@@ -2,27 +2,20 @@
   "id": "floatzel",
   "name": "Floatzel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gallade ➜ cambiar a Gengar Otra Vez +6 +2  ; luego Otra Vez  Atacar +4; (notas Krookodile ; sacrificio Banda Focus para Gallade",
-      "variant": []
-    },
-    {
-      "detail": "Feraligatr ➜ Contador ",
-      "variant": []
-    },
-    {
-      "detail": "Sceptile ➜ Jirachi Otra Vez ; cambiar a Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Ampharos ➜ Jirachi Otra Vez  frente a Salamence; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Vuelo violento  ➜ Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Gallade, cambia a Slowbro y usa Bostezo frente a Empoleon. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile. Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/flygon.json
+++ b/src/data/hoenn/dracon/flygon.json
@@ -2,19 +2,20 @@
   "id": "flygon",
   "name": "Flygon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Metagross ➜ cambiar a Jirachi Otra Vez  Gallade +2  +2 )",
-      "variant": []
-    },
-    {
-      "detail": "Fijar Cabezazo Zen ➜ Protección ",
-      "variant": []
-    },
-    {
-      "detail": "Flygon ➜ Otra Vez (; Gallade +2 / Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Metagross.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo frente a Lapras.",
+          "variant": []
+        },
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/gallade.json
+++ b/src/data/hoenn/dracon/gallade.json
@@ -2,23 +2,24 @@
   "id": "gallade",
   "name": "Gallade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar💡",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Lucario ➜ cambiar a Chansey ; asegura Trampa rocas cambio a Gengar  Otra Vez  no ataque especial  +2 Velocidad ; (si no hay golpe crítico  no es amenaza",
-      "variant": []
-    },
-    {
-      "detail": "Se queda  ➜ Gengar  Otra Vez para observar velocidad ",
-      "variant": []
-    },
-    {
-      "detail": "Gallade Pañuelo elegido  ➜ Gengar  +2 +2 );(pañuelo)",
-      "variant": []
-    },
-    {
-      "detail": "Gallade Banda Focus ➜ Gengar Otra Vez  +6 +2  + Otra Vez",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa la ruta rival.",
+      "variant": [
+        {
+          "detail": "Si usa Espada Santa, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Mantén Otra Vez cuando sea necesario. Gallade tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, Gengar usa Maquinación. Cuando entre Haxorus, cambia a Chansey y luego vuelve a Gengar. Usa Otra Vez y Maquinación hasta +4. Haxorus tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Haxorus, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Mantén Otra Vez cuando sea necesario. Haxorus tiene Banda Focus.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/haxorus.json
+++ b/src/data/hoenn/dracon/haxorus.json
@@ -2,20 +2,16 @@
   "id": "haxorus",
   "name": "Haxorus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "NO CAMBIA → Usar Truco para bloquear con Avalancha, luego sacar a Scrafty +3. Si por error queda bloqueado en Garra Dragón, dejarlo caer y entrar con Excadrill +2+2. / Priorizar el movimiento de mayor potencia.",
+      "detail": "Cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
       "variant": [
         {
-          "detail": "Si Excadrill muere por un golpe crítico de Garra Dragón → Sacar a Metagross para revivir a Excadrill (entra Ampharos), luego usar Excadrill +4+2.",
+          "detail": "Barre con Bola Sombra.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Contra Lucario en campo → Sacar a Scrafty con +3. / Paliza para debilitar a Haxorus con Banda Focus.",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/dracon/kingdra.json
+++ b/src/data/hoenn/dracon/kingdra.json
@@ -2,11 +2,20 @@
   "id": "kingdra",
   "name": "Kingdra",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz💡",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Gallade ➜ cambiar a Gengar  Otra Vez  +4 0 Velocidad ; luego Otra Vez y ataca (gallade Banda focus) ",
-      "variant": []
+      "detail": "Usa Amortiguador frente a Gallade.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Gallade tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/krookodile.json
+++ b/src/data/hoenn/dracon/krookodile.json
@@ -2,6 +2,20 @@
   "id": "krookodile",
   "name": "Krookodile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 Chandelure 2+ 2+",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Usa ataques súper eficaces para avanzar la ruta.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/dracon/lapras.json
+++ b/src/data/hoenn/dracon/lapras.json
@@ -2,31 +2,41 @@
   "id": "lapras",
   "name": "Lapras",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨 (Lapras Se queda Usa Amortiguador)",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lucario ➜ cambiar a Gengar  para observar movimiento ",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta ➜ Gengar (ghost) +2 0 Velocidad ; NO usar Otra Vez (pañuelo elegido)",
-      "variant": []
-    },
-    {
-      "detail": "A Bocajarro (close combat) ➜ Gengar (ghost) Otra Vez  +4 0 Velocidad  cambiar a  Altaria; continuar con Maquinación",
-      "variant": []
-    },
-    {
-      "detail": "Eelektross / Pillar ➜ Gengar  Otra Vez  +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Metagross ➜ cambiar a Chandelure para debilitar; frente a Flygon, cambiar a Dragonite  y luego a Jirachi Otra Vez ; Gallade +2 +2 ; (si Chandelure tiene PS bajos  puede cambiar directamente a Jirachi Otra Vez (",
-      "variant": []
-    },
-    {
-      "detail": "Haxorus ➜ Amortiguador ; Gengar  Otra Vez  +4 no velo ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Lapras se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Lucario, cambia a Gengar para revisar el movimiento.",
+          "variant": [
+            {
+              "detail": "A Bocajarro: Gengar usa Maquinación hasta +4 y barre con Bola Sombra.",
+              "variant": []
+            },
+            {
+              "detail": "Patada Salto Alta: puedes arriesgar usando Maquinación y barrer directo, aunque la ruta puede ser aleatoria contra Lapras. La ruta segura es cambiar a Slowbro, luego a Chansey y volver a Gengar.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Haxorus, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Ataca hasta que aparezca Lucario, luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario directamente, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross o Regice, cambia a Slowbro y usa Bostezo frente a Nidoking. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/lucario.json
+++ b/src/data/hoenn/dracon/lucario.json
@@ -2,27 +2,24 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Cambia a Gengar 👻",
   "tricks": [
     {
-      "detail": "ESFERA AURAL / A BOCAJARRO → Usa Truco para bloquear en Pulso Umbrío o Triturar, luego entra Scrafty +3. // Paliza contra Ampharos // en caso de parálisis salamence/metagross no te matan usar antiparalisis",
-      "variant": []
-    },
-    {
-      "detail": "PATADA SALTO ALTA → Usa Truco y espera a que se debilite solo; luego entra Lapras, después Poliwrath 6+2. / Haxorus banda Focus, no es pregriloso",
-      "variant": []
-    },
-    {
-      "detail": "SACRIFICIO → Usa Truco para intercambiar objetos, luego entra Scrafty +3. Previsto para enfrentarse a Haxorus con Banda Focus.",
-      "variant": []
-    },
-    {
-      "detail": "METAGROSS → Usa Truco para bloquear en Terremoto, luego entra Excadrill 2+2 y coloca Trampa Rocas.",
-      "variant": []
-    },
-    {
-      "detail": "FLYGON → Usa Truco para bloquear en Terremoto, luego entra Excadrill 2+2 y coloca Trampa Rocas. Si haces Danza Espada y entra Lapras, luego Poliwrath 6+2. Previsto para Lucario con Banda Focus.",
-      "variant": []
+      "detail": "Cambia a Gengar y revisa el movimiento de Lucario.",
+      "variant": [
+        {
+          "detail": "Si usa A Bocajarro, Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Lapras. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Patada Salto Alta, Gengar usa Maquinación y Lucario se debilita solo. Frente a Haxorus, cambia a Chansey y luego vuelve a Gengar. Usa Otra Vez y Maquinación hasta +4. Haxorus tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y luego a Chansey frente a Lapras. Coloca Trampa Rocas frente a Metagross, vuelve a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/metagross.json
+++ b/src/data/hoenn/dracon/metagross.json
@@ -2,54 +2,45 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto → Ver objeto:",
+      "detail": "Coloca Trampa Rocas. Si Metagross se queda, revisa la situación.",
       "variant": [
         {
-          "detail": "Pañuelo Elegido → Excadrill 4+2",
+          "detail": "Si tiene Vidasfera y sube su Ataque, Chansey usa Teletransporte hacia Volcarona. Volcarona usa Lanzallamas. Frente a Flygon, Slowbro usa Bostezo; luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Vidasfera → Excadrill 2+2 y luego colocar Trampa Rocas",
-          "variant": []
-        },
-        {
-          "detail": "Cinta Xperto → Excadrill 4+2 y luego colocar Trampa Rocas",
+          "detail": "En otras situaciones, cambia a Slowbro y usa Bostezo.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Puño Meteoro → Usa un Puño Trueno para debilitarlo un poco, luego cambia a Chandelure y usa Lanzallamas para debilitarlo. Ver qué entra después:",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Si entra Feraligatr → Poliwrath 6 + Raíz Grande +2, usar Carámbano para derrotar a Salamence",
+          "detail": "Si sale Lapras o Nidoking, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si entra Floatzel → Cambia a Poliwrath, luego a Chandelure para usar Truco",
-          "variant": [
-            {
-              "detail": "Si hace HidroBomba → Poliwrath 6+2",
-              "variant": []
-            },
-            {
-              "detail": "Si hace Triturar → Scrafty 3, usar Carámbano para derrotar a Salamence",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Ampharos → Cambia a Scrafty, luego a Chandelure y usa Truco para bloquear en Poder Oculto (tipo Roca), luego entra Scrafty +3",
-              "variant": []
-            }
-          ]
-        }       
+          "detail": "Si sale Salamence, usa Protección y Bostezo frente a Nidoking. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross o Regice, cambia a Slowbro y usa Bostezo. Frente a Nidoking, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Gengar y usa Maquinación hasta +4. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile. Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
+          "variant": []
+        }
       ]
-    },
-    {
-      "detail": "Ampharos → Excadrill 4+2 // Si cambia a Metagross, no importa, sigue con Danza Espada",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/dracon/nidoking.json
+++ b/src/data/hoenn/dracon/nidoking.json
@@ -2,11 +2,20 @@
   "id": "nidoking",
   "name": "Nidoking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Bloquea en Tierra Viva, luego entra Cloyster +6 // Usa Surf para derrotar a Regirock.",
-      "variant": []
+      "detail": "Usa Amortiguador frente a Eelektross.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        },
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/regirock.json
+++ b/src/data/hoenn/dracon/regirock.json
@@ -2,13 +2,17 @@
   "id": "regirock",
   "name": "Regirock",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "PANTALLA LUZ",
+  "initialMove": "👻 Cambia a Gengar 👻",
   "tricks": [
     {
-      "detail": "Puño drenaje/Elektross → Gengar Otra Vez 4+2",
+      "detail": "Cambia a Gengar y revisa la ruta rival.",
       "variant": [
         {
-          "detail": "Salamence/Pull comun → Gengar pushea hasta metagross luego cambia a Dragonite +3 (No Otra Vez)",
+          "detail": "Si usa Puño Drenaje, Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross, cambia a Chansey y luego vuelve a Gengar. Usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/dracon/salamence.json
+++ b/src/data/hoenn/dracon/salamence.json
@@ -2,139 +2,51 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "OBSERVA SI TIENE INTIMIDACIÓN",
+  "initialMove": "🔔 Revisa si tiene Intimidación 🔔",
   "tricks": [
     {
-      "detail": "Tiene intimidación → Cambia a Chandelure.",
+      "detail": "Si tiene Intimidación, usa Amortiguador y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Si no se retira, lanza un Poder Oculto.",
-          "variant": [
-            {
-              "detail": "Si lo derrota al 100%, observa quién entra después:",
-              "variant": [
-                {
-                  "detail": "Aggron → Excadrill coloca Trampa Rocas, luego usa Terremoto para acabarlo. Si entra Feraligatr, Poliwrath entra con +2 +2. / Prioriza el movimiento de mayor potencia. Si Excadrill es debilitado, Chandelure lo revive, se sacrifica, y luego vuelve a entrar Excadrill para rematar.",
-                  "variant": []
-                },
-                {
-                  "detail": "Regirock → Cambia a Scrafty y luego a Chandelure, usa Truco para bloquear en Roca Afilada, Scrafty entra con +2. / Usa a Bocajarro para matar a Eelektross. Se puede aprovechar el +1 con Puño Drenaje para recuperar salud.",
-                  "variant": []
-                },
-                {
-                  "detail": "Metagross → Excadrill entra con +4 +2.",
-                  "variant": []
-                },
-                {
-                  "detail": "Feraligatr → Cambia a Poliwrath y luego a Chandelure para usar Truco y bloquear en Cascada, entra Poliwrath +6 +2. Si intenta pasar Velocidad: Poliwrath entra con +6 + Raíz Grande +2.",
-                  "variant": []
-                },
-                {
-                  "detail": "Floatzel → Cambia a Poliwrath, luego a Chandelure y usa Truco.",
-                  "variant": [
-                    {
-                      "detail": "Si usa Hidrobomba, entra Poliwrath +6 +2.",
-                      "variant": []
-                    },
-                    {
-                      "detail": "Si usa Triturar, entra Scrafty +3. / Usa Puño Drenaje para matar a Metagross.",
-                      "variant": []
-                    }        
-                  ]
-                }
-              ]
-            },
-            {
-              "detail": "Si baja al 90% aprox. → Cambia a Metagross y usa Truco para bloquear en Llamarada, entra Poliwrath +6 +2. Si por error queda bloqueado en Metagross, Chandelure lo quema con Lanzallamas, y si entra Feraligatr o Floatzel, Poliwrath +6 + Raíz Energía +2.",
-              "variant": []
-            },
-            {
-              "detail": "Si baja al 60%–73% aprox., cambia a Metagross y observa a quién enfrenta:",
-              "variant": [
-                {
-                  "detail": "Contra Empoleon → Lanza un Puño Trueno.",
-                  "variant": [
-                    {
-                      "detail": "Si entra Krokodile, Excadrill entra con Trampa Rocas +4 +2.",
-                      "variant": []
-                    },
-                    {
-                      "detail": "Si no se retira, inflige gran daño (entra NO SE ENTIENDE), Excadrill entra con Trampa Rocas +4 +2.",
-                      "variant": []
-                    }
-                  ]
-                },
-                {
-                  "detail": "Contra Eelektross → Usa Puño Trueno, si entra Krookodile, Excadrill entra con Trampa Rocas +4 +2. Si Eelektross no se retira, sigue usando Puño Trueno.",
-                  "variant": []
-                }
-              ]
-            }   
-          ]
-        },
-        {
-          "detail": "Contra Aggron → Excadrill coloca Trampa Rocas, luego usa Terremoto para debilitar. Si luego entra Feraligatr, entra Poliwrath con +2 +2. / Prioriza el movimiento de mayor potencia. // Si Excadrill es derrotado, usa Chandelure para revivir a Excadrill, déjalo caer y vuelve a meter a Excadrill para rematar.",
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile. Luego entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X. Mantén los PS por encima del 75%.",
           "variant": []
         },
         {
-          "detail": "Contra Krookodile → Excadrill +4 +2, luego vuelve a colocar Trampa Rocas.",
+          "detail": "Si sale Gallade, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Gallade tiene Banda Focus.",
           "variant": []
         },
         {
-          "detail": "Contra Regirock → Chandelure usa Truco para bloquear en Roca Afilada, luego entra Scrafty.",
+          "detail": "Si sale Eelektross o Regice, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
           "variant": []
         }
       ]
-    },       
-    
+    },
     {
-      "detail": "NO Tiene intimidación → Truco",
+      "detail": "Si no tiene Intimidación, coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Si usa Llamarada → Verifica el objeto:",
+          "detail": "Si sale Lucario, cambia a Gengar y revisa el movimiento.",
           "variant": [
             {
-              "detail": "Si lleva Banda Focus o Vidasfera → Chandelure usa Truco para intercambiar objeto, luego entra Cloyster +6.",
+              "detail": "A Bocajarro: Gengar usa Maquinación hasta +4 y barre con Bola Sombra.",
               "variant": []
             },
             {
-              "detail": "Si lleva Pañuelo Elegido → Cambia a Chandelure y observa el movimiento.",
-              "variant": [
-                {
-                  "detail": "Si usa Llamarada → Chandelure hace Truco para intercambiar objeto, luego Excadrill Trampa rocas con 2 +2. Si entra Lapras, entra Poliwrath +6 +2.",
-                  "variant": []
-                },
-                {
-                  "detail": "Si usa Terremoto → Excadrill entra con 2 +2. Si entra Lapras, entra Poliwrath +6 +2.",
-                  "variant": []
-                },
-                {
-                  "detail": "Si usa Garra Dragón → Excadrill toma una Medicina de Defensa, luego entra con 2 +2.",
-                  "variant": []
-                }
-              ]
-            }
-          ]
-        },     
-        {
-          "detail": "Si usa Terremoto → Revisa el objeto:",
-          "variant": [
-            {
-              "detail": "Si lleva Pañuelo Elegido → Excadrill entra con 2 +2. / Si entra Lapras, luego entra Poliwrath +6 +2. Si Excadrill es golpeado con Garra Dragón, usa Medicina de Defensa, y entra con 2 +2.",
-              "variant": []
-            },
-            {
-              "detail": "Si lleva Banda Focus o Vidasfera → Cloyster entra con +6 (Metagross no muere de carámbano Cuidado).",
+              "detail": "Patada Salto Alta: puedes arriesgar usando Maquinación y barrer directo, aunque la ruta puede ser aleatoria contra Lapras. La ruta segura es cambiar a Slowbro, luego a Chansey y volver a Gengar.",
               "variant": []
             }
           ]
-        },        
+        },
         {
-          "detail": "Contra Lucario → Chandelure usa Truco para cambiar objeto, Scrafty entra con +3. / Usa Pulso Umbrío para matar a Haxorus.",
+          "detail": "Si sale Haxorus, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Ataca hasta que aparezca Lucario. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos. Lucario tiene Pañuelo Elegido.",
           "variant": []
         },
         {
-          "detail": "Contra Metagross → Excadrill entra con +4 +2 y luego coloca Trampa Rocas.",
+          "detail": "Si sale Lucario directamente, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo frente a Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Si Metagross se queda, sigue usando Bostezo.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/dracon/sceptile.json
+++ b/src/data/hoenn/dracon/sceptile.json
@@ -2,46 +2,20 @@
   "id": "sceptile",
   "name": "Sceptile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Ampharos → Excadrill +4 Ataque +2 Velocidad. Si sale Metagross, no hace falta cambiar; continúa boosteando.",
-      "variant": []
-    },
-    {
-      "detail": "Metagross → Chandelure usa Lanzallamas para debilitar y observa quién entra:",
+      "detail": "Cambia a Slowbro frente a Feraligatr y usa Bostezo frente a Sceptile.",
       "variant": [
         {
-          "detail": "Feraligatr → Poliwrath +6 Ataque con Raíz Energía +2 Velocidad.",
+          "detail": "Luego entra con Volcarona, usa Danza Aleteo x2 y Especial X.",
           "variant": []
         },
         {
-          "detail": "Floatzel → Cambia a Poliwrath y luego a Chandelure para usar Truco:",
-          "variant": [
-            {
-              "detail": "Hidrobomba, Poliwrath +6 Ataque +2 Velocidad.",
-              "variant": []
-            },
-            {
-              "detail": "Triturar, Scrafty +3.",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "Poder Oculto → Depende:",
-      "variant": [
-        {
-          "detail": "Económico → Scrafty +4. / Dos Puño Drenaje para matar a Metagross.",
-          "variant": []
-        },
-        {
-          "detail": "Velocidad → Poliwrath 6 +2. / Ten en cuenta que Sceptile es más rápido que Poliwrath +2, si tiene poca vida, recuerda curarlo.",
+          "detail": "Mantén los PS de Volcarona por encima del 75%.",
           "variant": []
         }
       ]
-    }    
+    }
   ]
 }

--- a/src/data/hoenn/dracon/seviper.json
+++ b/src/data/hoenn/dracon/seviper.json
@@ -2,24 +2,20 @@
   "id": "seviper",
   "name": "Seviper",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Flygon → Metagross coloca Trampa Rocas, luego entra Cloyster con +6. Si Metagross no logra colocar las rocas, revisa la siguiente situación.",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Si Metagross cae por un golpe crítico → entra Excadrill con +2 +2, coloca Trampa Rocas. Si mientras Danza Espada, entra Lapras; después entra Poliwrath con +6 +2. ( Lucario con Banda Focus).",
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo frente a Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade, cambia a Slowbro y usa Bostezo frente a Empoleon. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Krookodile → Excadrill con +4 +2 y luego coloca Trampa Rocas.",
-      "variant": []
-    },
-    {
-      "detail": "Metagross → Excadrill Trampa Rocas y 2+2.",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/dracon/torkoal.json
+++ b/src/data/hoenn/dracon/torkoal.json
@@ -2,19 +2,20 @@
   "id": "torkoal",
   "name": "Torkoal",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A JIRACHI",
+  "initialMove": "💡 Encanto 💡",
   "tricks": [
     {
-      "detail": "Gallade → Gengar +2 (No Otra Vez)",
+      "detail": "Usa Encanto. Si quieres arriesgar, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
-    }, 
+    },
     {
-      "detail": "Fuerza Bruta → Chandelure 2+2",
-      "variant": []
-    },  
-    {
-      "detail": "Salamence → Otra Vez y Saca a chandelure 2+2",
-      "variant": []
+      "detail": "Si usa Fuerza Bruta, usa Amortiguador y espera a Gallade o Roserade.",
+      "variant": [
+        {
+          "detail": "Frente a Gallade, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. No uses Otra Vez.",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Rewrites the Hoenn Dracon strategy files with clearer and more consistent Spanish instructions.
- Normalizes old shorthand boost notation into explicit actions.
- Keeps the existing JSON structure intact: `id`, `name`, `image`, `initialMove`, `tricks`, and `variant`.

## Scope
Only files under `src/data/hoenn/dracon` are updated.

## Validation
- Confirmed the branch is 0 commits behind `develop`.
- Confirmed the PR only touches 21 Hoenn Dracon JSON files.
- Checked for common old shorthand residues like `+2 +2`, `4+2`, `TrampaRocas`, and `matalo`.

## Notes
- No visual assets are changed.
- No `main` or deploy changes are included in this PR.