### PR TITLE
Release latest strategy fixes

### DIFF
--- a/src/data/hoenn/nivea/beartic.json
+++ b/src/data/hoenn/nivea/beartic.json
@@ -5,7 +5,7 @@
   "initialMove": "👻 Gengar 👻",
   "tricks": [
     {
-      "detail": "Cambia a Gengar y usa Maquinación hasta +6.",
+      "detail": "Cambia a Gengar, usa Otra Vez y Maquinación hasta +6.",
       "variant": [
         {
           "detail": "Barre con Bola Sombra.",

--- a/src/data/hoenn/nivea/mienshao.json
+++ b/src/data/hoenn/nivea/mienshao.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo hasta que entre Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
           "variant": []
         },
         {
@@ -33,15 +33,19 @@
           "variant": []
         },
         {
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Walrein o Dewgong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        },
+        {
           "detail": "Si cambia a Nidoking, coloca Trampa Rocas frente a Mienshao. Luego cambia a Gengar, usa Maquinación y barre si no hay crítico en contra.",
           "variant": []
         },
         {
-          "detail": "Si cambia a Mismagius, entra con Gengar y ataca hasta debilitarlo.",
-          "variant": []
-        },
-        {
-          "detail": "Contra Skarmory, Walrein o Dewgong, usa la ruta de Slowbro con Bostezo, sacrificio de Politoed y Poliwrath con Tambor hasta +6 Ataque.",
+          "detail": "Si cambia a Mismagius, coloca Trampa Rocas frente a Mienshao. Luego cambia a Gengar y espera a que se desgaste solo.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/nivea/nidoqueen.json
+++ b/src/data/hoenn/nivea/nidoqueen.json
@@ -16,11 +16,11 @@
           "variant": []
         },
         {
-          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa Onda Certera contra Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
           "variant": []
         },
         {
-          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Usa Onda Certera contra Beartic, Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Barre con Bola Sombra.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/nivea/skarmory.json
+++ b/src/data/hoenn/nivea/skarmory.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo hasta que entre Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
           "variant": []
         },
         {
@@ -24,11 +24,11 @@
           "variant": []
         },
         {
-          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa Onda Certera contra Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
           "variant": []
         },
         {
-          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Usa Onda Certera contra Beartic, Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Barre con Bola Sombra.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/nivea/walrein.json
+++ b/src/data/hoenn/nivea/walrein.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si Walrein mantiene Superdiente, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Usa Onda Certera para barrer.",
+          "detail": "Si Walrein mantiene Superdiente, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Barre con Bola Sombra. Si te bloquean Bola Sombra, usa Onda Certera.",
           "variant": []
         }
       ]
@@ -33,15 +33,15 @@
           "variant": []
         },
         {
-          "detail": "Si sale Glalie o Altaria, barre directamente.",
+          "detail": "Si sale Glalie o Altaria, barre con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa Onda Certera contra Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
           "variant": []
         },
         {
-          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Usa Onda Certera contra Beartic, Walrein, Dewgong o Skarmory.",
+          "detail": "Si sale Beartic, cambia a Gengar, usa Otra Vez y Maquinación hasta +4. Barre con Bola Sombra.",
           "variant": []
         },
         {

--- a/src/data/johto/bruno/heracross.json
+++ b/src/data/johto/bruno/heracross.json
@@ -5,7 +5,7 @@
   "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Ruta arriesgada con Trampa Rocas:",
+      "detail": "Ruta arriesgada con Trampa Rocas. Heracross tiene Banda Focus.",
       "variant": [
         {
           "detail": "Coloca Trampa Rocas. Si no recibes crítico, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",


### PR DESCRIPTION
## Summary
- Releases the latest strategy fixes from `develop` to `main`.
- Includes the Johto Bruno Heracross Focus Sash clarification.
- Includes the Hoenn Nivea route fixes for Walrein, Skarmory, Nidoqueen, Mienshao, and Beartic.

## Scope
Updated strategy JSON files only:
- `src/data/johto/bruno/heracross.json`
- `src/data/hoenn/nivea/walrein.json`
- `src/data/hoenn/nivea/skarmory.json`
- `src/data/hoenn/nivea/nidoqueen.json`
- `src/data/hoenn/nivea/mienshao.json`
- `src/data/hoenn/nivea/beartic.json`

## Notes
- No visual assets are changed.
- This PR publishes the latest fixes to the GitHub Pages deploy through `main`.