### PR TITLE
Fix Hoenn Nivea Mienshao and Beartic routes

### DIFF
--- a/src/data/hoenn/nivea/beartic.json
+++ b/src/data/hoenn/nivea/beartic.json
@@ -5,7 +5,7 @@
   "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "Cambia a Gengar y usa Maquinación hasta +6.",
+      "detail": "Cambia a Gengar, usa Otra Vez y Maquinación hasta +6.",
       "variant": [
         {
           "detail": "Barre con Bola Sombra.",

--- a/src/data/hoenn/nivea/mienshao.json
+++ b/src/data/hoenn/nivea/mienshao.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo hasta que entre Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
           "variant": []
         },
         {
@@ -33,15 +33,19 @@
           "variant": []
         },
         {
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Walrein o Dewgong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        },
+        {
           "detail": "Si cambia a Nidoking, coloca Trampa Rocas frente a Mienshao. Luego cambia a Gengar, usa Maquinación y barre si no hay crítico en contra.",
           "variant": []
         },
         {
-          "detail": "Si cambia a Mismagius, entra con Gengar y ataca hasta debilitarlo.",
-          "variant": []
-        },
-        {
-          "detail": "Contra Skarmory, Walrein o Dewgong, usa la ruta de Slowbro con Bostezo, sacrificio de Politoed y Poliwrath con Tambor hasta +6 Ataque.",
+          "detail": "Si cambia a Mismagius, coloca Trampa Rocas frente a Mienshao. Luego cambia a Gengar y espera a que se desgaste solo.",
           "variant": []
         }
       ]


### PR DESCRIPTION
## Summary
- Updates Hoenn Nivea Mienshao route details to match the corrected path.
- Adds the missing Encore step to the Hoenn Nivea Beartic route.
- Keeps the existing JSON structure intact.

## Scope
Only these files are updated:
- `src/data/hoenn/nivea/mienshao.json`
- `src/data/hoenn/nivea/beartic.json`

## Notes
- No visual assets are changed.
- No `main` or deployment changes are included.