### PR TITLE
Clarify Johto Bruno Heracross Focus Sash

### DIFF
--- a/src/data/johto/bruno/heracross.json
+++ b/src/data/johto/bruno/heracross.json
@@ -5,7 +5,7 @@
   "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Ruta arriesgada con Trampa Rocas:",
+      "detail": "Ruta arriesgada con Trampa Rocas. Heracross tiene Banda Focus.",
       "variant": [
         {
           "detail": "Coloca Trampa Rocas. Si no recibes crítico, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",


### PR DESCRIPTION
## Summary
- Clarifies that Heracross has Focus Sash in the risky route for Johto Bruno.
- Keeps the existing JSON structure intact.

## Scope
Only one file is updated:
- `src/data/johto/bruno/heracross.json`

## Notes
- No visual assets are changed.
- No `main` or deploy changes are included.