### PR TITLE
Fix Hoenn Nivea route details

### DIFF
--- a/src/data/hoenn/nivea/nidoqueen.json
+++ b/src/data/hoenn/nivea/nidoqueen.json
@@ -16,11 +16,11 @@
           "variant": []
         },
         {
-          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa Onda Certera contra Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
           "variant": []
         },
         {
-          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Usa Onda Certera contra Beartic, Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Barre con Bola Sombra.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/nivea/skarmory.json
+++ b/src/data/hoenn/nivea/skarmory.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo hasta que entre Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
           "variant": []
         },
         {
@@ -24,11 +24,11 @@
           "variant": []
         },
         {
-          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa Onda Certera contra Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
           "variant": []
         },
         {
-          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Usa Onda Certera contra Beartic, Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Barre con Bola Sombra.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/nivea/walrein.json
+++ b/src/data/hoenn/nivea/walrein.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si Walrein mantiene Superdiente, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Usa Onda Certera para barrer.",
+          "detail": "Si Walrein mantiene Superdiente, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Barre con Bola Sombra. Si te bloquean Bola Sombra, usa Onda Certera.",
           "variant": []
         }
       ]
@@ -33,15 +33,15 @@
           "variant": []
         },
         {
-          "detail": "Si sale Glalie o Altaria, barre directamente.",
+          "detail": "Si sale Glalie o Altaria, barre con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa Onda Certera contra Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
           "variant": []
         },
         {
-          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Usa Onda Certera contra Beartic, Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Barre con Bola Sombra.",
           "variant": []
         },
         {


### PR DESCRIPTION
## Summary
- Updates Hoenn Nivea route details for Walrein, Skarmory, and Nidoqueen.
- Aligns Gallade and Beartic routes with the corrected +4 Gengar setup and Shadow Ball cleanup.
- Clarifies the Walrein Super Fang route when Shadow Ball gets blocked.

## Scope
Only these files are updated:
- `src/data/hoenn/nivea/walrein.json`
- `src/data/hoenn/nivea/skarmory.json`
- `src/data/hoenn/nivea/nidoqueen.json`

## Notes
- Johto Koga Ferrothorn was reviewed and already matches the intended Politoed/Ditto wording.
- Hoenn Nivea Mismagius was reviewed and already matches the provided route.
- No visual assets are changed.
- No `main` or deployment changes are included.