### PR TITLE
Improve responsive layout

### DIFF
--- a/src/components/LeaderCard.tsx
+++ b/src/components/LeaderCard.tsx
@@ -13,15 +13,15 @@ export const LeaderCard = ({ leader, isExpanded, onClick }: LeaderCardProps) => 
   return (
     <button
       type="button"
-      className={`group relative min-w-0 overflow-hidden rounded-3xl border bg-slate-950/60 p-3 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 hover:border-rose-200/40 hover:bg-slate-900/90 ${
+      className={`group relative min-w-0 overflow-hidden rounded-2xl border bg-slate-950/60 p-2.5 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 hover:border-rose-200/40 hover:bg-slate-900/90 sm:rounded-3xl sm:p-3 ${
         isExpanded
-          ? 'scale-[1.02] border-rose-200/70 ring-2 ring-rose-300/70 sm:scale-[1.03]'
+          ? 'scale-[1.01] border-rose-200/70 ring-2 ring-rose-300/70 sm:scale-[1.03]'
           : 'border-white/10'
       }`}
       onClick={() => onClick(leader.id)}
     >
       <div className="absolute inset-0 bg-gradient-to-br from-rose-400/15 via-transparent to-cyan-300/10 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-      <div className="relative flex h-24 items-center justify-center overflow-hidden rounded-2xl min-[420px]:h-28 sm:h-32">
+      <div className="relative flex h-20 items-center justify-center overflow-hidden rounded-xl min-[420px]:h-24 sm:h-28 lg:h-32">
         <img
           src={leaderImage}
           alt={leader.name}
@@ -29,7 +29,7 @@ export const LeaderCard = ({ leader, isExpanded, onClick }: LeaderCardProps) => 
           loading="lazy"
         />
       </div>
-      <span className="relative mt-2 block truncate rounded-xl bg-black/35 px-2 py-1 text-center text-sm font-black text-white sm:text-base">
+      <span className="relative mt-2 block truncate rounded-xl bg-black/35 px-2 py-1 text-center text-xs font-black text-white sm:text-sm lg:text-base">
         {leader.name}
       </span>
     </button>

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -54,13 +54,13 @@ export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) 
       type="button"
       className={`group relative min-w-0 cursor-pointer overflow-hidden rounded-2xl border bg-slate-950/60 p-2 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 hover:border-cyan-200/40 hover:bg-slate-900/90 ${
         isSelected
-          ? 'scale-[1.02] border-cyan-200/70 ring-2 ring-cyan-300/70 sm:scale-[1.03]'
+          ? 'scale-[1.01] border-cyan-200/70 ring-2 ring-cyan-300/70 sm:scale-[1.03]'
           : 'border-white/10'
       }`}
       onClick={() => onClick(pokemon)}
     >
       <div className="absolute inset-0 bg-gradient-to-b from-cyan-300/10 via-transparent to-rose-400/10 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-      <div className="relative flex h-20 items-center justify-center min-[380px]:h-24 sm:h-28">
+      <div className="relative flex h-16 items-center justify-center min-[380px]:h-20 sm:h-24 lg:h-28">
         <img
           src={spriteSrc}
           alt={pokemon.name}
@@ -69,7 +69,7 @@ export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) 
           onError={handleSpriteError}
         />
       </div>
-      <span className="relative mt-2 block truncate rounded-xl bg-black/35 px-2 py-1 text-center text-xs font-black text-white sm:text-sm">
+      <span className="relative mt-2 block truncate rounded-xl bg-black/35 px-1.5 py-1 text-center text-[0.68rem] font-black leading-tight text-white min-[380px]:text-xs sm:text-sm">
         {pokemon.name}
       </span>
     </button>

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -16,19 +16,23 @@ export const PokemonDetails = ({ pokemon, language, labels }: PokemonDetailsProp
   )
 
   return (
-    <section className="animate-in slide-in-from-bottom duration-300 rounded-[2rem] border border-white/10 bg-slate-950/70 p-5 shadow-2xl shadow-black/30 backdrop-blur-xl sm:p-6">
-      <div className="mb-5 flex flex-col gap-4 border-b border-white/10 pb-5 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <span className="text-xs font-black uppercase tracking-[0.22em] text-rose-200">{labels.initialMoveLabel}</span>
-          <h3 className="mt-2 text-2xl font-black text-white">{initialMove}</h3>
+    <section className="animate-in slide-in-from-bottom duration-300 overflow-hidden rounded-[1.5rem] border border-white/10 bg-slate-950/70 p-3 shadow-2xl shadow-black/30 backdrop-blur-xl sm:rounded-[2rem] sm:p-6">
+      <div className="mb-4 flex flex-col gap-3 border-b border-white/10 pb-4 sm:mb-5 sm:flex-row sm:items-center sm:justify-between sm:pb-5">
+        <div className="min-w-0">
+          <span className="text-[0.65rem] font-black uppercase tracking-[0.18em] text-rose-200 sm:text-xs sm:tracking-[0.22em]">
+            {labels.initialMoveLabel}
+          </span>
+          <h3 className="mt-2 min-w-0 break-words text-xl font-black leading-tight text-white [overflow-wrap:anywhere] sm:text-2xl">
+            {initialMove}
+          </h3>
         </div>
-        <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-right">
-          <span className="block text-xs font-bold uppercase tracking-[0.18em] text-slate-400">Matchup</span>
-          <span className="text-lg font-black text-white">{pokemon.name}</span>
+        <div className="w-full rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-left sm:w-auto sm:px-4 sm:py-3 sm:text-right">
+          <span className="block text-[0.65rem] font-bold uppercase tracking-[0.16em] text-slate-400 sm:text-xs sm:tracking-[0.18em]">Matchup</span>
+          <span className="block truncate text-base font-black text-white sm:text-lg">{pokemon.name}</span>
         </div>
       </div>
 
-      <div className="space-y-3">
+      <div className="min-w-0 space-y-3 overflow-hidden">
         {pokemon.tricks && pokemon.tricks.length > 0 ? (
           pokemon.tricks.map((trick, index) => (
             <TrickItem key={`${pokemon.id}-${index}`} trick={trick} language={language} />

--- a/src/components/PokemonGuide.tsx
+++ b/src/components/PokemonGuide.tsx
@@ -130,30 +130,30 @@ export default function PokemonGuide() {
     <div className="min-h-screen overflow-x-hidden bg-[#0b1020] text-slate-50">
       <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(244,63,94,0.22),_transparent_32%),radial-gradient(circle_at_top_right,_rgba(59,130,246,0.2),_transparent_28%),linear-gradient(135deg,_#0b1020_0%,_#111827_45%,_#1e1b4b_100%)]" />
 
-      <main className="relative mx-auto min-h-screen w-full max-w-7xl px-3 py-4 sm:px-6 sm:py-6 lg:px-8">
-        <section className="mb-6 rounded-[1.5rem] border border-white/10 bg-white/[0.08] p-4 shadow-2xl shadow-black/30 backdrop-blur-xl sm:mb-8 sm:rounded-[2rem] sm:p-8">
+      <main className="relative mx-auto min-h-screen w-full max-w-7xl px-2 py-3 sm:px-5 sm:py-6 lg:px-8">
+        <section className="mb-4 overflow-hidden rounded-[1.25rem] border border-white/10 bg-white/[0.08] p-3 shadow-2xl shadow-black/30 backdrop-blur-xl sm:mb-8 sm:rounded-[2rem] sm:p-6 lg:p-8">
           <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
             <div className="min-w-0 max-w-3xl">
-              <span className="mb-3 inline-flex rounded-full border border-rose-300/30 bg-rose-400/10 px-3 py-1 text-[0.65rem] font-bold uppercase tracking-[0.2em] text-rose-100 sm:text-xs sm:tracking-[0.24em]">
+              <span className="mb-3 inline-flex max-w-full rounded-full border border-rose-300/30 bg-rose-400/10 px-3 py-1 text-[0.62rem] font-bold uppercase tracking-[0.16em] text-rose-100 sm:text-xs sm:tracking-[0.24em]">
                 PokeMMO Elite Four
               </span>
-              <h1 className="text-3xl font-black tracking-tight text-white sm:text-5xl lg:text-6xl">
+              <h1 className="break-words text-2xl font-black leading-tight tracking-tight text-white min-[380px]:text-3xl sm:text-5xl lg:text-6xl">
                 {t.title}
               </h1>
-              <p className="mt-4 max-w-2xl text-sm leading-6 text-slate-300 sm:text-base">
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-300 sm:mt-4 sm:text-base">
                 {t.subtitle}
               </p>
             </div>
 
             <div className="flex w-full flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-3 sm:w-auto sm:min-w-48">
-              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">{t.languageLabel}</span>
+              <span className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-slate-400 sm:text-xs sm:tracking-[0.2em]">{t.languageLabel}</span>
               <div className="grid grid-cols-2 gap-2">
                 {(Object.keys(languages) as Language[]).map((currentLanguage) => (
                   <button
                     key={currentLanguage}
                     type="button"
                     onClick={() => setLanguage(currentLanguage)}
-                    className={`rounded-xl px-4 py-2 text-sm font-bold transition-all duration-300 ${
+                    className={`rounded-xl px-3 py-2 text-sm font-bold transition-all duration-300 sm:px-4 ${
                       language === currentLanguage
                         ? 'bg-rose-400 text-slate-950 shadow-lg shadow-rose-500/25'
                         : 'bg-white/10 text-slate-200 hover:bg-white/15'
@@ -166,13 +166,13 @@ export default function PokemonGuide() {
             </div>
           </div>
 
-          <div className="mt-6 grid gap-3 lg:grid-cols-[1.1fr_1fr]">
-            <div className="rounded-2xl border border-cyan-300/20 bg-cyan-300/10 p-4">
-              <p className="text-xs font-bold uppercase tracking-[0.2em] text-cyan-200">{t.routeLabel}</p>
-              <p className="mt-2 text-base font-black text-white sm:text-lg">{t.route}</p>
+          <div className="mt-5 grid gap-3 lg:mt-6 lg:grid-cols-[1.1fr_1fr]">
+            <div className="rounded-2xl border border-cyan-300/20 bg-cyan-300/10 p-3 sm:p-4">
+              <p className="text-[0.65rem] font-bold uppercase tracking-[0.18em] text-cyan-200 sm:text-xs sm:tracking-[0.2em]">{t.routeLabel}</p>
+              <p className="mt-2 break-words text-base font-black text-white sm:text-lg">{t.route}</p>
             </div>
-            <div className="rounded-2xl border border-rose-300/20 bg-rose-300/10 p-4">
-              <p className="text-xs font-bold uppercase tracking-[0.2em] text-rose-100">{t.teamLabel}</p>
+            <div className="rounded-2xl border border-rose-300/20 bg-rose-300/10 p-3 sm:p-4">
+              <p className="text-[0.65rem] font-bold uppercase tracking-[0.18em] text-rose-100 sm:text-xs sm:tracking-[0.2em]">{t.teamLabel}</p>
               <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="min-w-0">
                   <p className="text-base font-black text-white sm:text-lg">{t.teamTitle}</p>
@@ -192,22 +192,22 @@ export default function PokemonGuide() {
           </div>
         </section>
 
-        <section className="mb-6 rounded-3xl border border-white/10 bg-slate-950/45 p-3 backdrop-blur-xl sm:p-4">
+        <section className="mb-5 rounded-2xl border border-white/10 bg-slate-950/45 p-2.5 backdrop-blur-xl sm:mb-6 sm:rounded-3xl sm:p-4">
           <button
             type="button"
             onClick={() => setShowTips(!showTips)}
             className="flex w-full items-center justify-between gap-3 rounded-2xl px-2 py-2 text-left transition-colors hover:bg-white/5"
           >
             <span className="min-w-0">
-              <span className="block text-sm font-black uppercase tracking-[0.18em] text-rose-100">{t.tipsTitle}</span>
-              <span className="mt-1 block text-xs font-bold uppercase tracking-[0.16em] text-slate-400">{t.tipsBadge}</span>
+              <span className="block text-xs font-black uppercase tracking-[0.16em] text-rose-100 sm:tracking-[0.18em]">{t.tipsTitle}</span>
+              <span className="mt-1 block text-[0.65rem] font-bold uppercase tracking-[0.14em] text-slate-400 sm:text-xs sm:tracking-[0.16em]">{t.tipsBadge}</span>
             </span>
             {showTips ? <ChevronUp className="h-5 w-5 flex-none text-rose-200" /> : <ChevronDown className="h-5 w-5 flex-none text-rose-200" />}
           </button>
 
           {showTips && (
-            <div className="grid gap-4 pt-4 md:grid-cols-[1.2fr_0.8fr] animate-in slide-in-from-top duration-300">
-              <ul className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm leading-6 text-slate-200">
+            <div className="grid gap-3 pt-3 md:grid-cols-[1.2fr_0.8fr] md:gap-4 md:pt-4 animate-in slide-in-from-top duration-300">
+              <ul className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-3 text-sm leading-6 text-slate-200 sm:p-4">
                 {t.tips.map((tip) => (
                   <li key={tip} className="flex gap-3">
                     <span className="mt-2 h-2 w-2 flex-none rounded-full bg-rose-300" />
@@ -216,8 +216,8 @@ export default function PokemonGuide() {
                 ))}
               </ul>
 
-              <div className="rounded-2xl border border-amber-300/20 bg-amber-300/10 p-4">
-                <h2 className="mb-3 text-sm font-black uppercase tracking-[0.18em] text-amber-100">{t.boostLegendTitle}</h2>
+              <div className="rounded-2xl border border-amber-300/20 bg-amber-300/10 p-3 sm:p-4">
+                <h2 className="mb-3 text-xs font-black uppercase tracking-[0.16em] text-amber-100 sm:text-sm sm:tracking-[0.18em]">{t.boostLegendTitle}</h2>
                 <ul className="space-y-2 text-sm leading-6 text-amber-50">
                   {t.boostLegend.map((item) => (
                     <li key={item} className="break-words">{item}</li>
@@ -228,11 +228,11 @@ export default function PokemonGuide() {
           )}
         </section>
 
-        <section className="mb-6">
+        <section className="mb-5 sm:mb-6">
           <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-xs font-black uppercase tracking-[0.22em] text-slate-400">{t.selectRegion}</h2>
+            <h2 className="text-[0.68rem] font-black uppercase tracking-[0.18em] text-slate-400 sm:text-xs sm:tracking-[0.22em]">{t.selectRegion}</h2>
           </div>
-          <div className="grid grid-cols-1 gap-3 min-[420px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(135px,1fr))] gap-2.5 sm:gap-3">
             {regions.map((region) => (
               <RegionCard
                 key={region.id}
@@ -245,9 +245,9 @@ export default function PokemonGuide() {
         </section>
 
         {expandedRegion && currentRegion && currentRegion.leaders.length > 0 && (
-          <section className="mb-6 animate-in slide-in-from-top duration-300">
-            <h2 className="mb-3 text-xs font-black uppercase tracking-[0.22em] text-slate-400">{t.selectLeader}</h2>
-            <div className="grid grid-cols-1 gap-3 min-[420px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
+          <section className="mb-5 animate-in slide-in-from-top duration-300 sm:mb-6">
+            <h2 className="mb-3 text-[0.68rem] font-black uppercase tracking-[0.18em] text-slate-400 sm:text-xs sm:tracking-[0.22em]">{t.selectLeader}</h2>
+            <div className="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-2.5 sm:grid-cols-[repeat(auto-fit,minmax(145px,1fr))] sm:gap-3">
               {currentRegion.leaders.map((leader) => (
                 <LeaderCard
                   key={leader.id}
@@ -261,9 +261,9 @@ export default function PokemonGuide() {
         )}
 
         {expandedLeader && (
-          <section className="mb-6 animate-in slide-in-from-top duration-300">
-            <h2 className="mb-3 text-xs font-black uppercase tracking-[0.22em] text-slate-400">{t.selectPokemon}</h2>
-            <div className="grid grid-cols-2 gap-2 min-[380px]:grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10">
+          <section className="mb-5 animate-in slide-in-from-top duration-300 sm:mb-6">
+            <h2 className="mb-3 text-[0.68rem] font-black uppercase tracking-[0.18em] text-slate-400 sm:text-xs sm:tracking-[0.22em]">{t.selectPokemon}</h2>
+            <div className="grid grid-cols-[repeat(auto-fit,minmax(86px,1fr))] gap-2 sm:grid-cols-[repeat(auto-fit,minmax(105px,1fr))] sm:gap-3 lg:grid-cols-[repeat(auto-fit,minmax(115px,1fr))]">
               {currentLeaderPokemons.map((pokemon) => (
                 <PokemonCard
                   key={pokemon.id || pokemon.name}

--- a/src/components/RegionCard.tsx
+++ b/src/components/RegionCard.tsx
@@ -18,7 +18,7 @@ export const RegionCard = ({ region, isExpanded, onClick }: RegionCardProps) => 
   return (
     <button
       type="button"
-      className={`group relative min-w-0 overflow-hidden rounded-3xl border p-4 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 ${
+      className={`group relative min-w-0 overflow-hidden rounded-2xl border p-3 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 sm:rounded-3xl sm:p-4 ${
         isExpanded
           ? 'border-cyan-200/70 bg-slate-900/90 ring-2 ring-cyan-300/70'
           : 'border-white/10 bg-slate-950/55 hover:border-white/25 hover:bg-slate-900/80'
@@ -26,10 +26,10 @@ export const RegionCard = ({ region, isExpanded, onClick }: RegionCardProps) => 
       onClick={() => onClick(region.id)}
     >
       <div className={`absolute inset-0 bg-gradient-to-br ${regionAccent[region.id] || 'from-cyan-300/20 to-rose-400/10'} opacity-80`} />
-      <div className="relative flex h-16 items-end sm:h-24">
+      <div className="relative flex h-14 items-end sm:h-20 lg:h-24">
         <div className="min-w-0">
-          <span className="mb-2 block h-1 w-10 rounded-full bg-cyan-200 transition-all duration-300 group-hover:w-16" />
-          <span className="block truncate text-xl font-black text-white sm:text-2xl">{region.name}</span>
+          <span className="mb-2 block h-1 w-8 rounded-full bg-cyan-200 transition-all duration-300 group-hover:w-14 sm:w-10 sm:group-hover:w-16" />
+          <span className="block truncate text-lg font-black text-white sm:text-xl lg:text-2xl">{region.name}</span>
         </div>
       </div>
     </button>

--- a/src/components/TrickItem.tsx
+++ b/src/components/TrickItem.tsx
@@ -1,5 +1,5 @@
 import { ChevronRight, ChevronDown } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import type { Language } from "../i18n/translations"
 import type { Tricks } from "../interfaces/Pokemon"
 import { translateFullStrategyText } from "../utils/fullStrategyTranslations"
@@ -18,6 +18,11 @@ export function TrickItem({ trick, language, level = 0 }: TrickItemProps) {
   const strategyText = formatStrategyText(
     translateStrategyText(translateFullStrategyText(trick.detail, language), language),
   )
+  const indentation = level > 0 ? `clamp(${level * 0.35}rem, ${level * 1.5}vw, ${level * 0.85}rem)` : undefined
+
+  useEffect(() => {
+    setIsExpanded(false)
+  }, [trick.detail, language])
 
   const toggleExpand = () => {
     setIsExpanded(!isExpanded)
@@ -33,36 +38,38 @@ export function TrickItem({ trick, language, level = 0 }: TrickItemProps) {
   }
 
   return (
-    <div className="w-full">
+    <div className="w-full min-w-0 overflow-hidden">
       <div
-        className={`group mb-2 rounded-2xl border p-3 transition-all duration-300 ${
+        className={`group mb-2 rounded-2xl border p-2.5 transition-all duration-300 sm:p-3 ${
           hasVariants
             ? 'cursor-pointer border-rose-300/20 bg-rose-400/10 hover:border-rose-200/40 hover:bg-rose-400/15'
             : 'border-white/10 bg-white/5'
         }`}
-        style={{ marginLeft: `${level * 0.85}rem` }}
+        style={{ marginLeft: indentation }}
         onClick={hasVariants ? toggleExpand : undefined}
         onKeyDown={handleKeyDown}
         role={hasVariants ? 'button' : undefined}
         tabIndex={hasVariants ? 0 : undefined}
         aria-expanded={hasVariants ? isExpanded : undefined}
       >
-        <div className="flex items-start gap-3">
+        <div className="flex min-w-0 items-start gap-2.5 sm:gap-3">
           {hasVariants ? (
             isExpanded ? (
-              <ChevronDown className="mt-0.5 h-5 w-5 flex-shrink-0 text-rose-200 transition-transform duration-300" />
+              <ChevronDown className="mt-0.5 h-4 w-4 flex-shrink-0 text-rose-200 transition-transform duration-300 sm:h-5 sm:w-5" />
             ) : (
-              <ChevronRight className="mt-0.5 h-5 w-5 flex-shrink-0 text-rose-200 transition-transform duration-300 group-hover:translate-x-0.5" />
+              <ChevronRight className="mt-0.5 h-4 w-4 flex-shrink-0 text-rose-200 transition-transform duration-300 group-hover:translate-x-0.5 sm:h-5 sm:w-5" />
             )
           ) : (
             <span className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-cyan-300" />
           )}
-          <span className="text-sm leading-6 text-slate-100">{strategyText}</span>
+          <span className="min-w-0 overflow-hidden break-words text-sm leading-6 text-slate-100 [overflow-wrap:anywhere]">
+            {strategyText}
+          </span>
         </div>
       </div>
 
       {hasVariants && isExpanded && (
-        <div className="border-l border-rose-200/20 pl-3 animate-in slide-in-from-top duration-300">
+        <div className="min-w-0 overflow-hidden border-l border-rose-200/20 pl-2 animate-in slide-in-from-top duration-300 sm:pl-3">
           {variants.map((variant, index) => (
             <TrickItem
               key={`${variant.detail}-${index}`}


### PR DESCRIPTION
## Summary
- Improves responsive spacing and sizing across the main guide layout.
- Makes region, leader, and Pokémon cards more compact and balanced on mobile and tablet widths.
- Improves the Pokémon details panel to avoid horizontal overflow with long strategy text.
- Keeps nested route sections closed when entering or switching strategy context.

## Scope
Visual/layout components only:
- `src/components/PokemonGuide.tsx`
- `src/components/PokemonDetails.tsx`
- `src/components/TrickItem.tsx`
- `src/components/RegionCard.tsx`
- `src/components/LeaderCard.tsx`
- `src/components/PokemonCard.tsx`

## Notes
- No strategy JSON files are changed.
- No assets are changed.
- No `main` or deployment changes are included in this PR.