### PR TITLE
Update Hoenn Plubio strategies

### DIFF
--- a/src/data/hoenn/plubio/altaria.json
+++ b/src/data/hoenn/plubio/altaria.json
@@ -2,28 +2,24 @@
   "id": "altaria",
   "name": "Altaria",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Swampert → Cambiar a Excadrill y luego a Chandelure, al enfrentarse a Gyarados usar Truco para bloquear Cascada, luego entra Poliwrath con +6+2. También puedes usar A Bocajarro para eliminar a Milotic // Eelektross Levitación. Si Chandelure ha caído y Poliwrath tiene al menos 75% de PS, entra Scrafty, luego cambia a Poliwrath para boostear.",
-      "variant": []
-    },
-    {
-      "detail": "Registeel → Cambiar a Scrafty y observar el movimiento.",
+      "detail": "Usa Amortiguador frente a Eelektross.",
       "variant": [
         {
-          "detail": "Si usa Terremoto, entra Scrafty con +2, puedes usar Puño Drenaje más Paliza para derrotar a Milotic.",
+          "detail": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Altaria.",
           "variant": []
         },
         {
-          "detail": "TERREMOTO CON RESTOS, Scrafty +1 + Raíz Energía + Píldora de Ataque / A Bocajarro para Milotic",
+          "detail": "Cambia a Chansey y espera a Eelektross. Usa Teletransporte hacia Slowbro y vuelve a usar Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Registeel → Sacrificar a Metagross, luego entra Poliwrath con +6 y curación con Raíz Energía, luego subir +2 Velocidad. Puedes usar A Bocajarro para matar a Milotic.",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/plubio/dragonite.json
+++ b/src/data/hoenn/plubio/dragonite.json
@@ -2,11 +2,16 @@
   "id": "dragonite",
   "name": "Dragonite",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💕 Encanto 💕",
   "tricks": [
     {
-      "detail": "Bloquea Puño Fuego, luego cambia a Chandelure y vuelve a usar Truco para bloquear a Milotic o Wailord, después entra Poliwrath con +6+2.",
-      "variant": []
+      "detail": "Usa Encanto para bajar el daño de Dragonite.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/eelektross.json
+++ b/src/data/hoenn/plubio/eelektross.json
@@ -2,48 +2,64 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lanzallamas → Truco para observar el movimiento del rival.",
+      "detail": "Coloca Trampa Rocas. Si usa Fuerza Bruta, Gengar usa Otra Vez y luego cambia a Slowbro.",
       "variant": [
         {
-          "detail": "Voltio Cruel → Se cambia a Excadrill con +6+0.",
+          "detail": "Si Milotic tiene Restos, usa Bostezo. Frente a Serperior, usa Protección y luego Bostezo otra vez. Después sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Rayo → Se entra con Excadrill Trampa Roca con +2+2.",
+          "detail": "Si Milotic no tiene Restos, usa Bostezo. Si usa Escaldar, sigue usando Bostezo hasta forzar la ruta.",
           "variant": []
         },
         {
-          "detail": "Voltiocambio y entra Starmie → Se cambia a Metagross y se usa Truco.",
-          "variant": [
-            {
-              "detail": "Si el rival usa Hidrobomba, entra Poliwrath con +6+2. // Si luego del Tambor aparece Eelektross, se continúa con Excadrill con +2+2.",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Registeel o el rival usa Rayo, entra Excadrill con +2+2.",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Voltiocambio y entra Milotic → Entra Poliwrath con +6+2.",
+          "detail": "Si Milotic usa Poder Oculto Eléctrico, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },   
-    {
-      "detail": "Puño Fuego → Se usa Truco para bloquear Voltio Cruel, luego entra Excadrill con +6+2.",
-      "variant": []
     },
     {
-      "detail": "Milotic → Se usa Truco para bloquear Escaldar y entra Poliwrath con +6+2. Puede usarse A Bocajarro para vencer a Sealeo o Milotic, sin necesidad de gastar Carámbano.",
-      "variant": []
+      "detail": "Rutas por cambio rival:",
+      "variant": [
+        {
+          "detail": "Si sale Serperior, usa Protección y luego Bostezo frente a Eelektross. Después sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Altaria, usa Protección y Bostezo. Frente a Eelektross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Swampert, usa Bostezo frente a Altaria. Cambia a Chansey para atraer a Eelektross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gardevoir, usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar y usa Otra Vez. Frente a Milotic, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Mienshao permite la ruta de Serperior, cambia a Slowbro y usa Bostezo contra Serperior. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, la ruta estable es cambiar a Slowbro y usar Bostezo. La ruta directa es sacrificar a Politoed y entrar con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Metagross → Se usa Truco para bloquear Avalancha, luego entra Scrafty con +3. Puede usarse A Bocajarro para vencer a Milotic, y también se puede recuperar PS usando Puño Drenaje desde +2.",
+      "detail": "Si Gengar atrapa a Eelektross en un ataque eléctrico, cambia a Chansey y usa Max Poción. Luego cambia a Slowbro y usa Bostezo frente a Altaria. Usa Chansey para atraer a Eelektross, Teletransporte hacia Slowbro, Bostezo, sacrificio de Politoed y Poliwrath con Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/plubio/empoleon.json
+++ b/src/data/hoenn/plubio/empoleon.json
@@ -2,59 +2,37 @@
   "id": "empoleon",
   "name": "Empoleon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto → Se cambia a Chandelure. //Si Metagross cae por un golpe crítico de Terremoto, se asume por defecto que Empoleon no se retira, así que se cambia directamente a Excadrill con +4+2.",
+      "detail": "Coloca Trampa Rocas y revisa el movimiento de Empoleon.",
       "variant": [
         {
-          "detail": "Empoleon no se retira, se entra igual con Excadrill +4+2.",
+          "detail": "Si usa Terremoto, cambia a Slowbro y usa Bostezo frente a Roserade. Luego entra con Volcarona y usa Danza Aleteo x3. Antes de barrer, mantén los PS por encima del 70%.",
           "variant": []
         },
         {
-          "detail": "Whiscash, se usa Truco. Si responde con Terremoto, entra Excadrill con +4+2. Si responde con Milotic, entra Poliwrath con +6+2.",
-          "variant": []
-        }
-      ]
-    },   
-    {
-      "detail": "Escaldar → Se cambia a Chandelure. Chandelure utiliza Truco para bloquear Escaldar, se cambia directamente a Poliwrath con +6+2.",
-      "variant": [
-        {
-          "detail": "Lanturn, se usa Truco para bloquear Escaldar y entra Poliwrath con +6+2.",
+          "detail": "Si usa Cascada, cambia a Slowbro y usa Bostezo frente a Roserade. Luego usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y presiona hasta Milotic. Frente a Milotic, usa Danza Aleteo una vez más y presiónalo dos veces. Si Milotic hace crítico, cura primero al máximo.",
           "variant": []
         },
         {
-          "detail": "Lanturn no se retira, igualmente se entra con Poliwrath +6+2 sin necesidad",
+          "detail": "Si usa Escaldar, cambia a Slowbro. Si Empoleon se queda, usa Bostezo frente a Roserade y entra con Volcarona para usar Danza Aleteo x4. Puedes usar Especial X.",
           "variant": []
         }
       ]
-    },   
-    {
-      "detail": "Whiscash → Se entra con Excadrill +4+2.",
-      "variant": []
     },
     {
-      "detail": "Milotic → Se entra con Poliwrath +6+2. Se puede usar A Bocajarro para derrotar a Milotic.",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Togekiss tras Tambor → Usar A Bocajarro para debilitarlo. Si luego entra un tipo veneno y no se puede continuar, se cambia a Scrafty para observar el movimiento:",
-          "variant": [
-            {
-              "detail": "Psicocarga, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Bomba Lodo, se cambia a Excadrill con +4+2.",
-              "variant": []
-            }
-          ]
+          "detail": "Si sale Milotic, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Roserade, usa Teletransporte para revisar movimiento. Si usa movimiento de Planta, Volcarona usa Danza Aleteo x4. Si usa movimiento de Veneno, Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
         }
       ]
-    },  
-    {
-      "detail": "Lanturn → Se entra con Poliwrath con +6+2. Si usa Rayo, se cambia a Excadrill entra con +4+2.",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/plubio/gardevoir.json
+++ b/src/data/hoenn/plubio/gardevoir.json
@@ -2,58 +2,35 @@
   "id": "gardevoir",
   "name": "Gardevoir",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Whiscash o Lanturn, usa Excadrill +4+2. Si por sorpresa recibe Escaldar, entra Poliwrath +6+2. Puede usar A Bocajarro para eliminar a Milotic.",
-      "variant": []
-    },
-    {
-      "detail": "Milotic, usa Poliwrath +6+2. (Primero Tambor) Puede usar A Bocajarro para eliminar a Milotic.",
+      "detail": "Coloca Trampa Rocas y revisa el objeto o movimiento de Gardevoir.",
       "variant": [
         {
-          "detail": "Si el rival cambia a Togekiss después del Tambor, usa A Bocajarro para eliminarlo. Luego si aparece Roserade, cambia a Scrafty y observa el movimiento:",
-          "variant": [
-            {
-              "detail": "Si usa Psíquico, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Si lanza Bomba Lodo, entra Excadrill +4+2.",
-              "variant": []
-            }
-          ]
-        }        
-      ]
-    },
-    {
-      "detail": "Registeel, coloca Trampa Rocas y luego entra Excadrill +2+2.",
-      "variant": []
-    },
-    {
-      "detail": "Bola Sombra, entra Scrafty +3.",
-      "variant": []
-    },
-    {
-      "detail": "Esfera Aural, cambia a Chandelure y utiliza Truco",
-      "variant": [
-        {
-          "detail": "Si Gardevoir no se retira, entra Scrafty +3.",
+          "detail": "Si tiene Vidasfera y usa Psicocarga, usa Teletransporte hacia Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si aparece Milotic, entra Poliwrath +6+2 // Si el rival cambia a Togekiss después del Tambor, usa A Bocajarro para eliminarlo. Luego si aparece Vileplume, cambia a Scrafty y observa el movimiento:",
-          "variant": [
-            {
-              "detail": "Si usa Psíquico, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Si lanza Bomba Lodo, entra Excadrill +4+2.",
-              "variant": []
-            }
-          ]
-        }        
+          "detail": "Si no tiene Vidasfera y usa Psicocarga, usa Teletransporte hacia Gengar y deja que Gengar caiga usando un movimiento.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Whiscash, la ruta segura es Slowbro con Bostezo frente a Roserade, sacrificio de Politoed y Poliwrath con Tambor hasta +6 Ataque. La ruta arriesgada es sacrificar a Politoed directo y entrar con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Milotic, Slowbro usa Bostezo frente a Roserade. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Togekiss, usa Onda Certera y sacrifica a Gengar. Slowbro usa Defensa Especial X y Bostezo frente a Roserade. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross, Gengar usa Otra Vez. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
       ]
     }
   ]

--- a/src/data/hoenn/plubio/gyarados.json
+++ b/src/data/hoenn/plubio/gyarados.json
@@ -2,24 +2,24 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "CASCADA, entra Poliwrath +6+2. Luego, usa A Bocajarro para eliminar a Milotic",
-      "variant": []
-    },
-    {
-      "detail": "REGISTEEL, cambia a Scrafty y observa el movimiento.",
+      "detail": "Usa Amortiguador frente a Eelektross.",
       "variant": [
         {
-          "detail": "TERREMOTO, Scrafty +2; luego puedes usar Puño Drenaje seguido de Paliza para vencer a Milotic",
+          "detail": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Altaria.",
           "variant": []
         },
         {
-          "detail": "MOV. SÍSMICO, haz Scrafty +1, luego usa Raíz Energía para recuperar y aplica Medicina de Ataque. Después, usa A Bocajarro para eliminar a Milotic",
+          "detail": "Cambia a Chansey y espera a Eelektross. Usa Teletransporte hacia Slowbro y vuelve a usar Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    }    
+    }
   ]
 }

--- a/src/data/hoenn/plubio/lanturn.json
+++ b/src/data/hoenn/plubio/lanturn.json
@@ -2,65 +2,52 @@
   "id": "lanturn",
   "name": "Lanturn",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Registeel, entra Excadrill +4+2",
-      "variant": []
-    },
-    {
-      "detail": "Milotic, entra Poliwrath +6+2. Puede usar A Bocajarro para eliminar a Milotic.",
+      "detail": "Usa Amortiguador. Si Lanturn se queda, aguanta con Defensa Especial X y usa Amortiguador dos veces.",
       "variant": [
         {
-          "detail": "Si el rival cambia a Togekiss después del Tambor, usa A Bocajarro para eliminarlo. Luego si aparece Vileplume, cambia a Scrafty y observa el movimiento:",
+          "detail": "Si Lanturn sigue en campo, usa Teletransporte hacia Gengar y ataca con Bola Sombra para revisar el daño.",
           "variant": [
             {
-              "detail": "Si usa Psíquico, Scrafty +3",
+              "detail": "Si Bola Sombra hace más del 40% de daño, sacrifica a Politoed. Luego Slowbro usa Bostezo, Teletransporte y entra Poliwrath para usar Tambor hasta +6 Ataque.",
               "variant": []
             },
             {
-              "detail": "Si lanza Bomba Lodo, entra Excadrill +4+2",
+              "detail": "Si Bola Sombra hace menos del 35% de daño, Gengar usa Maquinación. Si Gengar no cae, derrota con Bola Sombra y reinicia la ruta con Chansey si sale Togekiss o Roserade. Si Gengar cae, entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75% antes de barrer.",
               "variant": []
             }
           ]
-        }        
+        }
       ]
     },
     {
-      "detail": "Ludicolo, entra Poliwrath +6+2.",
-      "variant": []
-    },
-    {
-      "detail": "Rayo, entra Excadrill +4+2. Luego usa Terremoto para eliminar a Ludicolo / Roserade.",
-      "variant": []
-    },
-    {
-      "detail": "Casco Dentado + Escaldar, entra Poliwrath +6+2.",
-      "variant": []
-    },
-    {
-      "detail": "Baya Ziuela + Escaldar, entra Poliwrath +6+2. Puede usar A Bocajarro para eliminar a Milotic.",
-      "variant": []
-    },
-    {
-      "detail": "Restos + Escaldar, observa si Escaldar causa quemadura o golpe crítico:",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Si causa quemadura o crítico, entra Poliwrath +6+2.",
+          "detail": "Si sale Dragonite, usa Encanto, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si no hay quemadura ni crítico, cambia a Chandelure y observa:",
-          "variant": [
-            {
-              "detail": "Si Lanturn no se retira, entra Poliwrath +6+2",
-              "variant": []
-            },
-            {
-              "detail": "Si aparece Registeel, entra Excadrill +4+2",
-              "variant": []
-            }
-          ]
+          "detail": "Si sale Regice o Registeel, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Milotic, usa Teletransporte hacia Slowbro y Bostezo frente a Roserade. Luego entra con Volcarona y usa Danza Aleteo x4.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Empoleon, cambia a Slowbro y usa Bostezo frente a Roserade. Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 70%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gardevoir, usa Teletransporte hacia Slowbro y Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Roserade, usa Teletransporte para revisar el movimiento. Si usa movimiento de Planta, Volcarona usa Danza Aleteo x4. Si usa movimiento de Veneno, Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
         }
       ]
     }

--- a/src/data/hoenn/plubio/ludicolo.json
+++ b/src/data/hoenn/plubio/ludicolo.json
@@ -2,11 +2,16 @@
   "id": "ludicolo",
   "name": "Ludicolo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Bloquea Hidrobomba, luego entra Poliwrath +6+2.",
-      "variant": []
+      "detail": "Usa Teletransporte hacia Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/metagross.json
+++ b/src/data/hoenn/plubio/metagross.json
@@ -2,11 +2,16 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Chandelure y utiliza Truco para bloquear con Avalancha",
+  "initialMove": "🐸 Poliwrath 🐸",
   "tricks": [
     {
-      "detail": "Luego entra Scrafty +3. // Si aparece Milotic después, usa A Bocajarro para eliminarlo. Puedes aprovechar el +2 de Puño Drenaje para recuperar PS.",
-      "variant": []
+      "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "variant": [
+        {
+          "detail": "Si Poliwrath cae, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/mienshao.json
+++ b/src/data/hoenn/plubio/mienshao.json
@@ -2,11 +2,16 @@
   "id": "mienshao",
   "name": "Mienshao",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Bloquea a Registeel, Luego entra Excadrill +2+2.",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Serperior.",
+      "variant": [
+        {
+          "detail": "Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/milotic.json
+++ b/src/data/hoenn/plubio/milotic.json
@@ -2,78 +2,68 @@
   "id": "milotic",
   "name": "Milotic",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "GAFAS ELEGIDAS, entra Poliwrath +6+2.",
+      "detail": "Usa Amortiguador y revisa el movimiento o cambio rival.",
       "variant": [
         {
-          "detail": "Gardevoir hace un golpe crítico que derrota a Poliwrath, cambia a Chandelure y usa Truco para bloquear, luego entra Scrafty +3. // Si después entra Registeel, usa A Bocajarro para eliminarlo.",
+          "detail": "Si usa Surf o Hidrobomba, usa Teletransporte hacia Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Roserade, entra con Volcarona y usa Danza Aleteo x4.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Ludicolo o usa Rayo Hielo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Escaldar, usa Teletransporte hacia Slowbro y usa Bostezo. Si Milotic no cambia, sigue usando Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Serperior, usa Protección y Bostezo hasta que salga Lanturn. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gardevoir, Metagross, Regice, Registeel o Eelektross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "CASCO DENTADO, entra Poliwrath +6+2. Usa A Bocajarro para eliminar a Walrein o Milotic",
+      "detail": "Rutas de Roserade y Empoleon:",
       "variant": [
         {
-          "detail": "Si el rival cambia a Togekiss después del Tambor, usa a Bocajarro para eliminarlo. Luego si aparece Roserade, cambia a Scrafty y observa el movimiento:",
-          "variant": [
-            {
-              "detail": "Si usa Psíquico, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Si lanza Bomba Lodo, entra Excadrill +4+2",
-              "variant": []
-            }
-          ]
-        },        
-        {
-          "detail": "Si entra Gyarados tras el Tambor, cambia a Chandelure y usa Truco para bloquear Cascada.",
-          "variant": [
-            {
-              "detail": "Si Chandelure cae, cambia a Metagross, usa objeto curativo fuerte en Poliwrath, y luego entra Poliwrath +6+2",
-              "variant": []
-            },
-            {
-              "detail": "Si Chandelure sobrevive, cura a Poliwrath, cambia a Scrafty y luego a Poliwrath +6+2",
-              "variant": []
-            }
-          ]
-        }       
-      ]
-    },
-    {
-      "detail": "REGISTEEL, revisa su objeto:",
-      "variant": [
-        {
-          "detail": "Cinta Experto: entra Excadrill +4+2",
+          "detail": "Si sale Roserade, usa Teletransporte y revisa el objeto. Con Vidasfera, Volcarona usa Danza Aleteo x1 y Especial X. Sin Vidasfera, Volcarona usa Danza Aleteo x2 y Especial X. Mantén los PS por encima del 70%.",
           "variant": []
         },
         {
-          "detail": "Baya Atania: entra Excadrill con Trampa Rocas puesta +2+2",
-          "variant": []
-        },
-        {
-          "detail": "Gafas Elegidas: entra Excadrill +2+2",
+          "detail": "Si sale Empoleon, coloca Trampa Rocas para revisar el movimiento. Contra Cascada, Slowbro usa Bostezo frente a Roserade, Teletransporte hacia Volcarona y Danza Aleteo x1. Contra Terremoto, Slowbro usa Bostezo hasta Roserade y luego Volcarona usa Danza Aleteo x3.",
           "variant": []
         }
       ]
-    },    
-    {
-      "detail": "METAGROSS, usa Chandelure con Lanzallamas para debilitarlo. Luego si entra Whiscash o Milotic, entra Poliwrath +6+2. Usa A Bocajarro para derrotar a Milotic o Walrein. // Si se congela utiliza Cura Total",
-      "variant": []
     },
     {
-      "detail": "Whiscash o Lanturn, entra Excadrill +4+2. // Si recibe escaldado por sorpresa, entra Poliwrath +6+2. Usa A Bocajarro para eliminar a Milotic.",
-      "variant": []
-    },
-    {
-      "detail": "Swampert, cambia a Excadrill y luego a Chandelure. Entra Gyarados, usa Truco para bloquear Cascada. Entra Poliwrath +6+2. Usa A Bocajarro para eliminar a Milotic.",
+      "detail": "Rutas especiales:",
       "variant": [
         {
-          "detail": "Si Chandelure fue debilitado y Poliwrath tiene 75% de salud, cambia a Scrafty y luego entra Poliwrath para potenciarse.",
+          "detail": "Si sale Mienshao, cambia a Slowbro y usa Bostezo frente a Serperior. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Dragonite, usa Encanto, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Whiscash, usa Encanto, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque, Raíz Grande y Velocidad X.",
+          "variant": []
+        },
+        {
+          "detail": "Si Poliwrath cae por crítico, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/plubio/registeel.json
+++ b/src/data/hoenn/plubio/registeel.json
@@ -2,39 +2,35 @@
   "id": "registeel",
   "name": "Registeel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa Truco para observar el movimiento",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto, revisa el objeto:",
+      "detail": "Coloca Trampa Rocas. Si Registeel se queda, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez y luego cambia a Slowbro. Frente a Milotic o Swampert, usa Bostezo. Si Milotic se queda usando Escaldar, sigue usando Bostezo.",
       "variant": [
         {
-          "detail": "Restos: Scrafty +3 y usa A Bocajarro para eliminar a Milotic.",
-          "variant": []
-        },
-        {
-          "detail": "Cinta Experto: entra Excadrill +4+2",
-          "variant": []
-        },
-        {
-          "detail": "Gafas elegidas: entra Excadrill +4+2",
-          "variant": []
-        },
-        {
-          "detail": "Baya Ziuela: entra Excadrill con Trampa Rocas puesta +2+2",
+          "detail": "Si usa Poder Oculto Eléctrico, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },    
+    },
     {
-      "detail": "Aura Sphere: cambia a Chandelure y usa Truco para bloquear a Milotic. Luego entra Poliwrath +6+2",
+      "detail": "Si sale Altaria, cambia a Chansey para atraer a Eelektross. Usa Teletransporte hacia Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Rayo: entra Excadrill +2+2",
+      "detail": "Si sale Serperior, usa Protección y Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Movimiento Sísmico: entra Scrafty +1, usa Raíz Energía para recuperar salud y luego potenciador de ataque. Después usa a Bocajarro para eliminar a Milotic.",
+      "detail": "Si sale Gardevoir o Eelektross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Mienshao, cambia a Slowbro y usa Bostezo contra Serperior. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/plubio/roserade.json
+++ b/src/data/hoenn/plubio/roserade.json
@@ -2,27 +2,49 @@
   "id": "roserade",
   "name": "Roserade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Metagross: entra Chandelure y utiliza Lanzallamas para debilitarlo. Luego puede entrar Seaking o Milotic; en ambos casos entra Poliwrath +6+2. // Usa A Bocajarro para eliminar a Milotic o Walrein. // Si fuiste congelado, usa Cura Total.",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa el objeto y movimiento de Roserade.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidasfera y usa Lluevehojas o Bomba Lodo, usa Teletransporte hacia Slowbro, Bostezo y luego Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si no tiene Vidasfera y usa Lluevehojas, usa Teletransporte. Si Roserade se queda, entra con Volcarona y usa Danza Aleteo x4. Mantén los PS por encima del 70%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gardevoir o Milotic, Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si no tiene Vidasfera y usa Bomba Lodo, usa Teletransporte hacia Volcarona y debilita a Roserade. Revisa qué Pokémon entra después.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Milotic: entra Poliwrath +6+2 y usa A Bocajarro para derrotarlo",
-      "variant": []
-    },
-    {
-      "detail": "Eelektross: cambia a Chandelure frente a Milotic, utiliza Truco para bloquear Escaldar, luego entra Poliwrath +6+2 y usa A Bocajarro para eliminar a Milotic o Dewgong",
-      "variant": []
-    },
-    {
-      "detail": "Whiscash: entra Excadrill +4+2",
-      "variant": []
-    },
-    {
-      "detail": "Poder Oculto: entra Poliwrath +6+2 y usa A Bocajarro para eliminar a Milotic",
-      "variant": []
+      "detail": "Rutas posteriores a Roserade:",
+      "variant": [
+        {
+          "detail": "Si sale Milotic, cambia a Chansey para revisar movimiento. Contra Hidrobomba o Surf, usa Teletransporte hacia Slowbro y Bostezo frente a Ludicolo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Milotic usa Escaldar, cambia a Slowbro y usa Bostezo frente a Gardevoir. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Togekiss o Gardevoir, sacrifica a Volcarona. Slowbro aguanta con Defensa Especial X y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Si Poliwrath cae, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Usa Bola Sombra contra Seaking.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/seaking.json
+++ b/src/data/hoenn/plubio/seaking.json
@@ -2,19 +2,24 @@
   "id": "seaking",
   "name": "Seaking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🐸 Poliwrath 🐸",
   "tricks": [
     {
-      "detail": "Seaking no se retira o cambia a Milotic: entra Poliwrath +6+2 y usa A Bocajarro para derrotar a Dewgong o Milotic. // Si fuiste congelado, usa Cura Total.",
-      "variant": []
-    },
-    {
-      "detail": "Metagross: entra Chandelure y usa Lanzallamas para debilitarlo. Luego puede salir Seaking o Milotic; en ambos casos entra Poliwrath +6+2 y usa A Bocajarro para eliminar a Dewgong o Milotic. // Si fuiste congelado, usa Cura Total.",
-      "variant": []
-    },
-    {
-      "detail": "Eelektross: cambia a Chandelure contra Metagross, usa Lanzallamas para derrotarlo. Después si entra Seaking o Milotic, entra Poliwrath +6+2 y usa A Bocajarro para eliminar a Dewgong o Milotic. // Si fuiste congelado, usa Cura Total.",
-      "variant": []
+      "detail": "Cambia a Politoed y sacrifícalo.",
+      "variant": [
+        {
+          "detail": "Entra con Metagross y deja que caiga para abrir paso seguro.",
+          "variant": []
+        },
+        {
+          "detail": "Luego entra con Poliwrath y usa Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Poliwrath cae por crítico, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/serperior.json
+++ b/src/data/hoenn/plubio/serperior.json
@@ -2,50 +2,33 @@
   "id": "serperior",
   "name": "Serperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "REGISTEEL: observa el objeto.",
+      "detail": "Coloca Trampa Rocas y revisa si Serperior usa Lluevehojas.",
       "variant": [
         {
-          "detail": "Baya Zidra/Atania: coloca Trampa Rocas y entra Excadrill +4+2.",
+          "detail": "Si Lluevehojas deja a Serperior en +4 de Ataque Especial, usa Teletransporte hacia Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Cinta Experto: entra Excadrill +4+2.",
-          "variant": []
-        },
-        {
-          "detail": "GAFAS ELEGIDAS: entra Excadrill +2+2.",
+          "detail": "Si Lluevehojas deja a Serperior en +2 de Ataque Especial, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Poder Oculto: cambia a Chandelure.",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Si no se retira, usa Lanzallamas para derrotarlo. Luego, si entra Milotic o Wailord, entra Poliwrath +6+2.",
+          "detail": "Si sale Mienshao, cambia a Slowbro y usa Bostezo frente a Serperior. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
           "variant": []
         },
         {
-          "detail": "Si aparece Registeel frente a Chandelure: usa Truco.",
-          "variant": [
-            {
-              "detail": "Terremoto, entra Excadrill +4+2.",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Wailord, entra Poliwrath +6+4.",
-              "variant": []
-            }
-          ]
+          "detail": "Si sale Eelektross, Gengar usa Otra Vez. Luego cambia a Slowbro frente a Milotic y usa Bostezo. Después sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
         }
       ]
-    },
-    {
-      "detail": "Lluevehojas: usa Truco para recuperar el objeto, luego coloca Trampa Rocas y sacrifica al Pokémon. Después entra Chandelure y usa Lanzallamas para debilitarlo (si entra Milotic), entonces entra Poliwrath +6+2 (Falta probar)",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/plubio/starmie.json
+++ b/src/data/hoenn/plubio/starmie.json
@@ -2,11 +2,16 @@
   "id": "starmie",
   "name": "Starmie",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa Truco para bloquear a Registeel.",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Luego entra Excadrill +2+2.",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Serperior.",
+      "variant": [
+        {
+          "detail": "Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/swampert.json
+++ b/src/data/hoenn/plubio/swampert.json
@@ -2,6 +2,24 @@
   "id": "swampert",
   "name": "Swampert",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Truco para bloquear con Terremoto, luego cambia a Excadrill y después a Chandelure para enfrentar a Gyarados. Utiliza Truco nuevamente para bloquear Cascada, entra Poliwrath +6+2. // Usa A Bocajarro para eliminar a Milotic // Si Chandelure muere y Poliwrath tiene un 75% de PS, entra Scrafty, luego vuelve a cambiar a Poliwrath +6+2.",
-  "tricks": []
+  "initialMove": "🥚 Amortiguador 🥚",
+  "tricks": [
+    {
+      "detail": "Usa Amortiguador frente a Eelektross.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Altaria.",
+          "variant": []
+        },
+        {
+          "detail": "Cambia a Chansey y espera a Eelektross. Usa Teletransporte hacia Slowbro y vuelve a usar Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/tentacruel.json
+++ b/src/data/hoenn/plubio/tentacruel.json
@@ -2,11 +2,20 @@
   "id": "tentacruel",
   "name": "Tentacruel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Truco para bloquear a Registeel,",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Entra Excadrill +2 +2 + Trampa Rocas",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si sale Eelektross.",
+      "variant": [
+        {
+          "detail": "Si sale Eelektross, Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Milotic.",
+          "variant": []
+        },
+        {
+          "detail": "Después sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/togekiss.json
+++ b/src/data/hoenn/plubio/togekiss.json
@@ -2,42 +2,45 @@
   "id": "togekiss",
   "name": "Togekiss",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Teletransporte 💡",
   "tricks": [
     {
-      "detail": "Lanzallamas → Observa el objeto",
+      "detail": "Usa Teletransporte y revisa el daño recibido por Chansey.",
       "variant": [
         {
-          "detail": "Gafas Elegid. → Cambia a Chandelure y usa Truco. Luego envía a Poliwrath, potencia +6 Ataque y +2 Velocidad. ( Togekiss inesperadamente se queda en el combate, cambia a Metagross para sacrificarlo, y después envía nuevamente a Chandelure para usar Truco otra vez.) (No es necesario gastar Gema Hielo)",
+          "detail": "Si falla el cambio, revisa el daño. Si no hay golpe, compara con la ruta de Roserade con Vidasfera para confirmar el equipo rival.",
           "variant": []
         },
         {
-          "detail": "Restos → Puño Trueno y sacrifica",
-          "variant": [
-            {
-              "detail": "Scrafty, usa una Defensa Especial X + 3 Danza Dragón. / A Bocajarro para Milotic",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "ESFERA AURAL, cambia a Chandelure y usa Truco:",
-      "variant": [
-        {
-          "detail": "Vidasfera, sigue con Excadrill +4+2",
+          "detail": "Si el golpe a Chansey hace menos del 15%, envía a Slowbro, usa Defensa Especial X y Bostezo frente a Roserade. Luego usa Teletransporte hacia Volcarona y usa Danza Aleteo x4. Mantén los PS por encima del 70%.",
           "variant": []
         },
         {
-          "detail": "Restos, entra Poliwrath +6+2",
+          "detail": "Si el golpe a Chansey hace más del 15%, envía a Slowbro, usa Defensa Especial X y Bostezo frente a Roserade. Luego usa Teletransporte hacia Volcarona, Danza Aleteo x1 y Especial X.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "LANTURN O WHISCASH, entra Excadrill +4+2. Si cae por Escaldar inesperado, entra Poliwrath +6+2 // Usa A Bocajarro para eliminar a Milotic",
-      "variant": []
+      "detail": "Si usa Poder Oculto, revisa el daño.",
+      "variant": [
+        {
+          "detail": "Si el golpe a Chansey hace menos del 20%, Gengar usa Otra Vez. Luego cambia a Slowbro frente a Milotic y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si es Poder Oculto Eléctrico, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Roserade, Volcarona usa Danza Aleteo x4. Antes de barrer, mantén los PS por encima del 70%.",
+          "variant": []
+        },
+        {
+          "detail": "Si el golpe a Chansey hace más del 20%, envía a Slowbro, usa Bostezo frente a Roserade y Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/wailord.json
+++ b/src/data/hoenn/plubio/wailord.json
@@ -2,14 +2,10 @@
   "id": "wailord",
   "name": "Wailord",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🐸 Poliwrath 🐸",
   "tricks": [
     {
-      "detail": "Registeel, entra Excadrill +4+2.",
-      "variant": []
-    },
-    {
-      "detail": "Terremoto, cambia a Chandelure para enfrentarlo, utiliza Truco para bloquearlo con Terremoto y luego entra Excadrill +4+2.",
+      "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/plubio/walrein.json
+++ b/src/data/hoenn/plubio/walrein.json
@@ -2,15 +2,24 @@
   "id": "walrein",
   "name": "Walrein",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🐸 Poliwrath 🐸",
   "tricks": [
     {
-      "detail": "Metagross, cambia a Chandelure y usa Lanzallamas para debilitarlo. Si luego entra Seaking o Milotic, entra Poliwrath +6+2 // Usa A Bocajarro para eliminar a Milotic o Dewgong. // Si Poliwrath resulta congelado, utiliza Curación Total para recuperarlo.",
-      "variant": []
-    },
-    {
-      "detail": "Milotic, entra Poliwrath +6+2 // Usa A Bocajarro para eliminar a Milotic o Dewgong.",
-      "variant": []
+      "detail": "Cambia a Politoed y sacrifícalo.",
+      "variant": [
+        {
+          "detail": "Entra con Metagross y deja que caiga para abrir paso seguro.",
+          "variant": []
+        },
+        {
+          "detail": "Luego entra con Poliwrath y usa Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Poliwrath cae por crítico, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/whiscash.json
+++ b/src/data/hoenn/plubio/whiscash.json
@@ -2,6 +2,20 @@
   "id": "whiscash",
   "name": "Whiscash",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Truco para bloquear Terremoto, Excadrill 4+2",
-  "tricks": []
+  "initialMove": "💡 Encanto 💡",
+  "tricks": [
+    {
+      "detail": "Usa Encanto para bajar el daño de Whiscash.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Raíz Grande y Velocidad X para +2 Velocidad antes de cerrar la ruta.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Rewrites the Hoenn Plubio strategy files with clearer and more consistent Spanish instructions.
- Normalizes old shorthand boost notation into explicit actions.
- Keeps the existing JSON structure intact: `id`, `name`, `image`, `initialMove`, `tricks`, and `variant`.

## Scope
Only files under `src/data/hoenn/plubio` are updated.

## Validation
- Confirmed the branch is 0 commits behind `develop`.
- Confirmed the PR only touches 22 Hoenn Plubio JSON files.
- Checked for common old shorthand residues like `+6+2`, `4+2`, `TrampaRocas`, and `sapito`.

## Notes
- No visual assets are changed.
- No `main` or deploy changes are included in this PR.