### PR TITLE
Release Hoenn strategy updates

### DIFF
--- a/src/data/hoenn/dracon/aggron.json
+++ b/src/data/hoenn/dracon/aggron.json
@@ -2,11 +2,20 @@
   "id": "aggron",
   "name": "Aggron",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Contador💡",
+  "initialMove": "💡 Encanto + Amortiguador 💡",
   "tricks": [
     {
-      "detail": "Gallade ➜ cambiar a Jirachi; cambiar a Gengar  Otra Vez +4  0 Velocidad ; luego Otra Vez  sacrificio Banda Focus  para Gallade / Chansey ; si los HP son bajos  se puede entrar a golpear; jugada arriesgada  puede cambiar directamente a Gengar",
-      "variant": []
+      "detail": "Usa Encanto y luego Amortiguador para estabilizar el combate.",
+      "variant": [
+        {
+          "detail": "Frente a Gallade, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Gallade tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/altaria.json
+++ b/src/data/hoenn/dracon/altaria.json
@@ -2,15 +2,20 @@
   "id": "altaria",
   "name": "Altaria",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Uso de movimiento Fuego  ➜ cambiar a Chandelure; cambiar a Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Gengar Otra Vez  +4 0 Velocidad ; cambiar a (run to) Altaria o Lapras para continuar fortaleciendo ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar y usa Maquinación hasta +4.",
+          "variant": []
+        },
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/ampharos.json
+++ b/src/data/hoenn/dracon/ampharos.json
@@ -2,31 +2,33 @@
   "id": "ampharos",
   "name": "Ampharos",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Feraligatr ➜ contador ; verificar quién entra después",
-      "variant": []
-    },
-    {
-      "detail": "Salamence / Sceptile ➜ cambiar a Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Haxorus ➜ Amortiguador ; cambiar a Gengar  Otra Vez ; +4  +2 ; si baja la defensa  permanecer; ( usar Banda Focus  contra Haxorus)",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Gengar ",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta  ➜ Gengar x especial +2 Velocidad ; NO usar Otra Vez ; si no hay golpe crítico  no es amenaza; mantener estabilidad y usar X Velocidad",
-      "variant": []
-    },
-    {
-      "detail": "A Bocajarro  ➜ Gengar  Otra Vez  +4 0 Velocidad ; cambiar a  Ampharos / Altaria; luego usar Maquinación  una vez",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Haxorus, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Ataca hasta que aparezca Lucario. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Gengar para revisar el movimiento.",
+          "variant": [
+            {
+              "detail": "Patada Salto Alta: puedes arriesgar usando Maquinación y barrer directo, o jugar seguro cambiando a Slowbro, luego a Chansey y volver a Gengar.",
+              "variant": []
+            },
+            {
+              "detail": "A Bocajarro: Gengar usa Maquinación hasta +4 y barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile. Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/eelektross.json
+++ b/src/data/hoenn/dracon/eelektross.json
@@ -2,23 +2,20 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨 (gallade Banda focus)",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Fuerza Bruta  ➜ Amortiguador  frente a Gallade ; cambiar a Gengar  Otra Vez  +4  0 Velocidad ; (tiene banda focus  Gallade) ",
-      "variant": []
-    },
-    {
-      "detail": "Puño Drenaje  ➜ Gengar  Otra Vez ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Lapras ➜ Rayo  frente a Nidoking; Otra Vez   Chandelure +2 +2",
-      "variant": []
-    },
-    {
-      "detail": "Salamence ➜ Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa el movimiento rival.",
+      "variant": [
+        {
+          "detail": "Si usa Puño Drenaje, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Fuerza Bruta, mantén Amortiguador y espera a Gallade. Frente a Gallade, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Gallade tiene Banda Focus.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/empoleon.json
+++ b/src/data/hoenn/dracon/empoleon.json
@@ -2,15 +2,20 @@
   "id": "empoleon",
   "name": "Empoleon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gallade ➜ Gengar Otra Vez +6 +2 (banda focus gallade)",
-      "variant": []
-    },
-    {
-      "detail": "",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Gallade.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo frente a Empoleon.",
+          "variant": []
+        },
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/feraligatr.json
+++ b/src/data/hoenn/dracon/feraligatr.json
@@ -2,39 +2,28 @@
   "id": "feraligatr",
   "name": "Feraligatr",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Amortiguador💡",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gallade➜ Gengar  Otra Vez  +4 0 Velocidad; luego Otra Vez (banda focus Gallade)",
-      "variant": []
-    },
-    {
-      "detail": "Se queda  ➜ para observar movimiento ",
-      "variant": []
-    },
-    {
-      "detail": "Fuerza Bruta ➜ Amortiguador  esperar a Gallade ; Gengar  Otra Vez  +4 0 Velocidad ; luego Otra Vez  (sacrificio Banda Focus  Gallade) ",
-      "variant": []
-    },
-    {
-      "detail": "Cascada  ➜ Contador ",
-      "variant": []
-    },
-    {
-      "detail": "Gallade➜ cambiar a Jirachi; cambiar a Gengar Otra Vez  +4 0 Velocidad ; (luego Otra Vez  y mata a gallade tiene banda focus )",
-      "variant": []
-    },
-    {
-      "detail": "vs floatzel Mienshao ➜ Gengar  Otra Vez  +4 0 Velocidad ",
-      "variant": []
-    },
-    {
-      "detail": "Ampharos ➜ Gengar  Otra Vez ; cambiar a Jirachi frente a Sceptile; Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Vuelo violento  ➜ Jirachi Otra Vez (Encore); Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa el movimiento o cambio rival.",
+      "variant": [
+        {
+          "detail": "Si usa Cascada, usa Teletransporte hacia Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Triturar, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Sceptile, entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade o Roserade, sacrifica a Politoed. Luego Slowbro mantiene Bostezo frente a Salamence y usa Teletransporte para entrar con Poliwrath y usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/floatzel.json
+++ b/src/data/hoenn/dracon/floatzel.json
@@ -2,27 +2,20 @@
   "id": "floatzel",
   "name": "Floatzel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gallade ➜ cambiar a Gengar Otra Vez +6 +2  ; luego Otra Vez  Atacar +4; (notas Krookodile ; sacrificio Banda Focus para Gallade",
-      "variant": []
-    },
-    {
-      "detail": "Feraligatr ➜ Contador ",
-      "variant": []
-    },
-    {
-      "detail": "Sceptile ➜ Jirachi Otra Vez ; cambiar a Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Ampharos ➜ Jirachi Otra Vez  frente a Salamence; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Vuelo violento  ➜ Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Gallade, cambia a Slowbro y usa Bostezo frente a Empoleon. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile. Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/flygon.json
+++ b/src/data/hoenn/dracon/flygon.json
@@ -2,19 +2,20 @@
   "id": "flygon",
   "name": "Flygon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Metagross ➜ cambiar a Jirachi Otra Vez  Gallade +2  +2 )",
-      "variant": []
-    },
-    {
-      "detail": "Fijar Cabezazo Zen ➜ Protección ",
-      "variant": []
-    },
-    {
-      "detail": "Flygon ➜ Otra Vez (; Gallade +2 / Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Metagross.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo frente a Lapras.",
+          "variant": []
+        },
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/gallade.json
+++ b/src/data/hoenn/dracon/gallade.json
@@ -2,23 +2,24 @@
   "id": "gallade",
   "name": "Gallade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar💡",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Lucario ➜ cambiar a Chansey ; asegura Trampa rocas cambio a Gengar  Otra Vez  no ataque especial  +2 Velocidad ; (si no hay golpe crítico  no es amenaza",
-      "variant": []
-    },
-    {
-      "detail": "Se queda  ➜ Gengar  Otra Vez para observar velocidad ",
-      "variant": []
-    },
-    {
-      "detail": "Gallade Pañuelo elegido  ➜ Gengar  +2 +2 );(pañuelo)",
-      "variant": []
-    },
-    {
-      "detail": "Gallade Banda Focus ➜ Gengar Otra Vez  +6 +2  + Otra Vez",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa la ruta rival.",
+      "variant": [
+        {
+          "detail": "Si usa Espada Santa, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Mantén Otra Vez cuando sea necesario. Gallade tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, Gengar usa Maquinación. Cuando entre Haxorus, cambia a Chansey y luego vuelve a Gengar. Usa Otra Vez y Maquinación hasta +4. Haxorus tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Haxorus, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Mantén Otra Vez cuando sea necesario. Haxorus tiene Banda Focus.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/haxorus.json
+++ b/src/data/hoenn/dracon/haxorus.json
@@ -2,20 +2,16 @@
   "id": "haxorus",
   "name": "Haxorus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "NO CAMBIA → Usar Truco para bloquear con Avalancha, luego sacar a Scrafty +3. Si por error queda bloqueado en Garra Dragón, dejarlo caer y entrar con Excadrill +2+2. / Priorizar el movimiento de mayor potencia.",
+      "detail": "Cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
       "variant": [
         {
-          "detail": "Si Excadrill muere por un golpe crítico de Garra Dragón → Sacar a Metagross para revivir a Excadrill (entra Ampharos), luego usar Excadrill +4+2.",
+          "detail": "Barre con Bola Sombra.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Contra Lucario en campo → Sacar a Scrafty con +3. / Paliza para debilitar a Haxorus con Banda Focus.",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/dracon/kingdra.json
+++ b/src/data/hoenn/dracon/kingdra.json
@@ -2,11 +2,20 @@
   "id": "kingdra",
   "name": "Kingdra",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz💡",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Gallade ➜ cambiar a Gengar  Otra Vez  +4 0 Velocidad ; luego Otra Vez y ataca (gallade Banda focus) ",
-      "variant": []
+      "detail": "Usa Amortiguador frente a Gallade.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Gallade tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/krookodile.json
+++ b/src/data/hoenn/dracon/krookodile.json
@@ -2,6 +2,20 @@
   "id": "krookodile",
   "name": "Krookodile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 Chandelure 2+ 2+",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Usa ataques súper eficaces para avanzar la ruta.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/dracon/lapras.json
+++ b/src/data/hoenn/dracon/lapras.json
@@ -2,31 +2,41 @@
   "id": "lapras",
   "name": "Lapras",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨 (Lapras Se queda Usa Amortiguador)",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lucario ➜ cambiar a Gengar  para observar movimiento ",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta ➜ Gengar (ghost) +2 0 Velocidad ; NO usar Otra Vez (pañuelo elegido)",
-      "variant": []
-    },
-    {
-      "detail": "A Bocajarro (close combat) ➜ Gengar (ghost) Otra Vez  +4 0 Velocidad  cambiar a  Altaria; continuar con Maquinación",
-      "variant": []
-    },
-    {
-      "detail": "Eelektross / Pillar ➜ Gengar  Otra Vez  +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Metagross ➜ cambiar a Chandelure para debilitar; frente a Flygon, cambiar a Dragonite  y luego a Jirachi Otra Vez ; Gallade +2 +2 ; (si Chandelure tiene PS bajos  puede cambiar directamente a Jirachi Otra Vez (",
-      "variant": []
-    },
-    {
-      "detail": "Haxorus ➜ Amortiguador ; Gengar  Otra Vez  +4 no velo ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Lapras se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Lucario, cambia a Gengar para revisar el movimiento.",
+          "variant": [
+            {
+              "detail": "A Bocajarro: Gengar usa Maquinación hasta +4 y barre con Bola Sombra.",
+              "variant": []
+            },
+            {
+              "detail": "Patada Salto Alta: puedes arriesgar usando Maquinación y barrer directo, aunque la ruta puede ser aleatoria contra Lapras. La ruta segura es cambiar a Slowbro, luego a Chansey y volver a Gengar.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Haxorus, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Ataca hasta que aparezca Lucario, luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario directamente, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross o Regice, cambia a Slowbro y usa Bostezo frente a Nidoking. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/lucario.json
+++ b/src/data/hoenn/dracon/lucario.json
@@ -2,27 +2,24 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Cambia a Gengar 👻",
   "tricks": [
     {
-      "detail": "ESFERA AURAL / A BOCAJARRO → Usa Truco para bloquear en Pulso Umbrío o Triturar, luego entra Scrafty +3. // Paliza contra Ampharos // en caso de parálisis salamence/metagross no te matan usar antiparalisis",
-      "variant": []
-    },
-    {
-      "detail": "PATADA SALTO ALTA → Usa Truco y espera a que se debilite solo; luego entra Lapras, después Poliwrath 6+2. / Haxorus banda Focus, no es pregriloso",
-      "variant": []
-    },
-    {
-      "detail": "SACRIFICIO → Usa Truco para intercambiar objetos, luego entra Scrafty +3. Previsto para enfrentarse a Haxorus con Banda Focus.",
-      "variant": []
-    },
-    {
-      "detail": "METAGROSS → Usa Truco para bloquear en Terremoto, luego entra Excadrill 2+2 y coloca Trampa Rocas.",
-      "variant": []
-    },
-    {
-      "detail": "FLYGON → Usa Truco para bloquear en Terremoto, luego entra Excadrill 2+2 y coloca Trampa Rocas. Si haces Danza Espada y entra Lapras, luego Poliwrath 6+2. Previsto para Lucario con Banda Focus.",
-      "variant": []
+      "detail": "Cambia a Gengar y revisa el movimiento de Lucario.",
+      "variant": [
+        {
+          "detail": "Si usa A Bocajarro, Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Lapras. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Patada Salto Alta, Gengar usa Maquinación y Lucario se debilita solo. Frente a Haxorus, cambia a Chansey y luego vuelve a Gengar. Usa Otra Vez y Maquinación hasta +4. Haxorus tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y luego a Chansey frente a Lapras. Coloca Trampa Rocas frente a Metagross, vuelve a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/metagross.json
+++ b/src/data/hoenn/dracon/metagross.json
@@ -2,54 +2,45 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto → Ver objeto:",
+      "detail": "Coloca Trampa Rocas. Si Metagross se queda, revisa la situación.",
       "variant": [
         {
-          "detail": "Pañuelo Elegido → Excadrill 4+2",
+          "detail": "Si tiene Vidasfera y sube su Ataque, Chansey usa Teletransporte hacia Volcarona. Volcarona usa Lanzallamas. Frente a Flygon, Slowbro usa Bostezo; luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Vidasfera → Excadrill 2+2 y luego colocar Trampa Rocas",
-          "variant": []
-        },
-        {
-          "detail": "Cinta Xperto → Excadrill 4+2 y luego colocar Trampa Rocas",
+          "detail": "En otras situaciones, cambia a Slowbro y usa Bostezo.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Puño Meteoro → Usa un Puño Trueno para debilitarlo un poco, luego cambia a Chandelure y usa Lanzallamas para debilitarlo. Ver qué entra después:",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Si entra Feraligatr → Poliwrath 6 + Raíz Grande +2, usar Carámbano para derrotar a Salamence",
+          "detail": "Si sale Lapras o Nidoking, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si entra Floatzel → Cambia a Poliwrath, luego a Chandelure para usar Truco",
-          "variant": [
-            {
-              "detail": "Si hace HidroBomba → Poliwrath 6+2",
-              "variant": []
-            },
-            {
-              "detail": "Si hace Triturar → Scrafty 3, usar Carámbano para derrotar a Salamence",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Ampharos → Cambia a Scrafty, luego a Chandelure y usa Truco para bloquear en Poder Oculto (tipo Roca), luego entra Scrafty +3",
-              "variant": []
-            }
-          ]
-        }       
+          "detail": "Si sale Salamence, usa Protección y Bostezo frente a Nidoking. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross o Regice, cambia a Slowbro y usa Bostezo. Frente a Nidoking, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Gengar y usa Maquinación hasta +4. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile. Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
+          "variant": []
+        }
       ]
-    },
-    {
-      "detail": "Ampharos → Excadrill 4+2 // Si cambia a Metagross, no importa, sigue con Danza Espada",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/dracon/nidoking.json
+++ b/src/data/hoenn/dracon/nidoking.json
@@ -2,11 +2,20 @@
   "id": "nidoking",
   "name": "Nidoking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Bloquea en Tierra Viva, luego entra Cloyster +6 // Usa Surf para derrotar a Regirock.",
-      "variant": []
+      "detail": "Usa Amortiguador frente a Eelektross.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        },
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/regirock.json
+++ b/src/data/hoenn/dracon/regirock.json
@@ -2,13 +2,17 @@
   "id": "regirock",
   "name": "Regirock",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "PANTALLA LUZ",
+  "initialMove": "👻 Cambia a Gengar 👻",
   "tricks": [
     {
-      "detail": "Puño drenaje/Elektross → Gengar Otra Vez 4+2",
+      "detail": "Cambia a Gengar y revisa la ruta rival.",
       "variant": [
         {
-          "detail": "Salamence/Pull comun → Gengar pushea hasta metagross luego cambia a Dragonite +3 (No Otra Vez)",
+          "detail": "Si usa Puño Drenaje, Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross, cambia a Chansey y luego vuelve a Gengar. Usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/dracon/salamence.json
+++ b/src/data/hoenn/dracon/salamence.json
@@ -2,139 +2,51 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "OBSERVA SI TIENE INTIMIDACIÓN",
+  "initialMove": "🔔 Revisa si tiene Intimidación 🔔",
   "tricks": [
     {
-      "detail": "Tiene intimidación → Cambia a Chandelure.",
+      "detail": "Si tiene Intimidación, usa Amortiguador y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Si no se retira, lanza un Poder Oculto.",
-          "variant": [
-            {
-              "detail": "Si lo derrota al 100%, observa quién entra después:",
-              "variant": [
-                {
-                  "detail": "Aggron → Excadrill coloca Trampa Rocas, luego usa Terremoto para acabarlo. Si entra Feraligatr, Poliwrath entra con +2 +2. / Prioriza el movimiento de mayor potencia. Si Excadrill es debilitado, Chandelure lo revive, se sacrifica, y luego vuelve a entrar Excadrill para rematar.",
-                  "variant": []
-                },
-                {
-                  "detail": "Regirock → Cambia a Scrafty y luego a Chandelure, usa Truco para bloquear en Roca Afilada, Scrafty entra con +2. / Usa a Bocajarro para matar a Eelektross. Se puede aprovechar el +1 con Puño Drenaje para recuperar salud.",
-                  "variant": []
-                },
-                {
-                  "detail": "Metagross → Excadrill entra con +4 +2.",
-                  "variant": []
-                },
-                {
-                  "detail": "Feraligatr → Cambia a Poliwrath y luego a Chandelure para usar Truco y bloquear en Cascada, entra Poliwrath +6 +2. Si intenta pasar Velocidad: Poliwrath entra con +6 + Raíz Grande +2.",
-                  "variant": []
-                },
-                {
-                  "detail": "Floatzel → Cambia a Poliwrath, luego a Chandelure y usa Truco.",
-                  "variant": [
-                    {
-                      "detail": "Si usa Hidrobomba, entra Poliwrath +6 +2.",
-                      "variant": []
-                    },
-                    {
-                      "detail": "Si usa Triturar, entra Scrafty +3. / Usa Puño Drenaje para matar a Metagross.",
-                      "variant": []
-                    }        
-                  ]
-                }
-              ]
-            },
-            {
-              "detail": "Si baja al 90% aprox. → Cambia a Metagross y usa Truco para bloquear en Llamarada, entra Poliwrath +6 +2. Si por error queda bloqueado en Metagross, Chandelure lo quema con Lanzallamas, y si entra Feraligatr o Floatzel, Poliwrath +6 + Raíz Energía +2.",
-              "variant": []
-            },
-            {
-              "detail": "Si baja al 60%–73% aprox., cambia a Metagross y observa a quién enfrenta:",
-              "variant": [
-                {
-                  "detail": "Contra Empoleon → Lanza un Puño Trueno.",
-                  "variant": [
-                    {
-                      "detail": "Si entra Krokodile, Excadrill entra con Trampa Rocas +4 +2.",
-                      "variant": []
-                    },
-                    {
-                      "detail": "Si no se retira, inflige gran daño (entra NO SE ENTIENDE), Excadrill entra con Trampa Rocas +4 +2.",
-                      "variant": []
-                    }
-                  ]
-                },
-                {
-                  "detail": "Contra Eelektross → Usa Puño Trueno, si entra Krookodile, Excadrill entra con Trampa Rocas +4 +2. Si Eelektross no se retira, sigue usando Puño Trueno.",
-                  "variant": []
-                }
-              ]
-            }   
-          ]
-        },
-        {
-          "detail": "Contra Aggron → Excadrill coloca Trampa Rocas, luego usa Terremoto para debilitar. Si luego entra Feraligatr, entra Poliwrath con +2 +2. / Prioriza el movimiento de mayor potencia. // Si Excadrill es derrotado, usa Chandelure para revivir a Excadrill, déjalo caer y vuelve a meter a Excadrill para rematar.",
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile. Luego entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X. Mantén los PS por encima del 75%.",
           "variant": []
         },
         {
-          "detail": "Contra Krookodile → Excadrill +4 +2, luego vuelve a colocar Trampa Rocas.",
+          "detail": "Si sale Gallade, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Gallade tiene Banda Focus.",
           "variant": []
         },
         {
-          "detail": "Contra Regirock → Chandelure usa Truco para bloquear en Roca Afilada, luego entra Scrafty.",
+          "detail": "Si sale Eelektross o Regice, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
           "variant": []
         }
       ]
-    },       
-    
+    },
     {
-      "detail": "NO Tiene intimidación → Truco",
+      "detail": "Si no tiene Intimidación, coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Si usa Llamarada → Verifica el objeto:",
+          "detail": "Si sale Lucario, cambia a Gengar y revisa el movimiento.",
           "variant": [
             {
-              "detail": "Si lleva Banda Focus o Vidasfera → Chandelure usa Truco para intercambiar objeto, luego entra Cloyster +6.",
+              "detail": "A Bocajarro: Gengar usa Maquinación hasta +4 y barre con Bola Sombra.",
               "variant": []
             },
             {
-              "detail": "Si lleva Pañuelo Elegido → Cambia a Chandelure y observa el movimiento.",
-              "variant": [
-                {
-                  "detail": "Si usa Llamarada → Chandelure hace Truco para intercambiar objeto, luego Excadrill Trampa rocas con 2 +2. Si entra Lapras, entra Poliwrath +6 +2.",
-                  "variant": []
-                },
-                {
-                  "detail": "Si usa Terremoto → Excadrill entra con 2 +2. Si entra Lapras, entra Poliwrath +6 +2.",
-                  "variant": []
-                },
-                {
-                  "detail": "Si usa Garra Dragón → Excadrill toma una Medicina de Defensa, luego entra con 2 +2.",
-                  "variant": []
-                }
-              ]
-            }
-          ]
-        },     
-        {
-          "detail": "Si usa Terremoto → Revisa el objeto:",
-          "variant": [
-            {
-              "detail": "Si lleva Pañuelo Elegido → Excadrill entra con 2 +2. / Si entra Lapras, luego entra Poliwrath +6 +2. Si Excadrill es golpeado con Garra Dragón, usa Medicina de Defensa, y entra con 2 +2.",
-              "variant": []
-            },
-            {
-              "detail": "Si lleva Banda Focus o Vidasfera → Cloyster entra con +6 (Metagross no muere de carámbano Cuidado).",
+              "detail": "Patada Salto Alta: puedes arriesgar usando Maquinación y barrer directo, aunque la ruta puede ser aleatoria contra Lapras. La ruta segura es cambiar a Slowbro, luego a Chansey y volver a Gengar.",
               "variant": []
             }
           ]
-        },        
+        },
         {
-          "detail": "Contra Lucario → Chandelure usa Truco para cambiar objeto, Scrafty entra con +3. / Usa Pulso Umbrío para matar a Haxorus.",
+          "detail": "Si sale Haxorus, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Ataca hasta que aparezca Lucario. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos. Lucario tiene Pañuelo Elegido.",
           "variant": []
         },
         {
-          "detail": "Contra Metagross → Excadrill entra con +4 +2 y luego coloca Trampa Rocas.",
+          "detail": "Si sale Lucario directamente, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo frente a Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Si Metagross se queda, sigue usando Bostezo.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/dracon/sceptile.json
+++ b/src/data/hoenn/dracon/sceptile.json
@@ -2,46 +2,20 @@
   "id": "sceptile",
   "name": "Sceptile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Ampharos → Excadrill +4 Ataque +2 Velocidad. Si sale Metagross, no hace falta cambiar; continúa boosteando.",
-      "variant": []
-    },
-    {
-      "detail": "Metagross → Chandelure usa Lanzallamas para debilitar y observa quién entra:",
+      "detail": "Cambia a Slowbro frente a Feraligatr y usa Bostezo frente a Sceptile.",
       "variant": [
         {
-          "detail": "Feraligatr → Poliwrath +6 Ataque con Raíz Energía +2 Velocidad.",
+          "detail": "Luego entra con Volcarona, usa Danza Aleteo x2 y Especial X.",
           "variant": []
         },
         {
-          "detail": "Floatzel → Cambia a Poliwrath y luego a Chandelure para usar Truco:",
-          "variant": [
-            {
-              "detail": "Hidrobomba, Poliwrath +6 Ataque +2 Velocidad.",
-              "variant": []
-            },
-            {
-              "detail": "Triturar, Scrafty +3.",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "Poder Oculto → Depende:",
-      "variant": [
-        {
-          "detail": "Económico → Scrafty +4. / Dos Puño Drenaje para matar a Metagross.",
-          "variant": []
-        },
-        {
-          "detail": "Velocidad → Poliwrath 6 +2. / Ten en cuenta que Sceptile es más rápido que Poliwrath +2, si tiene poca vida, recuerda curarlo.",
+          "detail": "Mantén los PS de Volcarona por encima del 75%.",
           "variant": []
         }
       ]
-    }    
+    }
   ]
 }

--- a/src/data/hoenn/dracon/seviper.json
+++ b/src/data/hoenn/dracon/seviper.json
@@ -2,24 +2,20 @@
   "id": "seviper",
   "name": "Seviper",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Flygon → Metagross coloca Trampa Rocas, luego entra Cloyster con +6. Si Metagross no logra colocar las rocas, revisa la siguiente situación.",
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
       "variant": [
         {
-          "detail": "Si Metagross cae por un golpe crítico → entra Excadrill con +2 +2, coloca Trampa Rocas. Si mientras Danza Espada, entra Lapras; después entra Poliwrath con +6 +2. ( Lucario con Banda Focus).",
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo frente a Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade, cambia a Slowbro y usa Bostezo frente a Empoleon. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Krookodile → Excadrill con +4 +2 y luego coloca Trampa Rocas.",
-      "variant": []
-    },
-    {
-      "detail": "Metagross → Excadrill Trampa Rocas y 2+2.",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/dracon/torkoal.json
+++ b/src/data/hoenn/dracon/torkoal.json
@@ -2,19 +2,20 @@
   "id": "torkoal",
   "name": "Torkoal",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A JIRACHI",
+  "initialMove": "💡 Encanto 💡",
   "tricks": [
     {
-      "detail": "Gallade → Gengar +2 (No Otra Vez)",
+      "detail": "Usa Encanto. Si quieres arriesgar, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
-    }, 
+    },
     {
-      "detail": "Fuerza Bruta → Chandelure 2+2",
-      "variant": []
-    },  
-    {
-      "detail": "Salamence → Otra Vez y Saca a chandelure 2+2",
-      "variant": []
+      "detail": "Si usa Fuerza Bruta, usa Amortiguador y espera a Gallade o Roserade.",
+      "variant": [
+        {
+          "detail": "Frente a Gallade, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. No uses Otra Vez.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/arcanine.json
+++ b/src/data/hoenn/fatima/arcanine.json
@@ -2,11 +2,16 @@
   "id": "arcanine",
   "name": "Arcanine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Amortiguador💡",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "A bocajarro ➜ Gengar Otra vez +4 +2",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Raichu, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/banette.json
+++ b/src/data/hoenn/fatima/banette.json
@@ -2,15 +2,20 @@
   "id": "banette",
   "name": "Banette",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨USAR TRAMPA ROCAS🪨en honchkrow mira abajo ",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Método 1 ➜ Amortiguador ; cambiar a Dragonite Danza Dragón x1; Máxima Poción ; Danza Dragón x1; antes de presionar, mantener línea de PS en 150hp si falta salud, usar medicina",
-      "variant": []
-    },
-    {
-      "detail": "Método 2 ➜ cambiar a Gengar  Otra Vez  cambiar a chansey  hacia Hydreigon; Gengar +4 no velo  usar x defensa ; Hydreigon se bloquea solo en Llamarada ; Gengar  aguantar Golpe Crítico; ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Honchkrow.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath cuando aparezca Hydreigon.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Ataque X con Poliwrath y completa la ruta. Usa Puño Hielo para eliminar a Honchkrow.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/chandelure.json
+++ b/src/data/hoenn/fatima/chandelure.json
@@ -2,11 +2,20 @@
   "id": "chandelure",
   "name": "Chandelure",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lucario ➜ Chandelure +2 +2 (pañuelo)",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Para ahorrar objetos, puedes subir a Maquinación hasta +6 con Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/dusknoir.json
+++ b/src/data/hoenn/fatima/dusknoir.json
@@ -2,103 +2,58 @@
   "id": "dusknoir",
   "name": "Dusknoir",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Mira Que Habilidad tiene 💡",
+  "initialMove": "💡 Revisa si tiene Presión 💡",
   "tricks": [
     {
-      "detail": "Presión ➜ ASEGURAR Trampa rocas ",
-      "variant": []
+      "detail": "Si tiene Presión, coloca Trampa Rocas. Si Dusknoir se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Gengar para revisar el movimiento.",
+          "variant": [
+            {
+              "detail": "A Bocajarro: Gengar usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+              "variant": []
+            },
+            {
+              "detail": "Patada Salto Alta: Gengar usa Maquinación hasta +2 y se sacrifica frente a Houndoom. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Si hay quemadura, usa Restaurar Todo.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Honchkrow, sacrifica a Politoed. Poliwrath barre hasta Hydreigon, usa Ataque X y sigue barriendo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo frente a Raichu. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hydreigon, usa Teletransporte. Si Hydreigon se queda, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Honchkrow  ➜ cambiar a Jirachi Otra Vez; Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Chandelure",
-      "variant": []
-    },
-    {
-      "detail": "A bocajarro  ➜ Chandelure +2 +2 ; NO usar Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta  ➜ cambiar a Chansey ; cambiar a Gengar ; cambiar a Chansey Amortiguador ",
-      "variant": []
-    },
-    {
-      "detail": "Luxray ➜ Gengar  Otra Vez  +4  0 Velocidad; usar x2 defensa ",
-      "variant": []
-    },
-    {
-      "detail": "Mawile ➜ Dragonite usar x defensa; Danza Dragón x1; usar x ataque; si hay poca vida usar Máxima Poción ",
-      "variant": []
-    },
-    {
-      "detail": "Arcanine ➜ Amortiguador ; Gengar Otra Vez  +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Terremoto  ➜ Dragonite Otra Vez ; Danza Dragón x3 ; terremoto para  Froslass ",
-      "variant": []
-    },
-    {
-      "detail": "Mawile (repetido) ➜ Dragonite usar x defensa; Danza Dragón x1; usar x ataque; si hay poca vida usar Máxima Poción ",
-      "variant": []
-    },
-    {
-      "detail": "Puño Hielo  ➜ Amortiguador ; ver ruta de Se queda ?'",
-      "variant": []
-    },
-    {
-      "detail": "Frente a Mawile ➜ cambiar a Dragonite x defensa; +1; usar x ataque; curar con cuidado; terremoto debilita a Froslass",
-      "variant": []
-    },
-    {
-      "detail": "(Niebla) ➜ abrir Pantalla de Luz ; Amortiguador  para forzar cambio del rival ; ver rutas anteriores según el Pokémon que entre",
-      "variant": []
-    },
-    {
-      "detail": "Sin Presión ➜ abrir Pantalla de Luz ; frente a Lucario cambiar a Gengar  Zoroark",
-      "variant": []
-    },
-    {
-      "detail": "A bocajarro ➜ Gengar  Otra Vez (Encore) +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Gengar fortalecido  huye hacia Dusknoir ➜ cambiar a Jirachi Otra Vez  Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Gengar fortalecido  huye hacia Dusknoir real ➜ Dragonite Otra Vez ; Danza Dragón x2",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta  ➜ Gengar Otra Vez ; tener Pantalla de Luz activa; Hydreigon golpea a Gengar pero no cae ",
-      "variant": []
-    },
-    {
-      "detail": "Gengar Pot  ➜ cambiar a Chansey ASEGURAR trampa rocas",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir Real  ➜ cambiar a Jirachi; cambiar a Dragonite Otra Vez; Danza Dragón x2 ; cambio directo a Dragonite tiene probabilidad de recibir Puño Hielo ",
-      "variant": []
-    },
-    {
-      "detail": "Hydreigon ➜ Bola Sombra ; Jirachi Otra Vez ; Chandelure +2 +2 ; Bola Sombra rompe Banda Focus de Hydreigon; lanza llamas ",
-      "variant": []
-    },
-    {
-      "detail": "Se Queda  ➜ Bola Sombra ",
-      "variant": []
-    },
-    {
-      "detail": "Hydreigon (ruta alternativa) ➜ Jirachi Otra Vez ; Chandelure +2 +2 ; si Gengar cae por crítico , cambiar directo a Jirachi Otra Vez; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Debilitar si Hydreigon entra  ➜ Bola Sombra; cambiar a Dragonite; cambiar a Jirachi Otra Vez; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Si no tiene Presión, es Zoroark disfrazado de Dusknoir.",
+      "variant": [
+        {
+          "detail": "Coloca Trampa Rocas frente a Lucario y revisa la posición de Lucario en el equipo rival.",
+          "variant": []
+        },
+        {
+          "detail": "Lucario en posición 2 con A Bocajarro: cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Lucario en posición 3 con Patada Salto Alta: cambia a Slowbro y usa Bostezo frente al Dusknoir falso. Usa Protección y Bostezo si sale Hydreigon. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/froslass.json
+++ b/src/data/hoenn/fatima/froslass.json
@@ -2,11 +2,24 @@
   "id": "froslass",
   "name": "Froslass",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz💡",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mawile ➜ Dragonite usar x defensa; Danza Dragón x1 ; usar x ataque ; si tiene poca vida  usar Máxima Poción ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Froslass se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hydreigon, usa Teletransporte. Si Hydreigon permanece, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Mawile, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/honchkrow.json
+++ b/src/data/hoenn/fatima/honchkrow.json
@@ -2,15 +2,20 @@
   "id": "honchkrow",
   "name": "Honchkrow",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Roca 🪨 Jirachi Otra Vez ",
+  "initialMove": "Slowbro + Bostezo",
   "tricks": [
     {
-      "detail": "Fuerza Bruta ➜ Dragonite Danza Dragón x2 ; aguantar Golpe Crítico ; curar",
-      "variant": []
-    },
-    {
-      "detail": "Hydreigon ➜ Dragonite Danza Dragón x2 ; esperar a que se bloquee solo ; antes de presionar, volver a tener más de la mitad de la vida ",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Honchkrow permanece, o si sale Hydreigon o Lucario, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje para mantener una buena línea de salud.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Banette, cambia a Chansey y coloca Trampa Rocas frente a Honchkrow. Luego sacrifica a Politoed y entra con Poliwrath. Usa Puño Hielo contra Honchkrow; cuando entre Hydreigon, usa Ataque X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/houndoom.json
+++ b/src/data/hoenn/fatima/houndoom.json
@@ -2,15 +2,20 @@
   "id": "houndoom",
   "name": "Houndoom",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas 🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Honchkrow ➜ cambiar a Jirachi; Dragonite Otra Vez (Encore); Danza Dragón x2",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Gengar  Otra Vez ; Rayo  debilitar ; cambiar a Chansey Amortiguador ; atraer a Luxray ; Gengar  Otra Vez +4 no velo  usar x defensa",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Honchkrow, sacrifica a Politoed y entra con Poliwrath. Usa Puño Hielo contra Honchkrow; cuando entre Hydreigon, usa Ataque X y termina la ruta.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/hydreigon.json
+++ b/src/data/hoenn/fatima/hydreigon.json
@@ -2,59 +2,28 @@
   "id": "hydreigon",
   "name": "Hydreigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨trampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Honchkrow ➜ cambiar a Jirachi Otra Vez ; Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Onda Certera  ➜ verificar objeto ",
-      "variant": []
-    },
-    {
-      "detail": "Vida Esfera ➜ Pantalla de Luz  + Amortiguador  para forzar el cambio del rival",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir  ➜ cambiar a Jirachi; cambiar a Dragonite Otra Vez ; Danza Dragón x3 ; Sombra Vil  Chandelure hace 52%; esperar y curar",
-      "variant": []
-    },
-    {
-      "detail": "Mawile ➜ Dragonite usar x defensa ; Danza Dragón x1; usar x ataque ; si hay poca vida usar Máxima Poción  ( Terremoto para Froslass)",
-      "variant": []
-    },
-    {
-      "detail": "Rotom Lavado  ➜ cambiar a Chansey; cambiar a Jirachi; frente a Dusknoir Dragonite Otra Vez ; Danza Dragón x3 ",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir ➜ Dragonite Otra Vez ; Danza Dragón x3 ; rezar estabilidad ; primero cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Gengar ",
-      "variant": []
-    },
-    {
-      "detail": "A bocajarro  ➜ cambiar a Chansey; Pantalla de Luz; Chandelure +2 +2 ; (Pañuelo)",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta  ➜ cambiar a Gengar ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Hydreigon ➜ Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir  ➜ Dragonite Otra Vez ; Danza Dragón x3 ",
-      "variant": []
-    },
-    {
-      "detail": "Mawile  ➜ Dragonite usar x defensa; Danza Dragón x1; usar x ataque ; si hay poca vida usar Máxima Poción ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa el movimiento o cambio rival.",
+      "variant": [
+        {
+          "detail": "Si usa Onda Certera, usa Teletransporte. Si Hydreigon permanece, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Honchkrow, sacrifica a Politoed y entra con Poliwrath. Usa Puño Hielo contra Honchkrow; si entra Hydreigon, usa Ataque X y completa la ruta.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/lucario.json
+++ b/src/data/hoenn/fatima/lucario.json
@@ -2,43 +2,32 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambia a Gengar y Mira la situacion 💡",
+  "initialMove": "💡 Cambia a Slowbro 💡",
   "tricks": [
     {
-      "detail": "Se queda  ➜ para ver la habilidad ",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta  ➜ Gengar  Otra Vez ; debilitar ",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir ➜ Dragonite Otra Vez; Danza Dragón x2 ; huye hacia Meganium para continuar fortalecimiento ",
-      "variant": []
-    },
-    {
-      "detail": "Houndoom ➜ cambiar a Chansey  ASEGURAR Trampa rocas",
-      "variant": []
-    },
-    {
-      "detail": "Luxray ➜ Gengar  Otra Vez  +4 no velo; usar x2 defensa ",
-      "variant": []
-    },
-    {
-      "detail": "A bocajarro  ➜ cambiar a Chansey ; ver quién entra:",
-      "variant": []
-    },
-    {
-      "detail": "Hydreigon ➜ ASEGURAR trampa roca; frente a Lucario usar Chandelure +2 +2; Pañuelo elegido se bloquea solo; huye hacia columna de hielo  para resistir daño y fortalecerse",
-      "variant": []
-    },
-    {
-      "detail": "Honchkrow ➜ cambiar a Jirachi; ASEGURAR Trampa rocas; Otra Vez ; Dragonite +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Arcanine ➜ cambiar a Chandelure; cambiar a Chansey; Gengar  Otra Vez  +4 +2 ",
-      "variant": []
+      "detail": "Cambia a Slowbro y revisa el movimiento o cambio rival.",
+      "variant": [
+        {
+          "detail": "Si usa A Bocajarro, cambia a Chansey y coloca Trampa Rocas frente a Lucario. Luego cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Patada Salto Alta, usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Elimina la quemadura antes de barrer.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Honchkrow, usa Bostezo. Si Honchkrow permanece, o si sale Hydreigon o Lucario, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje para mantener una buena línea de salud.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Banette, cambia a Chansey y coloca Trampa Rocas frente a Honchkrow. Luego sacrifica a Politoed y entra con Poliwrath. Presiona hasta Hydreigon y usa Ataque X. Usa Puño Hielo contra Honchkrow.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Arcanine, Slowbro usa Bostezo frente a Raichu. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/luxray.json
+++ b/src/data/hoenn/fatima/luxray.json
@@ -2,11 +2,20 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 Gengar Otra Vez +4 x defensa no velo ",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "-",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Defensa X.",
+          "variant": []
+        },
+        {
+          "detail": "Si Luxray usa Fuerza Bruta y sale crítico, usa primero Max Poción y luego barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/mandibuzz.json
+++ b/src/data/hoenn/fatima/mandibuzz.json
@@ -2,11 +2,16 @@
   "id": "mandibuzz",
   "name": "Mandibuzz",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡PANTALLA LUZ💡",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Arcanine → Gengar Otra Vez  +4 +2",
-      "variant": []
+      "detail": "Cambia a Slowbro frente a Arcanine y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Raichu, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/mawile.json
+++ b/src/data/hoenn/fatima/mawile.json
@@ -2,6 +2,16 @@
   "id": "mawile",
   "name": "Mawile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Dragonite usar x defensa ; Danza Dragón x1 ; usar x ataque ; si los PS bajan de 35, usar Máxima Poción ; no aguantar Golpe Crítico ; aguantar un golpe de Bisharp 💡",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/fatima/meganium.json
+++ b/src/data/hoenn/fatima/meganium.json
@@ -2,39 +2,20 @@
   "id": "meganium",
   "name": "Meganium",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Arcanine ➜ Amortiguador ; Gengar Otra Vez +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Mandibuzz ➜ Rayo ; cambiar a Chansey contador atraer a Arcanine contador ; se queda arcanine; Gengar +2 +2  usando x defensa",
-      "variant": []
-    },
-    {
-      "detail": "Meganium ➜ Gallade Otra Vez  +2 +2 ; Sombra Vil hace 75%; rezar estabilidad; usar x defensa ",
-      "variant": []
-    },
-    {
-      "detail": "Mandibuzz  ➜ Espada Santa ",
-      "variant": []
-    },
-    {
-      "detail": "Arcanine ➜ cambiar a Chandelure; cambiar a Chansey contador ; atraer a Arcanine; se queda ; Gengar +4 +2  usando x defensa",
-      "variant": []
-    },
-    {
-      "detail": "Se queda  ➜ Gengar +4 +2  usando x defensa",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ cambiar a Gengar  Otra Vez ; debilitar; cambiar a Chansey Amortiguador ; frente a Luxray cambiar a Chansey  y luego a Gengar",
-      "variant": []
-    },
-    {
-      "detail": "Luxray ➜ Gengar Otra Vez +4 no velo ; usar x2 defensa ; ( priorizar velocidad  +2 +0 +2 )",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo frente a Raichu. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Lucario, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/mismagius.json
+++ b/src/data/hoenn/fatima/mismagius.json
@@ -2,11 +2,20 @@
   "id": "mismagius",
   "name": "Mismagius",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas 🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lucario ➜ cambiar a Gengar  Otra Vez  debilitar ; cambiar a Chansey  Amortiguador ; frente a Luxray Gengar  Otra Vez  +4 no velo  usar x defensa ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/ninetales.json
+++ b/src/data/hoenn/fatima/ninetales.json
@@ -2,19 +2,16 @@
   "id": "ninetales",
   "name": "Ninetales",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz💡",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Lucario ➜ Gengar  Otra Vez ; Maquinación ",
-      "variant": []
-    },
-    {
-      "detail": "Permanecer  ➜ +2 Velocidad ; presionar hasta completar ; ( cuidado con Banda Focus  de Lucario )",
-      "variant": []
-    },
-    {
-      "detail": "Tropius ➜ Dragonite Otra Vez ; Danza Dragón x1 ; usar x ataque; / Danza Dragón x3 ; Garra Dragón  para Dusknoir; resistir a Lucario",
-      "variant": []
+      "detail": "Usa Amortiguador frente a Lucario y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/raichu.json
+++ b/src/data/hoenn/fatima/raichu.json
@@ -2,11 +2,16 @@
   "id": "raichu",
   "name": "Raichu",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla Luz💡",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Arcanine ➜ Gengar  Otra Vez ; bostezo manual +4 +2 +2 ; usar x defensa ",
-      "variant": []
+      "detail": "Cambia a Slowbro frente a Arcanine y usa Bostezo frente a Raichu.",
+      "variant": [
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/regice.json
+++ b/src/data/hoenn/fatima/regice.json
@@ -2,11 +2,20 @@
   "id": "regice",
   "name": "Regice",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨(chandelure banda focus y lucario pañuelo)",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lucario ➜ cambiar a Chandelure; +2 +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Para ahorrar objetos, puedes subir a Maquinación hasta +6 con Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/rotom_agua.json
+++ b/src/data/hoenn/fatima/rotom_agua.json
@@ -2,23 +2,24 @@
   "id": "rotom_agua",
   "name": "Rotom Agua",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz💡",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Politoed ➜ Dragonite usar x defensa ; Danza Dragón x1  usar x ataque si hay poca vida usar Máxima Poción",
-      "variant": []
-    },
-    {
-      "detail": "Permanecer  ➜ cambiar a Dragonite",
-      "variant": []
-    },
-    {
-      "detail": "Mawile ➜ Terremoto ",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir ➜ cambiar a Jirachi; Dragonite Otra Vez ; Danza Dragón x3",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Rotom Agua se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hydreigon, usa Teletransporte. Si Hydreigon permanece, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Mawile, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/sableye.json
+++ b/src/data/hoenn/fatima/sableye.json
@@ -2,11 +2,20 @@
   "id": "sableye",
   "name": "Sableye",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Tramparocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lucario ➜ cambiar a Chandelure;  +2  +2 ; Tiene Pañuelo ; Poder Oculto Hielo  para Hydreigon",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Para ahorrar objetos, puedes subir a Maquinación hasta +6 con Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/umbreon.json
+++ b/src/data/hoenn/fatima/umbreon.json
@@ -2,11 +2,24 @@
   "id": "umbreon",
   "name": "Umbreon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡PantallaLuz Amortiguador 💡 ",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Politoed  ➜ Dragonite usar x defensa ; Danza Dragón x1  usar x ataque ; si los PS son bajos , usar Máxima Poción ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Umbreon se queda, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hydreigon, usa Teletransporte. Si Hydreigon permanece, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si vuelve Mawile, envía a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza, usa Cura Total.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/abomasnow.json
+++ b/src/data/hoenn/nivea/abomasnow.json
@@ -2,11 +2,47 @@
   "id": "abomasnow",
   "name": "Abomasnow",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambiar a Chandelure 💡 Gallade otra Vez +4 +2 ",
+  "initialMove": "⬇️ Opciones para resolver ⬇️",
   "tricks": [
     {
-      "detail": "-.",
-      "variant": []
+      "detail": "Ruta con suerte: sacrifica a Politoed, entra con Poliwrath y usa Puño Drenaje.",
+      "variant": [
+        {
+          "detail": "Frente a Empoleon, usa Ataque X y luego barre.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta rápida: cambia a Gengar y revisa si se activa Cuerpo Maldito.",
+      "variant": [
+        {
+          "detail": "Si Cuerpo Maldito se activa, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Cuerpo Maldito no se activa, Gengar usa Otra Vez y revisa la situación.",
+          "variant": [
+            {
+              "detail": "Si Gengar cae, entra con Volcarona y usa Danza Aleteo x2.",
+              "variant": []
+            },
+            {
+              "detail": "Si Gengar sobrevive, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Ruta de ahorro: usa Encanto tres veces, luego Teletransporte hacia Volcarona.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x2. Mantén los PS por encima del 70%.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/altaria.json
+++ b/src/data/hoenn/nivea/altaria.json
@@ -2,24 +2,20 @@
   "id": "altaria",
   "name": "Altaria",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨 (Glalie,mienshao banda focus)",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mienshao → Cambia a Gengar usa Otra Vez +2",
+      "detail": "Coloca Trampa Rocas frente a Mienshao.",
       "variant": [
         {
-          "detail": "Sale Altaria → Cambia a Jirachi usa Otra Vez luego saca a Dragonite +2",
+          "detail": "Cambia a Gengar y usa Maquinación hasta +2.",
           "variant": []
-        },  
-        {    
-          "detail": "Sale Metagross → Cambia a Dragonite usa Otra Vez +2",
+        },
+        {
+          "detail": "Barre con Bola Sombra.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Garra dragon → Cambia a Jirachi luego a Gallade usa Otra Vez 2+2",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/nivea/beartic.json
+++ b/src/data/hoenn/nivea/beartic.json
@@ -2,15 +2,16 @@
   "id": "beartic",
   "name": "Beartic",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡GENGAR otra vez Chansey Trampa rocas 💡(Frente a Walrein o Dewgong ➜ resistir daño)",
+  "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "Gallade → Gengar +4 (no otra vez )",
-      "variant": []
-    },
-    {
-      "detail": "Beartic → Gengar otra vez  +2",
-      "variant": []
+      "detail": "Cambia a Gengar y usa Maquinación hasta +6.",
+      "variant": [
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/blissey.json
+++ b/src/data/hoenn/nivea/blissey.json
@@ -2,15 +2,19 @@
   "id": "blissey",
   "name": "Blissey",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS 🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mienshao → Gengar Otra Vez y usa Maquinacion",
+      "detail": "Coloca Trampa Rocas frente a Mienshao y cambia a Gengar para usar Bola Sombra contra Mienshao.",
       "variant": [
-         {
-          "detail": "Migmagius → Matalo luego usa Maquinacion frente a Walrein o Dewgong y luego pushea",
+        {
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo hasta que entre Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
           "variant": []
-         }
+        },
+        {
+          "detail": "Si sale Walrein o Dewgong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        }
       ]
     }
   ]

--- a/src/data/hoenn/nivea/froslass.json
+++ b/src/data/hoenn/nivea/froslass.json
@@ -2,11 +2,20 @@
   "id": "froslass",
   "name": "Froslass",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨COLOCA TRAMPA ROCA🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Hariyama ➜ Gengar  Otra Vez ; +4 +2 ; (usar movimiento Eléctrico  para debilitar  a Froslass)",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Hariyama.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Puño Hielo contra Froslass.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/gallade.json
+++ b/src/data/hoenn/nivea/gallade.json
@@ -2,15 +2,20 @@
   "id": "gallade",
   "name": "Gallade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " 💡Gengar (jugada arriesgada Chandelure +2 no velo frente a skarmory te curas)",
+  "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "Se queda  ➜ Gengar +4; NO usar Otra Vez ; (cuidado con Banda Focus de Skarmory)",
-      "variant": []
-    },
-    {
-      "detail": "Cambiar a otro poke  ➜ Chansey Amortiguador/tramparoca aguantar golpe fuerte de Lucha ; Gengar  Otra Vez  +2 para Gallade; NO usar Otra Vez ",
-      "variant": []
+      "detail": "Cambia a Gengar y usa Maquinación hasta +6.",
+      "variant": [
+        {
+          "detail": "Ataca con Bola Sombra para cerrar la ruta.",
+          "variant": []
+        },
+        {
+          "detail": "Si Skarmory conecta un crítico, usa Max Poción antes de continuar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/glalie.json
+++ b/src/data/hoenn/nivea/glalie.json
@@ -2,11 +2,20 @@
   "id": "glalie",
   "name": "Glalie",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mienshao → Gengar Otra Vez +2 no velo ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas.",
+      "variant": [
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar y usa Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/hariyama.json
+++ b/src/data/hoenn/nivea/hariyama.json
@@ -2,6 +2,33 @@
   "id": "hariyama",
   "name": "Hariyama",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨 Gengar Otra Vez +4 +2 (rayo para Frosslas)",
-  "tricks": []
+  "initialMove": "🐸 Opciones para resolver 🐸",
+  "tricks": [
+    {
+      "detail": "Ruta rápida: coloca Trampa Rocas y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Barre con Bola Sombra. Si te quedas bloqueado, usa Onda Certera.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta de ahorro: cambia a Slowbro, luego a Chansey y coloca Trampa Rocas.",
+      "variant": [
+        {
+          "detail": "Vuelve a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Cascada contra Froslass.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/nivea/lanturn.json
+++ b/src/data/hoenn/nivea/lanturn.json
@@ -2,35 +2,40 @@
   "id": "lanturn",
   "name": "Lanturn",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mienshao ➜ Gengar  Otra Vez  +2 no velo ; cambiar a Chansey +6; completar carga ; cambiar a Walrein o Dewgong; usar x def especial  y fortalecer ",
-      "variant": []
-    },
-    {
-      "detail": "Beartic ➜ Gengar Otra Vez  +2 0 velocidad",
-      "variant": []
-    },
-    {
-      "detail": "Metagross ➜ Gengar  Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Priorizar Velocidad ➜ +4 no velo ; frente a Walrein o Dewgong resistir daño ",
-      "variant": []
-    },
-    {
-      "detail": "Asegurar estabilidad  ➜ cambiar a Jirachi movimiento Eléctrico frente a Nido; Jirachi Otra Vez; Gallade +2+2  / Chandelure +2+2 ",
-      "variant": []
-    },
-    {
-      "detail": "Hariyama ➜ Gengar Otra Vez  +4 +2 ; Rayo  para debilitar  a Froslass; cambiar a Chansey  usar Amortiguador  para aguantar golpe fuerte",
-      "variant": []
-    },
-    {
-      "detail": "Gallade ➜ Gengar  +4 0 Velocidad; NO usar Otra Vez ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Hariyama, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro. Luego cambia a Volcarona frente a Serperior y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar y usa Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo hasta que entre Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Walrein o Dewgong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/metagross.json
+++ b/src/data/hoenn/nivea/metagross.json
@@ -2,35 +2,33 @@
   "id": "metagross_4",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mamoswine ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez  ; cambiar a Gallade +4 +2  priorizando usar x velocidad primero",
-      "variant": []
-    },
-    {
-      "detail": "Machada  ➜ cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Machada ➜ ESTABILIZAR Trampa Rocas dos veces; Otra Vez  sacrificio ; Chandelure +2 +2  con Golpe Crítico (CT); si la salud es baja 27% usar Otra Vez directamente",
-      "variant": []
-    },
-    {
-      "detail": "Nidoqueen ➜ Jirachi Otra Vez ; Chandelure +2 +2 / Gallade +2 +2; hacia Jirachi hay probabilidad de recibir movimiento de Fuego",
-      "variant": []
-    },
-    {
-      "detail": "Puño Meteoro  ➜ cambiar a Jirachi; Protección ",
-      "variant": []
-    },
-    {
-      "detail": "Terremoto  ➜ cambiar a Gallade; Otra Vez +2 +2",
-      "variant": []
-    },
-    {
-      "detail": "Poder Oculto Fuego  ➜ Jirachi Otra Vez ; Gallade +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué movimiento usa Metagross.",
+      "variant": [
+        {
+          "detail": "Si usa Machada, cambia a Slowbro y luego a Volcarona frente a Serperior. Volcarona usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Puño Meteoro, usa Teletransporte hacia Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mamoswine, usa Encanto y cambia a Slowbro. Usa Bostezo frente a Mismagius y revisa la salud de Slowbro.",
+          "variant": [
+            {
+              "detail": "Si Slowbro queda con menos del 79% de vida, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Metagross.",
+              "variant": []
+            },
+            {
+              "detail": "Si Slowbro queda con más del 79% de vida, entra con Volcarona y usa Danza Aleteo x1.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/mienshao.json
+++ b/src/data/hoenn/nivea/mienshao.json
@@ -2,31 +2,49 @@
   "id": "mienshao",
   "name": "Mienshao",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar Cambia a Jirachi Trampa rocas 💡",
+  "initialMove": "💡 Gengar + Slowbro 💡",
   "tricks": [
     {
-      "detail": "Mienshao permanecer  ➜ cambiar a Gengar  usar Bola Sombra ",
-      "variant": []
+      "detail": "Cambia a Gengar y luego a Slowbro para recibir Roca Afilada. Revisa el objeto y la precisión.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidasfera, cambia a Chansey para recibir Ida y Vuelta. Coloca Trampa Rocas frente a Mienshao, cambia a Gengar y espera a que se desgaste solo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo hasta que entre Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Walrein o Dewgong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si no tiene Vidasfera, usa Slowbro y Bostezo frente a Nidoking. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Chansey  ➜ Gengar  +4 0 Velocidad  NO usar Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Metagross ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Gallade +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Walrein ➜ Chandelure +2 +2 ; NO usar Otra Vez",
-      "variant": []
-    },
-    {
-      "detail": "Nidoqueen ➜ Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Blissey ➜ Chandelure +2 +2  / Gengar  +4 0 Velocidad ; NO usar Otra Vez",
-      "variant": []
+      "detail": "Si no tienes precisión segura, cambia a Chansey para revisar el objeto.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidasfera y usa Ida y Vuelta, coloca Trampa Rocas frente a Mienshao. Luego cambia a Gengar y espera a que se desgaste solo.",
+          "variant": []
+        },
+        {
+          "detail": "Si cambia a Nidoking, coloca Trampa Rocas frente a Mienshao. Luego cambia a Gengar, usa Maquinación y barre si no hay crítico en contra.",
+          "variant": []
+        },
+        {
+          "detail": "Si cambia a Mismagius, entra con Gengar y ataca hasta debilitarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Contra Skarmory, Walrein o Dewgong, usa la ruta de Slowbro con Bostezo, sacrificio de Politoed y Poliwrath con Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/mismagius.json
+++ b/src/data/hoenn/nivea/mismagius.json
@@ -2,15 +2,19 @@
   "id": "mismagius",
   "name": "Mismagius",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
-     {
-      "detail": "Mienshao → Gengar Otra Vez y Maquinacion, frente a Walrein o Derwgong usa Maquinacion y Pushea",
+    {
+      "detail": "Coloca Trampa Rocas frente a Mienshao y cambia a Gengar para usar Bola Sombra.",
       "variant": [
-         {
-          "detail": "Blissey → Gengar +6 (Blissey no te hara daño no te preocupes)",
+        {
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo hasta que entre Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
           "variant": []
-         }
+        },
+        {
+          "detail": "Si sale Walrein o Dewgong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        }
       ]
     }
   ]

--- a/src/data/hoenn/nivea/nidoqueen.json
+++ b/src/data/hoenn/nivea/nidoqueen.json
@@ -2,23 +2,28 @@
   "id": "nidoqueen",
   "name": "Nidoqueen",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Beartic ➜ cambiar a Gengar  Otra Vez ; +2 no Velocidad ",
-      "variant": []
-    },
-    {
-      "detail": "Mienshao ➜ cambiar a Gengar Otra Vez ; +2 0 Velocidad ",
-      "variant": []
-    },
-    {
-      "detail": "Metagross ➜ abrir con Pantalla Luz ; Gengar  Otra Vez ; Maquinación ; permanecer con Gengar +4 0 Velocidad Serperior  a salud completa; Gengar sin amenaza  / cambiar para seguir fortaleciendo ; Curar  tras Golpe Crítico ",
-      "variant": []
-    },
-    {
-      "detail": "Gallade ➜ cambiar a Gengar +4 0 Velocidad  NO usar Otra Vez ; si se elimina la quemadura puede entrar Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro y luego a Volcarona frente a Serperior. Volcarona usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa Onda Certera contra Walrein, Dewgong o Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Usa Onda Certera contra Beartic, Walrein, Dewgong o Skarmory.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/serperior.json
+++ b/src/data/hoenn/nivea/serperior.json
@@ -1,7 +1,21 @@
-   {
+{
   "id": "serperior",
   "name": "Serperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz 💡 Frente a Metagross Cambia a Gengar Otra Vez +4 no velo ",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas frente a Metagross.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y luego a Volcarona cuando entre Serperior.",
+          "variant": []
+        },
+        {
+          "detail": "Volcarona usa Danza Aleteo x2. Serperior no debilita a Volcarona en esta ruta.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/nivea/skarmory.json
+++ b/src/data/hoenn/nivea/skarmory.json
@@ -2,31 +2,36 @@
   "id": "skarmory",
   "name": "Skarmory",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mienshao ➜ cambiar a Gengar mata a mienshao ; cambiar a Chansey  ",
-      "variant": []
-    },
-    {
-      "detail": "Blissey ➜ cambiar a Gengar  Maquinación ; cambiar a Chansey  +6 0 Velocidad atacar ",
-      "variant": []
-    },
-    {
-      "detail": "Hariyama ➜ Gengar Otra Vez  +4  +2  (usar movimiento Eléctrico para  Froslass)",
-      "variant": []
-    },
-    {
-      "detail": "Cambiar a  ➜ Chansey  Amortiguador ; aguantar golpe fuerte ",
-      "variant": []
-    },
-    {
-      "detail": "Beartic ➜ Gengar  Otra Vez  +4 0 Velocidad ; si se elimina la quemadura ; cambiar a Walrein o Dewgong o priorizar Velocidad  directamente +2; necesita resistir daño",
-      "variant": []
-    },
-    {
-      "detail": "Gallade ➜ Gengar  +4 +0 Velocidad ; NO usar Otra Vez ; frente a Walrein o Dewgong resistir daño fortalecer ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Skarmory no cambia, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar y ataca con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo hasta que entre Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Walrein o Dewgong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hariyama, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa Onda Certera contra Walrein, Dewgong o Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Usa Onda Certera contra Beartic, Walrein, Dewgong o Skarmory.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/togekiss.json
+++ b/src/data/hoenn/nivea/togekiss.json
@@ -2,6 +2,20 @@
   "id": "togekiss",
   "name": "Togekiss",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz💡Gengar otra vez +4 +2  ",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨",
+  "tricks": [
+    {
+      "detail": "Coloca Trampa Rocas frente a Metagross.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y luego a Volcarona cuando entre Serperior.",
+          "variant": []
+        },
+        {
+          "detail": "Volcarona usa Danza Aleteo x2. Serperior no debilita a Volcarona en esta ruta.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/nivea/vanilluxe.json
+++ b/src/data/hoenn/nivea/vanilluxe.json
@@ -2,11 +2,20 @@
   "id": "vanilluxe",
   "name": "Vanilluxe",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz💡",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Gallade ➜ Gengar Otra Vez +2 +2 (Rayo para matar a walrein o dewgong)",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa si sale Gallade.",
+      "variant": [
+        {
+          "detail": "Si sale Gallade, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Gallade no tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Onda Certera contra Empoleon, Walrein o Dewgong.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/walrein.json
+++ b/src/data/hoenn/nivea/walrein.json
@@ -2,38 +2,53 @@
   "id": "walrein",
   "name": "Walrein",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨 (SI SE QUEDA USA AMORTIGUADOR)",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mienshao → Gengar Otra Vez y Maquinacion luego pushea hasta Chansey y Bostea +6",
-      "variant": []
-    },
-    {
-      "detail": "Beartic → Gengar Otra Vez +2 no velo ",
-      "variant": []
-    },
-    {
-      "detail": "Metagross → Gengar Otra Vez",
+      "detail": "Coloca Trampa Rocas. Si Walrein se queda y usa Superdiente, usa Amortiguador frente a Hariyama.",
       "variant": [
         {
-          "detail": "Estrategia rapida → Gengar +4 y pushear",
+          "detail": "Luego cambia a Slowbro y usa Bostezo. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
           "variant": []
         },
         {
-          "detail": "Estrategia segura → Cambia Jirachi despues usa Rayo luego usa Otra Vez y entra Gallade o Chandelure 2+2",
+          "detail": "Si Walrein mantiene Superdiente, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Usa Onda Certera para barrer.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Gallade → Gengar +4 (No usar Otra Vez)",
-      "variant": []
-    },
-    {
-      "detail": "Hariyama → Gengar Otra Vez 4+2 ( rayo a froslass)",
-      "variant": []
+      "detail": "Rutas por cambio rival:",
+      "variant": [
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar y usa Otra Vez con Maquinación hasta +2. Si entra Mismagius, derrótalo con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory. Si entra Lanturn, usará Voltiocambio: usa Bostezo otra vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Walrein o Dewgong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory. Si entra Lanturn, usará Voltiocambio: usa Bostezo otra vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Glalie o Altaria, barre directamente.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa Onda Certera contra Walrein, Dewgong o Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Usa Onda Certera contra Beartic, Walrein, Dewgong o Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, cambia a Slowbro. Cuando entre Serperior, cambia a Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }
-        
-

--- a/src/data/hoenn/plubio/altaria.json
+++ b/src/data/hoenn/plubio/altaria.json
@@ -2,28 +2,24 @@
   "id": "altaria",
   "name": "Altaria",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Swampert → Cambiar a Excadrill y luego a Chandelure, al enfrentarse a Gyarados usar Truco para bloquear Cascada, luego entra Poliwrath con +6+2. También puedes usar A Bocajarro para eliminar a Milotic // Eelektross Levitación. Si Chandelure ha caído y Poliwrath tiene al menos 75% de PS, entra Scrafty, luego cambia a Poliwrath para boostear.",
-      "variant": []
-    },
-    {
-      "detail": "Registeel → Cambiar a Scrafty y observar el movimiento.",
+      "detail": "Usa Amortiguador frente a Eelektross.",
       "variant": [
         {
-          "detail": "Si usa Terremoto, entra Scrafty con +2, puedes usar Puño Drenaje más Paliza para derrotar a Milotic.",
+          "detail": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Altaria.",
           "variant": []
         },
         {
-          "detail": "TERREMOTO CON RESTOS, Scrafty +1 + Raíz Energía + Píldora de Ataque / A Bocajarro para Milotic",
+          "detail": "Cambia a Chansey y espera a Eelektross. Usa Teletransporte hacia Slowbro y vuelve a usar Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Registeel → Sacrificar a Metagross, luego entra Poliwrath con +6 y curación con Raíz Energía, luego subir +2 Velocidad. Puedes usar A Bocajarro para matar a Milotic.",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/plubio/dragonite.json
+++ b/src/data/hoenn/plubio/dragonite.json
@@ -2,11 +2,16 @@
   "id": "dragonite",
   "name": "Dragonite",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💕 Encanto 💕",
   "tricks": [
     {
-      "detail": "Bloquea Puño Fuego, luego cambia a Chandelure y vuelve a usar Truco para bloquear a Milotic o Wailord, después entra Poliwrath con +6+2.",
-      "variant": []
+      "detail": "Usa Encanto para bajar el daño de Dragonite.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/eelektross.json
+++ b/src/data/hoenn/plubio/eelektross.json
@@ -2,48 +2,64 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lanzallamas → Truco para observar el movimiento del rival.",
+      "detail": "Coloca Trampa Rocas. Si usa Fuerza Bruta, Gengar usa Otra Vez y luego cambia a Slowbro.",
       "variant": [
         {
-          "detail": "Voltio Cruel → Se cambia a Excadrill con +6+0.",
+          "detail": "Si Milotic tiene Restos, usa Bostezo. Frente a Serperior, usa Protección y luego Bostezo otra vez. Después sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Rayo → Se entra con Excadrill Trampa Roca con +2+2.",
+          "detail": "Si Milotic no tiene Restos, usa Bostezo. Si usa Escaldar, sigue usando Bostezo hasta forzar la ruta.",
           "variant": []
         },
         {
-          "detail": "Voltiocambio y entra Starmie → Se cambia a Metagross y se usa Truco.",
-          "variant": [
-            {
-              "detail": "Si el rival usa Hidrobomba, entra Poliwrath con +6+2. // Si luego del Tambor aparece Eelektross, se continúa con Excadrill con +2+2.",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Registeel o el rival usa Rayo, entra Excadrill con +2+2.",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Voltiocambio y entra Milotic → Entra Poliwrath con +6+2.",
+          "detail": "Si Milotic usa Poder Oculto Eléctrico, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },   
-    {
-      "detail": "Puño Fuego → Se usa Truco para bloquear Voltio Cruel, luego entra Excadrill con +6+2.",
-      "variant": []
     },
     {
-      "detail": "Milotic → Se usa Truco para bloquear Escaldar y entra Poliwrath con +6+2. Puede usarse A Bocajarro para vencer a Sealeo o Milotic, sin necesidad de gastar Carámbano.",
-      "variant": []
+      "detail": "Rutas por cambio rival:",
+      "variant": [
+        {
+          "detail": "Si sale Serperior, usa Protección y luego Bostezo frente a Eelektross. Después sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Altaria, usa Protección y Bostezo. Frente a Eelektross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Swampert, usa Bostezo frente a Altaria. Cambia a Chansey para atraer a Eelektross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gardevoir, usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar y usa Otra Vez. Frente a Milotic, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Mienshao permite la ruta de Serperior, cambia a Slowbro y usa Bostezo contra Serperior. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, la ruta estable es cambiar a Slowbro y usar Bostezo. La ruta directa es sacrificar a Politoed y entrar con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Metagross → Se usa Truco para bloquear Avalancha, luego entra Scrafty con +3. Puede usarse A Bocajarro para vencer a Milotic, y también se puede recuperar PS usando Puño Drenaje desde +2.",
+      "detail": "Si Gengar atrapa a Eelektross en un ataque eléctrico, cambia a Chansey y usa Max Poción. Luego cambia a Slowbro y usa Bostezo frente a Altaria. Usa Chansey para atraer a Eelektross, Teletransporte hacia Slowbro, Bostezo, sacrificio de Politoed y Poliwrath con Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/plubio/empoleon.json
+++ b/src/data/hoenn/plubio/empoleon.json
@@ -2,59 +2,37 @@
   "id": "empoleon",
   "name": "Empoleon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto → Se cambia a Chandelure. //Si Metagross cae por un golpe crítico de Terremoto, se asume por defecto que Empoleon no se retira, así que se cambia directamente a Excadrill con +4+2.",
+      "detail": "Coloca Trampa Rocas y revisa el movimiento de Empoleon.",
       "variant": [
         {
-          "detail": "Empoleon no se retira, se entra igual con Excadrill +4+2.",
+          "detail": "Si usa Terremoto, cambia a Slowbro y usa Bostezo frente a Roserade. Luego entra con Volcarona y usa Danza Aleteo x3. Antes de barrer, mantén los PS por encima del 70%.",
           "variant": []
         },
         {
-          "detail": "Whiscash, se usa Truco. Si responde con Terremoto, entra Excadrill con +4+2. Si responde con Milotic, entra Poliwrath con +6+2.",
-          "variant": []
-        }
-      ]
-    },   
-    {
-      "detail": "Escaldar → Se cambia a Chandelure. Chandelure utiliza Truco para bloquear Escaldar, se cambia directamente a Poliwrath con +6+2.",
-      "variant": [
-        {
-          "detail": "Lanturn, se usa Truco para bloquear Escaldar y entra Poliwrath con +6+2.",
+          "detail": "Si usa Cascada, cambia a Slowbro y usa Bostezo frente a Roserade. Luego usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y presiona hasta Milotic. Frente a Milotic, usa Danza Aleteo una vez más y presiónalo dos veces. Si Milotic hace crítico, cura primero al máximo.",
           "variant": []
         },
         {
-          "detail": "Lanturn no se retira, igualmente se entra con Poliwrath +6+2 sin necesidad",
+          "detail": "Si usa Escaldar, cambia a Slowbro. Si Empoleon se queda, usa Bostezo frente a Roserade y entra con Volcarona para usar Danza Aleteo x4. Puedes usar Especial X.",
           "variant": []
         }
       ]
-    },   
-    {
-      "detail": "Whiscash → Se entra con Excadrill +4+2.",
-      "variant": []
     },
     {
-      "detail": "Milotic → Se entra con Poliwrath +6+2. Se puede usar A Bocajarro para derrotar a Milotic.",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Togekiss tras Tambor → Usar A Bocajarro para debilitarlo. Si luego entra un tipo veneno y no se puede continuar, se cambia a Scrafty para observar el movimiento:",
-          "variant": [
-            {
-              "detail": "Psicocarga, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Bomba Lodo, se cambia a Excadrill con +4+2.",
-              "variant": []
-            }
-          ]
+          "detail": "Si sale Milotic, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Roserade, usa Teletransporte para revisar movimiento. Si usa movimiento de Planta, Volcarona usa Danza Aleteo x4. Si usa movimiento de Veneno, Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
         }
       ]
-    },  
-    {
-      "detail": "Lanturn → Se entra con Poliwrath con +6+2. Si usa Rayo, se cambia a Excadrill entra con +4+2.",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/plubio/gardevoir.json
+++ b/src/data/hoenn/plubio/gardevoir.json
@@ -2,58 +2,35 @@
   "id": "gardevoir",
   "name": "Gardevoir",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Whiscash o Lanturn, usa Excadrill +4+2. Si por sorpresa recibe Escaldar, entra Poliwrath +6+2. Puede usar A Bocajarro para eliminar a Milotic.",
-      "variant": []
-    },
-    {
-      "detail": "Milotic, usa Poliwrath +6+2. (Primero Tambor) Puede usar A Bocajarro para eliminar a Milotic.",
+      "detail": "Coloca Trampa Rocas y revisa el objeto o movimiento de Gardevoir.",
       "variant": [
         {
-          "detail": "Si el rival cambia a Togekiss después del Tambor, usa A Bocajarro para eliminarlo. Luego si aparece Roserade, cambia a Scrafty y observa el movimiento:",
-          "variant": [
-            {
-              "detail": "Si usa Psíquico, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Si lanza Bomba Lodo, entra Excadrill +4+2.",
-              "variant": []
-            }
-          ]
-        }        
-      ]
-    },
-    {
-      "detail": "Registeel, coloca Trampa Rocas y luego entra Excadrill +2+2.",
-      "variant": []
-    },
-    {
-      "detail": "Bola Sombra, entra Scrafty +3.",
-      "variant": []
-    },
-    {
-      "detail": "Esfera Aural, cambia a Chandelure y utiliza Truco",
-      "variant": [
-        {
-          "detail": "Si Gardevoir no se retira, entra Scrafty +3.",
+          "detail": "Si tiene Vidasfera y usa Psicocarga, usa Teletransporte hacia Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si aparece Milotic, entra Poliwrath +6+2 // Si el rival cambia a Togekiss después del Tambor, usa A Bocajarro para eliminarlo. Luego si aparece Vileplume, cambia a Scrafty y observa el movimiento:",
-          "variant": [
-            {
-              "detail": "Si usa Psíquico, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Si lanza Bomba Lodo, entra Excadrill +4+2.",
-              "variant": []
-            }
-          ]
-        }        
+          "detail": "Si no tiene Vidasfera y usa Psicocarga, usa Teletransporte hacia Gengar y deja que Gengar caiga usando un movimiento.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Whiscash, la ruta segura es Slowbro con Bostezo frente a Roserade, sacrificio de Politoed y Poliwrath con Tambor hasta +6 Ataque. La ruta arriesgada es sacrificar a Politoed directo y entrar con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Milotic, Slowbro usa Bostezo frente a Roserade. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Togekiss, usa Onda Certera y sacrifica a Gengar. Slowbro usa Defensa Especial X y Bostezo frente a Roserade. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Eelektross, Gengar usa Otra Vez. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
       ]
     }
   ]

--- a/src/data/hoenn/plubio/gyarados.json
+++ b/src/data/hoenn/plubio/gyarados.json
@@ -2,24 +2,24 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "CASCADA, entra Poliwrath +6+2. Luego, usa A Bocajarro para eliminar a Milotic",
-      "variant": []
-    },
-    {
-      "detail": "REGISTEEL, cambia a Scrafty y observa el movimiento.",
+      "detail": "Usa Amortiguador frente a Eelektross.",
       "variant": [
         {
-          "detail": "TERREMOTO, Scrafty +2; luego puedes usar Puño Drenaje seguido de Paliza para vencer a Milotic",
+          "detail": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Altaria.",
           "variant": []
         },
         {
-          "detail": "MOV. SÍSMICO, haz Scrafty +1, luego usa Raíz Energía para recuperar y aplica Medicina de Ataque. Después, usa A Bocajarro para eliminar a Milotic",
+          "detail": "Cambia a Chansey y espera a Eelektross. Usa Teletransporte hacia Slowbro y vuelve a usar Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    }    
+    }
   ]
 }

--- a/src/data/hoenn/plubio/lanturn.json
+++ b/src/data/hoenn/plubio/lanturn.json
@@ -2,65 +2,52 @@
   "id": "lanturn",
   "name": "Lanturn",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Registeel, entra Excadrill +4+2",
-      "variant": []
-    },
-    {
-      "detail": "Milotic, entra Poliwrath +6+2. Puede usar A Bocajarro para eliminar a Milotic.",
+      "detail": "Usa Amortiguador. Si Lanturn se queda, aguanta con Defensa Especial X y usa Amortiguador dos veces.",
       "variant": [
         {
-          "detail": "Si el rival cambia a Togekiss después del Tambor, usa A Bocajarro para eliminarlo. Luego si aparece Vileplume, cambia a Scrafty y observa el movimiento:",
+          "detail": "Si Lanturn sigue en campo, usa Teletransporte hacia Gengar y ataca con Bola Sombra para revisar el daño.",
           "variant": [
             {
-              "detail": "Si usa Psíquico, Scrafty +3",
+              "detail": "Si Bola Sombra hace más del 40% de daño, sacrifica a Politoed. Luego Slowbro usa Bostezo, Teletransporte y entra Poliwrath para usar Tambor hasta +6 Ataque.",
               "variant": []
             },
             {
-              "detail": "Si lanza Bomba Lodo, entra Excadrill +4+2",
+              "detail": "Si Bola Sombra hace menos del 35% de daño, Gengar usa Maquinación. Si Gengar no cae, derrota con Bola Sombra y reinicia la ruta con Chansey si sale Togekiss o Roserade. Si Gengar cae, entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75% antes de barrer.",
               "variant": []
             }
           ]
-        }        
+        }
       ]
     },
     {
-      "detail": "Ludicolo, entra Poliwrath +6+2.",
-      "variant": []
-    },
-    {
-      "detail": "Rayo, entra Excadrill +4+2. Luego usa Terremoto para eliminar a Ludicolo / Roserade.",
-      "variant": []
-    },
-    {
-      "detail": "Casco Dentado + Escaldar, entra Poliwrath +6+2.",
-      "variant": []
-    },
-    {
-      "detail": "Baya Ziuela + Escaldar, entra Poliwrath +6+2. Puede usar A Bocajarro para eliminar a Milotic.",
-      "variant": []
-    },
-    {
-      "detail": "Restos + Escaldar, observa si Escaldar causa quemadura o golpe crítico:",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Si causa quemadura o crítico, entra Poliwrath +6+2.",
+          "detail": "Si sale Dragonite, usa Encanto, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si no hay quemadura ni crítico, cambia a Chandelure y observa:",
-          "variant": [
-            {
-              "detail": "Si Lanturn no se retira, entra Poliwrath +6+2",
-              "variant": []
-            },
-            {
-              "detail": "Si aparece Registeel, entra Excadrill +4+2",
-              "variant": []
-            }
-          ]
+          "detail": "Si sale Regice o Registeel, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Milotic, usa Teletransporte hacia Slowbro y Bostezo frente a Roserade. Luego entra con Volcarona y usa Danza Aleteo x4.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Empoleon, cambia a Slowbro y usa Bostezo frente a Roserade. Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 70%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gardevoir, usa Teletransporte hacia Slowbro y Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Roserade, usa Teletransporte para revisar el movimiento. Si usa movimiento de Planta, Volcarona usa Danza Aleteo x4. Si usa movimiento de Veneno, Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
         }
       ]
     }

--- a/src/data/hoenn/plubio/ludicolo.json
+++ b/src/data/hoenn/plubio/ludicolo.json
@@ -2,11 +2,16 @@
   "id": "ludicolo",
   "name": "Ludicolo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Bloquea Hidrobomba, luego entra Poliwrath +6+2.",
-      "variant": []
+      "detail": "Usa Teletransporte hacia Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/metagross.json
+++ b/src/data/hoenn/plubio/metagross.json
@@ -2,11 +2,16 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Chandelure y utiliza Truco para bloquear con Avalancha",
+  "initialMove": "🐸 Poliwrath 🐸",
   "tricks": [
     {
-      "detail": "Luego entra Scrafty +3. // Si aparece Milotic después, usa A Bocajarro para eliminarlo. Puedes aprovechar el +2 de Puño Drenaje para recuperar PS.",
-      "variant": []
+      "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "variant": [
+        {
+          "detail": "Si Poliwrath cae, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/mienshao.json
+++ b/src/data/hoenn/plubio/mienshao.json
@@ -2,11 +2,16 @@
   "id": "mienshao",
   "name": "Mienshao",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Bloquea a Registeel, Luego entra Excadrill +2+2.",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Serperior.",
+      "variant": [
+        {
+          "detail": "Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/milotic.json
+++ b/src/data/hoenn/plubio/milotic.json
@@ -2,78 +2,68 @@
   "id": "milotic",
   "name": "Milotic",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "GAFAS ELEGIDAS, entra Poliwrath +6+2.",
+      "detail": "Usa Amortiguador y revisa el movimiento o cambio rival.",
       "variant": [
         {
-          "detail": "Gardevoir hace un golpe crítico que derrota a Poliwrath, cambia a Chandelure y usa Truco para bloquear, luego entra Scrafty +3. // Si después entra Registeel, usa A Bocajarro para eliminarlo.",
+          "detail": "Si usa Surf o Hidrobomba, usa Teletransporte hacia Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Roserade, entra con Volcarona y usa Danza Aleteo x4.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Ludicolo o usa Rayo Hielo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Escaldar, usa Teletransporte hacia Slowbro y usa Bostezo. Si Milotic no cambia, sigue usando Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Serperior, usa Protección y Bostezo hasta que salga Lanturn. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gardevoir, Metagross, Regice, Registeel o Eelektross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "CASCO DENTADO, entra Poliwrath +6+2. Usa A Bocajarro para eliminar a Walrein o Milotic",
+      "detail": "Rutas de Roserade y Empoleon:",
       "variant": [
         {
-          "detail": "Si el rival cambia a Togekiss después del Tambor, usa a Bocajarro para eliminarlo. Luego si aparece Roserade, cambia a Scrafty y observa el movimiento:",
-          "variant": [
-            {
-              "detail": "Si usa Psíquico, Scrafty +3",
-              "variant": []
-            },
-            {
-              "detail": "Si lanza Bomba Lodo, entra Excadrill +4+2",
-              "variant": []
-            }
-          ]
-        },        
-        {
-          "detail": "Si entra Gyarados tras el Tambor, cambia a Chandelure y usa Truco para bloquear Cascada.",
-          "variant": [
-            {
-              "detail": "Si Chandelure cae, cambia a Metagross, usa objeto curativo fuerte en Poliwrath, y luego entra Poliwrath +6+2",
-              "variant": []
-            },
-            {
-              "detail": "Si Chandelure sobrevive, cura a Poliwrath, cambia a Scrafty y luego a Poliwrath +6+2",
-              "variant": []
-            }
-          ]
-        }       
-      ]
-    },
-    {
-      "detail": "REGISTEEL, revisa su objeto:",
-      "variant": [
-        {
-          "detail": "Cinta Experto: entra Excadrill +4+2",
+          "detail": "Si sale Roserade, usa Teletransporte y revisa el objeto. Con Vidasfera, Volcarona usa Danza Aleteo x1 y Especial X. Sin Vidasfera, Volcarona usa Danza Aleteo x2 y Especial X. Mantén los PS por encima del 70%.",
           "variant": []
         },
         {
-          "detail": "Baya Atania: entra Excadrill con Trampa Rocas puesta +2+2",
-          "variant": []
-        },
-        {
-          "detail": "Gafas Elegidas: entra Excadrill +2+2",
+          "detail": "Si sale Empoleon, coloca Trampa Rocas para revisar el movimiento. Contra Cascada, Slowbro usa Bostezo frente a Roserade, Teletransporte hacia Volcarona y Danza Aleteo x1. Contra Terremoto, Slowbro usa Bostezo hasta Roserade y luego Volcarona usa Danza Aleteo x3.",
           "variant": []
         }
       ]
-    },    
-    {
-      "detail": "METAGROSS, usa Chandelure con Lanzallamas para debilitarlo. Luego si entra Whiscash o Milotic, entra Poliwrath +6+2. Usa A Bocajarro para derrotar a Milotic o Walrein. // Si se congela utiliza Cura Total",
-      "variant": []
     },
     {
-      "detail": "Whiscash o Lanturn, entra Excadrill +4+2. // Si recibe escaldado por sorpresa, entra Poliwrath +6+2. Usa A Bocajarro para eliminar a Milotic.",
-      "variant": []
-    },
-    {
-      "detail": "Swampert, cambia a Excadrill y luego a Chandelure. Entra Gyarados, usa Truco para bloquear Cascada. Entra Poliwrath +6+2. Usa A Bocajarro para eliminar a Milotic.",
+      "detail": "Rutas especiales:",
       "variant": [
         {
-          "detail": "Si Chandelure fue debilitado y Poliwrath tiene 75% de salud, cambia a Scrafty y luego entra Poliwrath para potenciarse.",
+          "detail": "Si sale Mienshao, cambia a Slowbro y usa Bostezo frente a Serperior. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Dragonite, usa Encanto, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Whiscash, usa Encanto, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque, Raíz Grande y Velocidad X.",
+          "variant": []
+        },
+        {
+          "detail": "Si Poliwrath cae por crítico, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/plubio/registeel.json
+++ b/src/data/hoenn/plubio/registeel.json
@@ -2,39 +2,35 @@
   "id": "registeel",
   "name": "Registeel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa Truco para observar el movimiento",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto, revisa el objeto:",
+      "detail": "Coloca Trampa Rocas. Si Registeel se queda, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez y luego cambia a Slowbro. Frente a Milotic o Swampert, usa Bostezo. Si Milotic se queda usando Escaldar, sigue usando Bostezo.",
       "variant": [
         {
-          "detail": "Restos: Scrafty +3 y usa A Bocajarro para eliminar a Milotic.",
-          "variant": []
-        },
-        {
-          "detail": "Cinta Experto: entra Excadrill +4+2",
-          "variant": []
-        },
-        {
-          "detail": "Gafas elegidas: entra Excadrill +4+2",
-          "variant": []
-        },
-        {
-          "detail": "Baya Ziuela: entra Excadrill con Trampa Rocas puesta +2+2",
+          "detail": "Si usa Poder Oculto Eléctrico, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },    
+    },
     {
-      "detail": "Aura Sphere: cambia a Chandelure y usa Truco para bloquear a Milotic. Luego entra Poliwrath +6+2",
+      "detail": "Si sale Altaria, cambia a Chansey para atraer a Eelektross. Usa Teletransporte hacia Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Rayo: entra Excadrill +2+2",
+      "detail": "Si sale Serperior, usa Protección y Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Movimiento Sísmico: entra Scrafty +1, usa Raíz Energía para recuperar salud y luego potenciador de ataque. Después usa a Bocajarro para eliminar a Milotic.",
+      "detail": "Si sale Gardevoir o Eelektross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Mienshao, cambia a Slowbro y usa Bostezo contra Serperior. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/plubio/roserade.json
+++ b/src/data/hoenn/plubio/roserade.json
@@ -2,27 +2,49 @@
   "id": "roserade",
   "name": "Roserade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Metagross: entra Chandelure y utiliza Lanzallamas para debilitarlo. Luego puede entrar Seaking o Milotic; en ambos casos entra Poliwrath +6+2. // Usa A Bocajarro para eliminar a Milotic o Walrein. // Si fuiste congelado, usa Cura Total.",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa el objeto y movimiento de Roserade.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidasfera y usa Lluevehojas o Bomba Lodo, usa Teletransporte hacia Slowbro, Bostezo y luego Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si no tiene Vidasfera y usa Lluevehojas, usa Teletransporte. Si Roserade se queda, entra con Volcarona y usa Danza Aleteo x4. Mantén los PS por encima del 70%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gardevoir o Milotic, Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si no tiene Vidasfera y usa Bomba Lodo, usa Teletransporte hacia Volcarona y debilita a Roserade. Revisa qué Pokémon entra después.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Milotic: entra Poliwrath +6+2 y usa A Bocajarro para derrotarlo",
-      "variant": []
-    },
-    {
-      "detail": "Eelektross: cambia a Chandelure frente a Milotic, utiliza Truco para bloquear Escaldar, luego entra Poliwrath +6+2 y usa A Bocajarro para eliminar a Milotic o Dewgong",
-      "variant": []
-    },
-    {
-      "detail": "Whiscash: entra Excadrill +4+2",
-      "variant": []
-    },
-    {
-      "detail": "Poder Oculto: entra Poliwrath +6+2 y usa A Bocajarro para eliminar a Milotic",
-      "variant": []
+      "detail": "Rutas posteriores a Roserade:",
+      "variant": [
+        {
+          "detail": "Si sale Milotic, cambia a Chansey para revisar movimiento. Contra Hidrobomba o Surf, usa Teletransporte hacia Slowbro y Bostezo frente a Ludicolo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Milotic usa Escaldar, cambia a Slowbro y usa Bostezo frente a Gardevoir. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Togekiss o Gardevoir, sacrifica a Volcarona. Slowbro aguanta con Defensa Especial X y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Si Poliwrath cae, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Usa Bola Sombra contra Seaking.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/seaking.json
+++ b/src/data/hoenn/plubio/seaking.json
@@ -2,19 +2,24 @@
   "id": "seaking",
   "name": "Seaking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🐸 Poliwrath 🐸",
   "tricks": [
     {
-      "detail": "Seaking no se retira o cambia a Milotic: entra Poliwrath +6+2 y usa A Bocajarro para derrotar a Dewgong o Milotic. // Si fuiste congelado, usa Cura Total.",
-      "variant": []
-    },
-    {
-      "detail": "Metagross: entra Chandelure y usa Lanzallamas para debilitarlo. Luego puede salir Seaking o Milotic; en ambos casos entra Poliwrath +6+2 y usa A Bocajarro para eliminar a Dewgong o Milotic. // Si fuiste congelado, usa Cura Total.",
-      "variant": []
-    },
-    {
-      "detail": "Eelektross: cambia a Chandelure contra Metagross, usa Lanzallamas para derrotarlo. Después si entra Seaking o Milotic, entra Poliwrath +6+2 y usa A Bocajarro para eliminar a Dewgong o Milotic. // Si fuiste congelado, usa Cura Total.",
-      "variant": []
+      "detail": "Cambia a Politoed y sacrifícalo.",
+      "variant": [
+        {
+          "detail": "Entra con Metagross y deja que caiga para abrir paso seguro.",
+          "variant": []
+        },
+        {
+          "detail": "Luego entra con Poliwrath y usa Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Poliwrath cae por crítico, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/serperior.json
+++ b/src/data/hoenn/plubio/serperior.json
@@ -2,50 +2,33 @@
   "id": "serperior",
   "name": "Serperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "REGISTEEL: observa el objeto.",
+      "detail": "Coloca Trampa Rocas y revisa si Serperior usa Lluevehojas.",
       "variant": [
         {
-          "detail": "Baya Zidra/Atania: coloca Trampa Rocas y entra Excadrill +4+2.",
+          "detail": "Si Lluevehojas deja a Serperior en +4 de Ataque Especial, usa Teletransporte hacia Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Cinta Experto: entra Excadrill +4+2.",
-          "variant": []
-        },
-        {
-          "detail": "GAFAS ELEGIDAS: entra Excadrill +2+2.",
+          "detail": "Si Lluevehojas deja a Serperior en +2 de Ataque Especial, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Poder Oculto: cambia a Chandelure.",
+      "detail": "Rutas por cambio rival:",
       "variant": [
         {
-          "detail": "Si no se retira, usa Lanzallamas para derrotarlo. Luego, si entra Milotic o Wailord, entra Poliwrath +6+2.",
+          "detail": "Si sale Mienshao, cambia a Slowbro y usa Bostezo frente a Serperior. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
           "variant": []
         },
         {
-          "detail": "Si aparece Registeel frente a Chandelure: usa Truco.",
-          "variant": [
-            {
-              "detail": "Terremoto, entra Excadrill +4+2.",
-              "variant": []
-            },
-            {
-              "detail": "Si entra Wailord, entra Poliwrath +6+4.",
-              "variant": []
-            }
-          ]
+          "detail": "Si sale Eelektross, Gengar usa Otra Vez. Luego cambia a Slowbro frente a Milotic y usa Bostezo. Después sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
         }
       ]
-    },
-    {
-      "detail": "Lluevehojas: usa Truco para recuperar el objeto, luego coloca Trampa Rocas y sacrifica al Pokémon. Después entra Chandelure y usa Lanzallamas para debilitarlo (si entra Milotic), entonces entra Poliwrath +6+2 (Falta probar)",
-      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/plubio/starmie.json
+++ b/src/data/hoenn/plubio/starmie.json
@@ -2,11 +2,16 @@
   "id": "starmie",
   "name": "Starmie",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa Truco para bloquear a Registeel.",
+  "initialMove": "💡 Slowbro + Bostezo 💡",
   "tricks": [
     {
-      "detail": "Luego entra Excadrill +2+2.",
-      "variant": []
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Serperior.",
+      "variant": [
+        {
+          "detail": "Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/swampert.json
+++ b/src/data/hoenn/plubio/swampert.json
@@ -2,6 +2,24 @@
   "id": "swampert",
   "name": "Swampert",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Truco para bloquear con Terremoto, luego cambia a Excadrill y después a Chandelure para enfrentar a Gyarados. Utiliza Truco nuevamente para bloquear Cascada, entra Poliwrath +6+2. // Usa A Bocajarro para eliminar a Milotic // Si Chandelure muere y Poliwrath tiene un 75% de PS, entra Scrafty, luego vuelve a cambiar a Poliwrath +6+2.",
-  "tricks": []
+  "initialMove": "🥚 Amortiguador 🥚",
+  "tricks": [
+    {
+      "detail": "Usa Amortiguador frente a Eelektross.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Altaria.",
+          "variant": []
+        },
+        {
+          "detail": "Cambia a Chansey y espera a Eelektross. Usa Teletransporte hacia Slowbro y vuelve a usar Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/tentacruel.json
+++ b/src/data/hoenn/plubio/tentacruel.json
@@ -2,11 +2,20 @@
   "id": "tentacruel",
   "name": "Tentacruel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Truco para bloquear a Registeel,",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Entra Excadrill +2 +2 + Trampa Rocas",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa si sale Eelektross.",
+      "variant": [
+        {
+          "detail": "Si sale Eelektross, Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Milotic.",
+          "variant": []
+        },
+        {
+          "detail": "Después sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/togekiss.json
+++ b/src/data/hoenn/plubio/togekiss.json
@@ -2,42 +2,45 @@
   "id": "togekiss",
   "name": "Togekiss",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "💡 Teletransporte 💡",
   "tricks": [
     {
-      "detail": "Lanzallamas → Observa el objeto",
+      "detail": "Usa Teletransporte y revisa el daño recibido por Chansey.",
       "variant": [
         {
-          "detail": "Gafas Elegid. → Cambia a Chandelure y usa Truco. Luego envía a Poliwrath, potencia +6 Ataque y +2 Velocidad. ( Togekiss inesperadamente se queda en el combate, cambia a Metagross para sacrificarlo, y después envía nuevamente a Chandelure para usar Truco otra vez.) (No es necesario gastar Gema Hielo)",
+          "detail": "Si falla el cambio, revisa el daño. Si no hay golpe, compara con la ruta de Roserade con Vidasfera para confirmar el equipo rival.",
           "variant": []
         },
         {
-          "detail": "Restos → Puño Trueno y sacrifica",
-          "variant": [
-            {
-              "detail": "Scrafty, usa una Defensa Especial X + 3 Danza Dragón. / A Bocajarro para Milotic",
-              "variant": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "ESFERA AURAL, cambia a Chandelure y usa Truco:",
-      "variant": [
-        {
-          "detail": "Vidasfera, sigue con Excadrill +4+2",
+          "detail": "Si el golpe a Chansey hace menos del 15%, envía a Slowbro, usa Defensa Especial X y Bostezo frente a Roserade. Luego usa Teletransporte hacia Volcarona y usa Danza Aleteo x4. Mantén los PS por encima del 70%.",
           "variant": []
         },
         {
-          "detail": "Restos, entra Poliwrath +6+2",
+          "detail": "Si el golpe a Chansey hace más del 15%, envía a Slowbro, usa Defensa Especial X y Bostezo frente a Roserade. Luego usa Teletransporte hacia Volcarona, Danza Aleteo x1 y Especial X.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "LANTURN O WHISCASH, entra Excadrill +4+2. Si cae por Escaldar inesperado, entra Poliwrath +6+2 // Usa A Bocajarro para eliminar a Milotic",
-      "variant": []
+      "detail": "Si usa Poder Oculto, revisa el daño.",
+      "variant": [
+        {
+          "detail": "Si el golpe a Chansey hace menos del 20%, Gengar usa Otra Vez. Luego cambia a Slowbro frente a Milotic y usa Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Si es Poder Oculto Eléctrico, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Roserade, Volcarona usa Danza Aleteo x4. Antes de barrer, mantén los PS por encima del 70%.",
+          "variant": []
+        },
+        {
+          "detail": "Si el golpe a Chansey hace más del 20%, envía a Slowbro, usa Bostezo frente a Roserade y Teletransporte hacia Volcarona. Volcarona usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/wailord.json
+++ b/src/data/hoenn/plubio/wailord.json
@@ -2,14 +2,10 @@
   "id": "wailord",
   "name": "Wailord",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🐸 Poliwrath 🐸",
   "tricks": [
     {
-      "detail": "Registeel, entra Excadrill +4+2.",
-      "variant": []
-    },
-    {
-      "detail": "Terremoto, cambia a Chandelure para enfrentarlo, utiliza Truco para bloquearlo con Terremoto y luego entra Excadrill +4+2.",
+      "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/plubio/walrein.json
+++ b/src/data/hoenn/plubio/walrein.json
@@ -2,15 +2,24 @@
   "id": "walrein",
   "name": "Walrein",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRUCO",
+  "initialMove": "🐸 Poliwrath 🐸",
   "tricks": [
     {
-      "detail": "Metagross, cambia a Chandelure y usa Lanzallamas para debilitarlo. Si luego entra Seaking o Milotic, entra Poliwrath +6+2 // Usa A Bocajarro para eliminar a Milotic o Dewgong. // Si Poliwrath resulta congelado, utiliza Curación Total para recuperarlo.",
-      "variant": []
-    },
-    {
-      "detail": "Milotic, entra Poliwrath +6+2 // Usa A Bocajarro para eliminar a Milotic o Dewgong.",
-      "variant": []
+      "detail": "Cambia a Politoed y sacrifícalo.",
+      "variant": [
+        {
+          "detail": "Entra con Metagross y deja que caiga para abrir paso seguro.",
+          "variant": []
+        },
+        {
+          "detail": "Luego entra con Poliwrath y usa Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Poliwrath cae por crítico, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/whiscash.json
+++ b/src/data/hoenn/plubio/whiscash.json
@@ -2,6 +2,20 @@
   "id": "whiscash",
   "name": "Whiscash",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Truco para bloquear Terremoto, Excadrill 4+2",
-  "tricks": []
+  "initialMove": "💡 Encanto 💡",
+  "tricks": [
+    {
+      "detail": "Usa Encanto para bajar el daño de Whiscash.",
+      "variant": [
+        {
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Usa Raíz Grande y Velocidad X para +2 Velocidad antes de cerrar la ruta.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/sixto/absol.json
+++ b/src/data/hoenn/sixto/absol.json
@@ -2,51 +2,112 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨",
+  "initialMove": "💡 Cambia a Slowbro 💡",
   "tricks": [
     {
-      "detail": "Sin Vidasfera  ➜ cambiar a Gengar  Otra Vez  +4 +2 ; (contra Gengar veloz, ver abajo)",
-      "variant": []
+      "detail": "Si Absol tiene Vidasfera, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si usa Tajo Umbrío, cambia a Chansey y usa Encanto frente a Garchomp. Luego coloca Trampa Rocas, cambia a Slowbro y usa Bostezo frente a Magnezone. Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Electivire, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Electivire o Toxicroak.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, cambia a Chansey y coloca Trampa Rocas.",
+          "variant": [
+            {
+              "detail": "Si luego sale Absol, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Barre con Bola Sombra.",
+              "variant": []
+            },
+            {
+              "detail": "Si luego sale Luxray, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Excadrill sin Globo Helio  al azar ➜ rezar por estabilidad , ver abajo",
-      "variant": []
-    },
-    {
-      "detail": "Fortalecerse y huir hacia Excadrill ➜ cambiar a Dragonite, cambiar a Jirachi Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Globo Helio  ➜ Galladee +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Sin Globo Helio  ➜ Dragonite +2 )",
-      "variant": []
-    },
-    {
-      "detail": "Absol Pañuelo elegido  ➜ Dragonite aguanta x Defensa Danza Dragón x3 / Gengar  +6 +0 +2  (querer hacer daño);( Gengar +6 al azar, para matar a  (crafty)",
-      "variant": []
-    },
-    {
-      "detail": "Cambiar Gengar  ante Hariyama ➜ cambiar a huevo, cambiar a Gengar Otra Vez; frente a Aggron puede aguantar mucho, cambiar a Dragonite Otra Vez , Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Shiftry ➜ Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Vidasfera (Life Orb) ➜ cambiar a Jirachi Otra Vez (Encore), cambiar a Chandelure +2 +2 (22)",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp ➜ Otra Vez (Encore) para bloquear en Colmillo Ígneo (fire fang); Chandelure +2 +2 (22)",
-      "variant": []
-    },
-    {
-      "detail": "Electivire ➜ Otra Vez (Encore) para bloquear en Fuego; cambiar a Chandelure +2 +2 (22)",
-      "variant": []
+      "detail": "Si Absol no tiene Vidasfera, usa Teletransporte y revisa el movimiento.",
+      "variant": [
+        {
+          "detail": "Si usa Tajo Umbrío, Chansey coloca Trampa Rocas. Si el golpe es crítico, usa Max Poción antes de cambiar a Gengar.",
+          "variant": [
+            {
+              "detail": "Cuando recibas A Bocajarro, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Persecución, envía a Chansey, luego cambia a Gengar, usa Otra Vez y Bola Sombra. Después cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si el rival se queda, usa Protección y Bostezo frente a Huntail o Excadrill. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Huntail, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Luxray, envía a Chansey y usa Amortiguador.",
+          "variant": [
+            {
+              "detail": "Si vuelve Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Magnezone, envía a Chansey y coloca Trampa Rocas.",
+          "variant": [
+            {
+              "detail": "Si sale Darmanitan, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+              "variant": []
+            },
+            {
+              "detail": "Si vuelve Absol, Gengar usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Salamence con Intimidación, envía a Chansey y usa Amortiguador.",
+          "variant": [
+            {
+              "detail": "Si vuelve Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Salamence sin Intimidación, envía a Chansey, sacrifica a Politoed y usa Puño Hielo con Poliwrath.",
+          "variant": [
+            {
+              "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Hariyama, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/aggron.json
+++ b/src/data/hoenn/sixto/aggron.json
@@ -2,11 +2,20 @@
   "id": "aggron",
   "name": "Aggron",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Aggron → Cambia a Jirachi luego Cambia a Dragonite usa Otra Vez +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas, sacrifica a Politoed y entra con Poliwrath para absorber el golpe y derrotar a Aggron.",
+      "variant": [
+        {
+          "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Mantén los PS por encima del 23%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hariyama, Poliwrath usa Ataque X y termina con Cascada contra Hariyama.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/cacturne.json
+++ b/src/data/hoenn/sixto/cacturne.json
@@ -2,13 +2,22 @@
   "id": "cacturne",
   "name": "Cacturne",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🔔 Opciones para resolver 🔔",
   "tricks": [
     {
-      "detail": "Puño dranaje → Cambia a Gengar usa Otra Vez 6+2",
+      "detail": "Ruta rápida: coloca Trampa Rocas, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
       "variant": [
         {
-          "detail": "Darmanitan → Chandelure 2+2",
+          "detail": "Ataca siempre con el movimiento súper eficaz para avanzar el combate.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta de ahorro: usa Encanto y Amortiguador para estabilizar el combate.",
+      "variant": [
+        {
+          "detail": "Coloca Trampa Rocas frente a Darmanitan. Luego cambia a Gengar, usa Maquinación hasta +6 y barre con Bola Sombra. No uses Otra Vez.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/sixto/crawdaunt.json
+++ b/src/data/hoenn/sixto/crawdaunt.json
@@ -2,11 +2,20 @@
   "id": "crawdaunt",
   "name": "Crawdaunt",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨(scolipede y excadrill banda focus )",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Se queda → Chandelure +2 +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Ruta rápida: usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta de ahorro: usa Maquinación hasta +6 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/darmanitan.json
+++ b/src/data/hoenn/sixto/darmanitan.json
@@ -2,15 +2,25 @@
   "id": "darmanitan",
   "name": "Darmanitan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Fuerza Bruta  ➜ Gengar  +6  NO usar Otra Vez ",
-      "variant": []
+      "detail": "Ruta rápida: cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+      "variant": [
+        {
+          "detail": "Ataca siempre con el movimiento súper eficaz para avanzar el combate.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Buscando superar velocidad  ➜ ASEGURAR (NAIL) Chandelure +2 +2 ; si no se puede asegurar trampa rocas al azar ; Gyarados y Absol apostar por Arcanine si no se puede asegurar )",
-      "variant": []
+      "detail": "Ruta de ahorro: cambia a Gengar y usa Maquinación hasta +6. No uses Otra Vez.",
+      "variant": [
+        {
+          "detail": "Barre con Bola Sombra cuando ya estés preparado.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/electivire.json
+++ b/src/data/hoenn/sixto/electivire.json
@@ -2,11 +2,16 @@
   "id": "electivire",
   "name": "Electivire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Gengar Otra Vez +2 y Pushea",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/excadrill.json
+++ b/src/data/hoenn/sixto/excadrill.json
@@ -1,24 +1,25 @@
-  {
+{
   "id": "excadrill",
   "name": "Excadrill",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨.",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sin Globo Helio Absol/Luxray ➜ cambiar a Gengar Otra Vez ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Sin Globo Helio : Excadrill ➜ Jirachi Otra Vez; Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Con Globo Helio ➜ cambiar a Gengar  debilitar  a Mienshao",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ cambiar a Dragonite Cambia a Jirachi Otra Vez Gallade +4 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar y usa Bola Sombra contra Mienshao. Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2. Usa Gigadrenado contra Absol.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Absol no tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Luxray, usa Amortiguador y espera quedar frente a Absol o Crawdaunt. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/garchomp.json
+++ b/src/data/hoenn/sixto/garchomp.json
@@ -2,19 +2,29 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Absol ➜ Gengar  Otra Vez ; cambiar a Jirachi; usar a Chandelure hasta que salga Gyarados",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp ➜ Jirachi Otra Vez; Dragonite Danza Dragón x2 ; resistir Colmillo Ígneo  y eliminar quemadura ",
-      "variant": []
-    },
-    {
-      "detail": "Se Queda  ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Chandelure +2 +2",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa la ruta rival.",
+      "variant": [
+        {
+          "detail": "Si usa Colmillo Ígneo, usa Encanto y Amortiguador frente a Absol. Luego cambia a Gengar, usa Maquinación hasta +2 y barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, puedes resolver con ruta rápida o de ahorro.",
+          "variant": [
+            {
+              "detail": "Ruta rápida: cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+              "variant": []
+            },
+            {
+              "detail": "Ruta de ahorro: cambia a Gengar, usa Maquinación hasta +6 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/golurk.json
+++ b/src/data/hoenn/sixto/golurk.json
@@ -2,15 +2,34 @@
   "id": "golurk",
   "name": "Golurk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Tramparocas🪨",
+  "initialMove": "🔔 Opciones para resolver 🔔",
   "tricks": [
     {
-      "detail": "Puño Drenaje  y se queda  ➜ cambiar a Gengar; Bola Sombra",
-      "variant": []
+      "detail": "Ruta rápida: coloca Trampa Rocas y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Ataca siempre con el movimiento súper eficaz.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Debilitar  o frente a Darmanitan ➜ Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Ruta de ahorro: usa Encanto y Amortiguador para estabilizar el combate.",
+      "variant": [
+        {
+          "detail": "Coloca Trampa Rocas frente a Darmanitan. Luego cambia a Gengar, usa Maquinación hasta +6 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si usas Amortiguador frente a Darmanitan, cambia a Gengar y usa Otra Vez con Maquinación hasta +2 para derrotarlo.",
+      "variant": [
+        {
+          "detail": "Frente a Absol, cambia a Chansey y luego vuelve a Gengar para usar Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/gyarados.json
+++ b/src/data/hoenn/sixto/gyarados.json
@@ -2,63 +2,59 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Intimidacion mira abajo 💡",
+  "initialMove": "💡 Revisa la habilidad 💡",
   "tricks": [
     {
-      "detail": "Intimidación  ➜ ASEGURAR Trampa rocas y  frente a Absol ; Gengar Otra Vez  +2 no velo",
-      "variant": []
+      "detail": "Si tiene Intimidación, coloca Trampa Rocas.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar y usa Maquinación hasta +2. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Luxray, cambia a Gengar y usa Maquinación hasta +4. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Autoestima  ➜ ASEGURAR Trampa rocas",
-      "variant": []
-    },
-    {
-      "detail": "Darmanitan ➜ cambiar a Gengar  +6 no velo  (drama pañuelo)",
-      "variant": []
-    },
-    {
-      "detail": "Golurk ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Toxicroak ➜ cambiar a Gengar  Otra Vez  +4 no velo; y ataca  tras Otra Vez",
-      "variant": []
-    },
-    {
-      "detail": "Se queda con Acua Cola ➜ cambiar a Jirachi Rayo ; si es enfrentamiento directo no hace falta Rayo",
-      "variant": []
-    },
-    {
-      "detail": "Electivire / Absol ➜ Otra Vez ; cambiar a Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ cambiar a Gengar  Otra Vez (Encore) +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Gallade +4 +2 , primero asegurar x velocidad ",
-      "variant": []
-    },
-    {
-      "detail": "Maquinación  y huye hacia Mightyena ➜ ataca ",
-      "variant": []
-    },
-    {
-      "detail": "Magnezone ➜ cambiar a huevo  Pantalla de Luz ; cambio pesado ",
-      "variant": []
-    },
-    {
-      "detail": "Luxray ➜ cambiar a huevo; cambiar a Gengar Otra Vez ; frente a Excadrill, ver las variantes de Excadrill",
-      "variant": []
-    },
-    {
-      "detail": "Luxray ➜ Gengar  Otra Vez ; cambiar a Jirachi ante Excadrill; Jirachi Otra Vez ; Gallade +4 +2 , primero asegurar x velocidad",
-      "variant": []
+      "detail": "Si no tiene Intimidación, coloca Trampa Rocas y revisa el movimiento o cambio rival.",
+      "variant": [
+        {
+          "detail": "Si usa Acua Cola, usa Amortiguador frente a Absol. Luego cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Darmanitan, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Ataca siempre con el movimiento súper eficaz. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si Bostezo fuerza la salida de un atacante especial, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si usa Tajo Umbrío, revisa si Slowbro sobrevive.",
+              "variant": [
+                {
+                  "detail": "Si Slowbro sobrevive, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Golpe Bajo no es amenaza.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si Slowbro cae, cambia a Chansey. Luego entra con Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Luxray, usa Amortiguador y espera a Absol. Luego cambia a Gengar, usa Maquinación hasta +2 y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/hariyama.json
+++ b/src/data/hoenn/sixto/hariyama.json
@@ -2,23 +2,28 @@
   "id": "hariyama",
   "name": "Hariyama",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Hariyama se queda  ➜ cambiar a Jirachi Protección",
-      "variant": []
-    },
-    {
-      "detail": "Salamence ➜ Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ Chandelure +2 +2 ; (absol pañuelo)  Bola Sombra debilita a Hariyama",
-      "variant": []
-    },
-    {
-      "detail": "Aggron ➜ cambiar a Jirachi Otra Vez; Gallade +4 +2  hacia Jirachi; probabilidad de recibir golpe de roca ( nota: pendiente de optimización )",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Aggron, sacrifica a Politoed y entra con Poliwrath para derrotarlo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas. Mantén los PS por encima del 23%.",
+          "variant": []
+        },
+        {
+          "detail": "Si Hariyama se queda, usa Ataque X con Poliwrath y luego Cascada contra Hariyama.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/huntail.json
+++ b/src/data/hoenn/sixto/huntail.json
@@ -2,19 +2,20 @@
   "id": "huntail",
   "name": "Huntail",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Absol ➜ cambiar a Gengar Otra Vez  +2 ataca y su cambia a   Garchomp",
-      "variant": []
-    },
-    {
-      "detail": "Mienshao ➜ Gengar  rematalo ",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Gallade +4 +2, primero asegurar x velocidad ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Ataca con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar y usa Bola Sombra. Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2. Usa Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/luxray.json
+++ b/src/data/hoenn/sixto/luxray.json
@@ -2,43 +2,37 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "🔔 Revisa la habilidad 🔔",
   "tricks": [
     {
-      "detail": "Intimidación : Frente a Absol ➜ cambiar a Gengar  Otra Vez ; revisar objeto",
-      "variant": []
+      "detail": "Si tiene Intimidación, usa Amortiguador y revisa la ruta rival.",
+      "variant": [
+        {
+          "detail": "Si usa Fuerza Bruta, coloca Trampa Rocas. Frente a Absol, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Absol Pañuelo elegido  ➜ cambiar a Gengar; cambiar a Dragonite frente a Scrafty Danza Dragón x2  + x ataque ",
-      "variant": []
-    },
-    {
-      "detail": "Absol con Mal de Ojo  ➜ Gengar +4 no velo y atacar ",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ Gengar ; cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Dragonite Danza Dragón x2 ; probar grado de fuerza ; rezar por estabilidad +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty ➜ Chansey ; cambiar a Chandelure frente a Scizor para eliminarlo ; cambiar a chansey Amortiguador  frente a Absol; cambiar a Gengar; cambiar a Dragonite ante Scrafty Danza Dragón x2 + Atk X",
-      "variant": []
-    },
-    {
-      "detail": "Vidasfera  con Fuerza Bruta  ➜ cambiar a Gengar Otra Vez ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ Otra Vez ; Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Scizor ➜ lanzallamas frente a Tentacruel; cambiar a chansey Amortiguador  frente a Absol; cambiar a Gengar; cambiar a Dragonite ante Scrafty Danza Dragón x2 + Atk X",
-      "variant": []
-    },
-    {
-      "detail": "Sin Intimidación  ➜ Gengar  Otra Vez  +2 no velo ; atacar",
-      "variant": []
+      "detail": "Si no tiene Intimidación, elige una ruta para resolver.",
+      "variant": [
+        {
+          "detail": "Ruta segura: coloca Trampa Rocas, entra con Gengar, usa Otra Vez y Maquinación hasta +2 para derrotar a Luxray. Frente a Absol, pasa por Chansey y vuelve a Gengar con Otra Vez y Maquinación hasta +2.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta alternativa: cambia a Slowbro y usa Bostezo frente a Gyarados. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/magnezone.json
+++ b/src/data/hoenn/sixto/magnezone.json
@@ -2,23 +2,20 @@
   "id": "magnezone",
   "name": "Magnezone",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Tramparocas🪨 y mira que item tiene ",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Globo Helio  ➜ ASEGURAR trampa rocas  frente a Darmanitan; Gengar  +6 0 velo ; NO usar Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Sin Globo Helio  ➜ ASEGURAR Trampa rocas frente a Absol; cambiar a Gengar Otra Vez ; cambiar a Jirachi; no recibir Absorbe Fuego frente a Gyarados ; cambiar a Chansey ",
-      "variant": []
-    },
-    {
-      "detail": "Huye hacia Magnezone ➜ cambio a chansey ",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp ➜ Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Darmanitan, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Ataca siempre con el movimiento súper eficaz.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Ataca siempre con el movimiento súper eficaz.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/mandibuzz.json
+++ b/src/data/hoenn/sixto/mandibuzz.json
@@ -2,11 +2,20 @@
   "id": "mandibuzz",
   "name": "Mandibuzz",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mienshao➜ Gengar Bola sombra sale ➜ Excadril ➜ Dragonite ➜ Jirachi otra vez , Gallade +4 +2  ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Mienshao.",
+      "variant": [
+        {
+          "detail": "Gengar derrota a Mienshao con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2. Usa Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/metagross.json
+++ b/src/data/hoenn/sixto/metagross.json
@@ -2,21 +2,20 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa rocas 🪨(huntail Banda Focus)",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Absol/Luxray ➜ Gengar Otra Vez +2 no velo ",
+      "detail": "Coloca Trampa Rocas frente a Absol y cambia a Gengar.",
       "variant": [
         {
-          "detail": "-",
+          "detail": "Gengar usa Maquinación hasta +2 y barre con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "-",
+          "detail": "Huntail tiene Banda Focus; mantén la ruta preparada antes de intentar cerrar el combate.",
           "variant": []
         }
       ]
     }
-  
   ]
 }

--- a/src/data/hoenn/sixto/mienshao.json
+++ b/src/data/hoenn/sixto/mienshao.json
@@ -2,23 +2,20 @@
   "id": "mienshao",
   "name": "Mienshao",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Gengar otra vez para que se muera ",
+  "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "Excadrill ➜ Chansey  ASEGURAR Trampa rocas  quedarse y usar Amortiguador ",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ cambiar a Gengar ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ Otra Vez ; Gallade +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Si Persecución  debilita a Gengar  ➜ Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Cambia a Gengar y derrota a Mienshao con Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Frente a Mandibuzz o Spiritomb, cambia a Chansey y coloca Trampa Rocas.",
+          "variant": []
+        },
+        {
+          "detail": "Frente a Absol, entra con Volcarona, usa Danza Aleteo x2 y Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/mightyena.json
+++ b/src/data/hoenn/sixto/mightyena.json
@@ -2,11 +2,16 @@
   "id": "mightyena",
   "name": "Mightyena",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨USA TRAMPA ROCAS🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Absol ➜ Gengar Otra Vez +2 no velo ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/sableye.json
+++ b/src/data/hoenn/sixto/sableye.json
@@ -2,31 +2,37 @@
   "id": "sableye",
   "name": "Sableye",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Aggron ➜ Jirachi Protección ; Gallade Otra Vez  +4 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si sale Absol, cambia a Gengar y usa Otra Vez. Revisa el objeto de Absol.",
+      "variant": [
+        {
+          "detail": "Si Gengar es más rápido que Absol, usa la ruta rápida: Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta de ahorro: usa Maquinación hasta +6 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si Absol usa A Bocajarro primero, usa Maquinación hasta +4 con Gengar. No uses Otra Vez; Absol tiene Pañuelo Elegido.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Absol ➜ Amortiguador ; revisar objeto",
-      "variant": []
-    },
-    {
-      "detail": "Pañuelo elegido  ➜ Chandelure +2 +2 ; Bola Sombra debilita a Hariyama",
-      "variant": []
-    },
-    {
-      "detail": "Vidasfera  ➜ Gengar  Otra Vez  +6 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Magnezone ➜ cambiar a jirachi  ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ Jirachi Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Si sale Aggron, sacrifica a Politoed y entra con Poliwrath para usar Puño Drenaje.",
+      "variant": [
+        {
+          "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hariyama, Poliwrath usa Ataque X y termina con Cascada contra Hariyama.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/salamence.json
+++ b/src/data/hoenn/sixto/salamence.json
@@ -2,31 +2,33 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Mira Que Habilidad Tiene💡",
+  "initialMove": "💡 Revisa la habilidad 💡",
   "tricks": [
     {
-      "detail": "Intimidación ➜ Pantalla de Luz ",
-      "variant": []
+      "detail": "Si tiene Intimidación, usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Huye hacia Absol ➜ Dragonite; asegurar x defensa ; Danza Dragón x2 ; x ataque  ",
-      "variant": []
-    },
-    {
-      "detail": "Sin Intimidación  ➜ ASEGURAR Trampa rocas  ; cambiar a Jirachi Otra Vez; Chandelure +2 +2 ; Chandelure +2; Bola Sombra  objetivo aleatorio",
-      "variant": []
-    },
-    {
-      "detail": "Probando sin Intimidación  ➜ ASEGURAR trampa rocas ; cambiar a Gengar  Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Se queda  ➜ Click hasta debilitar; ver instrucciones abajo",
-      "variant": []
-    },
-    {
-      "detail": "Aggron ➜ cambiar a Jirachi; cambiar a Dragonite Otra Vez ; Danza Dragón x2 ",
-      "variant": []
+      "detail": "Si no tiene Intimidación, coloca Trampa Rocas, sacrifica a Politoed y entra con Poliwrath. Usa Puño Hielo para derrotar a Salamence.",
+      "variant": [
+        {
+          "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas. Mantén los PS por encima del 23%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hariyama, Poliwrath usa Ataque X. Usa Cascada contra Hariyama.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/scizor.json
+++ b/src/data/hoenn/sixto/scizor.json
@@ -2,23 +2,20 @@
   "id": "scizor",
   "name": "Scizor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " 💡cambia a chande y matalo 💡",
+  "initialMove": "🦋 Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Tentacruel ➜ cambiar a chansey Pantalla de Luz ; frente a Absol cambiar a Gengar  Rayo  cambia a Jirachi Otra Vez; Chandelure no puede  si falta uno entre Tentacruel y Scrafty",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty huye hacia Salamence ➜ continuar con Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Se bloquea en Puño Drenaje Pañuelo ➜ Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ Chansey Contador ; frente a Scrafty Gengar  Otra Vez  +2 +2  + Otra Vez (Encore)",
-      "variant": []
+      "detail": "Entra con Volcarona, usa Danza Aleteo x2 y Especial X.",
+      "variant": [
+        {
+          "detail": "Usa Gigadrenado contra Luxray.",
+          "variant": []
+        },
+        {
+          "detail": "Haz Danza Aleteo x2: si solo haces una Danza Aleteo, Absol con Pañuelo Elegido puede superar a Volcarona en velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/scolipede.json
+++ b/src/data/hoenn/sixto/scolipede.json
@@ -2,15 +2,20 @@
   "id": "scolipede",
   "name": "Scolipede",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨 AMORTIGUADOR  directo ➜ Aguantar presión (Cuidado con Scolipede/Excadrill banda focus)",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Rezar por estabilidad  ➜ Gengar  Otra Vez ; Maquinación ; presionar hasta Excadrill ; cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Dragonite Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Buscando velocidad  ➜ Dragonite Danza Dragón x2 ; NO usar Otra Vez ; Scolipede Banda Focus ; cuidado con tu vida  ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas. Si Scolipede no cambia, usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6. Absol no tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Luxray, usa Amortiguador y espera quedar frente a Absol o Crawdaunt. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Para ahorrar objetos, puedes subir a Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/scrafty.json
+++ b/src/data/hoenn/sixto/scrafty.json
@@ -2,31 +2,20 @@
   "id": "scrafty",
   "name": "Scrafty",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Absol ➜ cambiar a Gengar ; cambiar a Jirachi frente a Scrafty Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Salamence ➜ luego usar Otra Vez ; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty con Puño Drenaje  ➜ Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Scizor ➜ cambiar a Chandelure para debilitarlo; frente a Absol ver instrucciones arriba",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ cambiar a Jirachi Protección frente a Salamence; Otra Vez; Chandelure +2 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Tentacruel ➜ cambiar a Chansey Amortiguador  frente a Absol",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/sharpedo.json
+++ b/src/data/hoenn/sixto/sharpedo.json
@@ -2,23 +2,20 @@
   "id": "sharpedo",
   "name": "Sharpedo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Frente a Absol ➜ Gengar  Otra Vez ; cambiar a Jirachi",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp ➜ Jirachi Otra Vez; bloquear en Colmillo Ígneo ; Chandelure +2 +2 (22); estrategia arriesgada : Dragonite Danza Dragón x3 ; Jirachi y Dragonite NO usar Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Chandelure huye hacia Gyarados ➜ Dragonite Danza Dragón x3 ; NO usar Otra Vez ",
-      "variant": []
-    },
-    {
-      "detail": "Magnezone ➜ cambiar a Chandelure Pantalla de Luz; contador",
-      "variant": []
+      "detail": "Coloca Trampa Rocas frente a Absol y cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Ruta rápida: usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta de ahorro: usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad. Mantén Otra Vez cuando sea necesario hasta terminar de boostearte y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/shiftry.json
+++ b/src/data/hoenn/sixto/shiftry.json
@@ -2,15 +2,30 @@
   "id": "shiftry",
   "name": "Shiftry",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampasRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Aggron ➜ cambiar a Jirachi; cambiar a Dragonite Otra Vez ; Danza Dragón x2 ",
-      "variant": []
-    },
-    {
-      "detail": "Absol (pañuelo elegido) ➜ Chandelure +2 +2 ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si entra Absol, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si entra Aggron, sacrifica a Politoed y entra con Poliwrath para derrotarlo.",
+          "variant": [
+            {
+              "detail": "Si luego entra Shiftry, cambia a Volcarona, usa Danza Aleteo x2 y Lanzallamas contra Shiftry. Contra el resto de plantas, usa Psíquico. Mantén los PS por encima del 23%.",
+              "variant": [
+                {
+                  "detail": "Si entra Hariyama, Poliwrath usa Ataque X y ataca. Usa Cascada contra Hariyama.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/spiritomb.json
+++ b/src/data/hoenn/sixto/spiritomb.json
@@ -2,19 +2,20 @@
   "id": "spiritomb",
   "name": "Spiritomb",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Mienshao ➜ Gengar Otra Vez  debilitar ",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill ➜ cambiar a Dragonite; cambiar a Jirachi Otra Vez ; Gallade +4 +2 ",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ Gengar  Otra Vez +2 no velo ",
-      "variant": []
+      "detail": "Coloca Trampa Rocas y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar y usa Maquinación hasta +4.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mienshao, Gengar lo derrota con Bola Sombra. Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/tentacruel.json
+++ b/src/data/hoenn/sixto/tentacruel.json
@@ -2,19 +2,20 @@
   "id": "tentacruel",
   "name": "Tentacruel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Pantalla luz 💡",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Pantalla de Luz frente a Absol ➜ cambiar a Dragonite; usar x defensa ; Danza Dragón x3 ; x ataque; curar hasta 20% ",
-      "variant": []
-    },
-    {
-      "detail": "Scizor ➜ lanzallamas scizor",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty ➜ Dragonite +4 +2 ; si no hay suficiente  curar ; ante bajada de defensa , asegurar con x defensa ",
-      "variant": []
+      "detail": "Usa Amortiguador y revisa qué Pokémon entra después.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/toxicroak.json
+++ b/src/data/hoenn/sixto/toxicroak.json
@@ -2,15 +2,16 @@
   "id": "toxicroak",
   "name": "Toxicroak",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "CAMBIA A CHANDELURE",
+  "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "Gengar  Otra Vez  +4 no velo ; Otra Vez; ataca ",
-      "variant": []
-    },
-    {
-      "detail": "Huye hacia Mightyena ➜ cambiar a chansey ASEGURAR trampa rocas; atraer movimiento lucha ; Gengar  Otra Vez  +0 +2 ",
-      "variant": []
+      "detail": "Cambia a Gengar, usa Maquinación hasta +4 y luego usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Toxicroak tiene Banda Focus. Barre con Bola Sombra después de preparar a Gengar.",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Releases the full Hoenn Elite Four strategy update from `develop` to `main`.
- Includes all Hoenn trainer strategy rewrites:
  - Sixto: 28 JSON files
  - Fatima: 20 JSON files
  - Nivea: 18 JSON files
  - Dracon: 21 JSON files
  - Plubio: 22 JSON files

## Validation
- Compared `main` against `develop`: 109 Hoenn JSON files are updated.
- Confirmed `develop` is 0 commits behind `main`.
- Checked Hoenn strategy files for common old shorthand and legacy residues, including `TRUCO`, `Truco`, `+6+2`, `+2+2`, `4+2`, `TrampaRocas`, `sapito`, and `matalo`.
- No visual assets or non-strategy files are included in the Hoenn update scope.

## Notes
- This PR is intended to publish the Hoenn strategy changes to the GitHub Pages deploy through `main`.