### PR TITLE
Improve responsive layout visibility

### DIFF
--- a/src/components/LeaderCard.tsx
+++ b/src/components/LeaderCard.tsx
@@ -13,23 +13,23 @@ export const LeaderCard = ({ leader, isExpanded, onClick }: LeaderCardProps) => 
   return (
     <button
       type="button"
-      className={`group relative min-w-0 overflow-hidden rounded-2xl border bg-slate-950/60 p-2.5 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 hover:border-rose-200/40 hover:bg-slate-900/90 sm:rounded-3xl sm:p-3 ${
+      className={`group relative min-w-0 overflow-hidden rounded-xl border bg-slate-950/75 p-2 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 hover:border-rose-200/50 hover:bg-slate-900/95 sm:rounded-3xl sm:p-3 ${
         isExpanded
-          ? 'scale-[1.01] border-rose-200/70 ring-2 ring-rose-300/70 sm:scale-[1.03]'
+          ? 'border-rose-200/80 ring-2 ring-rose-300/70'
           : 'border-white/10'
       }`}
       onClick={() => onClick(leader.id)}
     >
-      <div className="absolute inset-0 bg-gradient-to-br from-rose-400/15 via-transparent to-cyan-300/10 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-      <div className="relative flex h-20 items-center justify-center overflow-hidden rounded-xl min-[420px]:h-24 sm:h-28 lg:h-32">
+      <div className="absolute inset-0 bg-gradient-to-br from-rose-400/25 via-transparent to-cyan-300/15 opacity-80 transition-opacity duration-300 group-hover:opacity-100" />
+      <div className="relative flex h-24 items-center justify-center overflow-hidden rounded-lg bg-black/20 min-[420px]:h-28 sm:h-32 lg:h-36">
         <img
           src={leaderImage}
           alt={leader.name}
-          className="h-full w-full object-contain transition-transform duration-300 group-hover:scale-105"
+          className="h-full w-full object-contain drop-shadow-2xl transition-transform duration-300 group-hover:scale-105"
           loading="lazy"
         />
       </div>
-      <span className="relative mt-2 block truncate rounded-xl bg-black/35 px-2 py-1 text-center text-xs font-black text-white sm:text-sm lg:text-base">
+      <span className="relative mt-2 block truncate rounded-lg bg-black/55 px-2 py-1.5 text-center text-xs font-black text-white sm:rounded-xl sm:text-sm lg:text-base">
         {leader.name}
       </span>
     </button>

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -52,15 +52,15 @@ export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) 
   return (
     <button
       type="button"
-      className={`group relative min-w-0 cursor-pointer overflow-hidden rounded-2xl border bg-slate-950/60 p-2 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 hover:border-cyan-200/40 hover:bg-slate-900/90 ${
+      className={`group relative min-w-0 cursor-pointer overflow-hidden rounded-xl border bg-slate-950/75 p-1.5 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 hover:border-cyan-200/50 hover:bg-slate-900/95 sm:rounded-2xl sm:p-2 ${
         isSelected
-          ? 'scale-[1.01] border-cyan-200/70 ring-2 ring-cyan-300/70 sm:scale-[1.03]'
+          ? 'border-cyan-200/80 ring-2 ring-cyan-300/70'
           : 'border-white/10'
       }`}
       onClick={() => onClick(pokemon)}
     >
-      <div className="absolute inset-0 bg-gradient-to-b from-cyan-300/10 via-transparent to-rose-400/10 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-      <div className="relative flex h-16 items-center justify-center min-[380px]:h-20 sm:h-24 lg:h-28">
+      <div className="absolute inset-0 bg-gradient-to-b from-cyan-300/20 via-transparent to-rose-400/15 opacity-70 transition-opacity duration-300 group-hover:opacity-100" />
+      <div className="relative flex h-18 items-center justify-center rounded-lg bg-black/20 min-[380px]:h-20 sm:h-24 lg:h-28">
         <img
           src={spriteSrc}
           alt={pokemon.name}
@@ -69,7 +69,7 @@ export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) 
           onError={handleSpriteError}
         />
       </div>
-      <span className="relative mt-2 block truncate rounded-xl bg-black/35 px-1.5 py-1 text-center text-[0.68rem] font-black leading-tight text-white min-[380px]:text-xs sm:text-sm">
+      <span className="relative mt-1.5 block truncate rounded-lg bg-black/55 px-1.5 py-1 text-center text-[0.66rem] font-black leading-tight text-white min-[380px]:text-xs sm:text-sm">
         {pokemon.name}
       </span>
     </button>

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -60,7 +60,7 @@ export const PokemonCard = ({ pokemon, isSelected, onClick }: PokemonCardProps) 
       onClick={() => onClick(pokemon)}
     >
       <div className="absolute inset-0 bg-gradient-to-b from-cyan-300/20 via-transparent to-rose-400/15 opacity-70 transition-opacity duration-300 group-hover:opacity-100" />
-      <div className="relative flex h-18 items-center justify-center rounded-lg bg-black/20 min-[380px]:h-20 sm:h-24 lg:h-28">
+      <div className="relative flex h-[4.5rem] items-center justify-center rounded-lg bg-black/20 min-[380px]:h-20 sm:h-24 lg:h-28">
         <img
           src={spriteSrc}
           alt={pokemon.name}

--- a/src/components/PokemonGuide.tsx
+++ b/src/components/PokemonGuide.tsx
@@ -128,16 +128,16 @@ export default function PokemonGuide() {
 
   return (
     <div className="min-h-screen overflow-x-hidden bg-[#0b1020] text-slate-50">
-      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(244,63,94,0.22),_transparent_32%),radial-gradient(circle_at_top_right,_rgba(59,130,246,0.2),_transparent_28%),linear-gradient(135deg,_#0b1020_0%,_#111827_45%,_#1e1b4b_100%)]" />
+      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(244,63,94,0.28),_transparent_34%),radial-gradient(circle_at_top_right,_rgba(34,211,238,0.22),_transparent_30%),linear-gradient(135deg,_#070b18_0%,_#111827_45%,_#21174c_100%)]" />
 
-      <main className="relative mx-auto min-h-screen w-full max-w-7xl px-2 py-3 sm:px-5 sm:py-6 lg:px-8">
-        <section className="mb-4 overflow-hidden rounded-[1.25rem] border border-white/10 bg-white/[0.08] p-3 shadow-2xl shadow-black/30 backdrop-blur-xl sm:mb-8 sm:rounded-[2rem] sm:p-6 lg:p-8">
-          <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+      <main className="relative mx-auto min-h-screen w-full max-w-6xl px-3 py-3 sm:px-5 sm:py-6 lg:px-8">
+        <section className="mb-4 overflow-hidden rounded-2xl border border-white/15 bg-slate-950/70 p-4 shadow-2xl shadow-black/40 backdrop-blur-xl sm:mb-7 sm:rounded-[2rem] sm:p-6 lg:p-8">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div className="min-w-0 max-w-3xl">
-              <span className="mb-3 inline-flex max-w-full rounded-full border border-rose-300/30 bg-rose-400/10 px-3 py-1 text-[0.62rem] font-bold uppercase tracking-[0.16em] text-rose-100 sm:text-xs sm:tracking-[0.24em]">
+              <span className="mb-3 inline-flex max-w-full rounded-full border border-cyan-200/40 bg-cyan-300/15 px-3 py-1 text-[0.62rem] font-black uppercase tracking-[0.16em] text-cyan-100 sm:text-xs sm:tracking-[0.24em]">
                 PokeMMO Elite Four
               </span>
-              <h1 className="break-words text-2xl font-black leading-tight tracking-tight text-white min-[380px]:text-3xl sm:text-5xl lg:text-6xl">
+              <h1 className="break-words text-3xl font-black leading-none tracking-tight text-white min-[420px]:text-4xl sm:text-5xl lg:text-6xl">
                 {t.title}
               </h1>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-300 sm:mt-4 sm:text-base">
@@ -145,18 +145,18 @@ export default function PokemonGuide() {
               </p>
             </div>
 
-            <div className="flex w-full flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-3 sm:w-auto sm:min-w-48">
-              <span className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-slate-400 sm:text-xs sm:tracking-[0.2em]">{t.languageLabel}</span>
+            <div className="flex w-full flex-col gap-3 rounded-2xl border border-white/15 bg-white/10 p-3 sm:w-auto sm:min-w-52">
+              <span className="text-[0.65rem] font-bold uppercase tracking-[0.18em] text-slate-300 sm:text-xs sm:tracking-[0.2em]">{t.languageLabel}</span>
               <div className="grid grid-cols-2 gap-2">
                 {(Object.keys(languages) as Language[]).map((currentLanguage) => (
                   <button
                     key={currentLanguage}
                     type="button"
                     onClick={() => setLanguage(currentLanguage)}
-                    className={`rounded-xl px-3 py-2 text-sm font-bold transition-all duration-300 sm:px-4 ${
+                    className={`rounded-xl px-3 py-2 text-sm font-black transition-all duration-300 sm:px-4 ${
                       language === currentLanguage
-                        ? 'bg-rose-400 text-slate-950 shadow-lg shadow-rose-500/25'
-                        : 'bg-white/10 text-slate-200 hover:bg-white/15'
+                        ? 'bg-cyan-300 text-slate-950 shadow-lg shadow-cyan-500/25'
+                        : 'bg-slate-950/60 text-slate-200 hover:bg-white/15'
                     }`}
                   >
                     {languages[currentLanguage]}
@@ -166,13 +166,13 @@ export default function PokemonGuide() {
             </div>
           </div>
 
-          <div className="mt-5 grid gap-3 lg:mt-6 lg:grid-cols-[1.1fr_1fr]">
-            <div className="rounded-2xl border border-cyan-300/20 bg-cyan-300/10 p-3 sm:p-4">
-              <p className="text-[0.65rem] font-bold uppercase tracking-[0.18em] text-cyan-200 sm:text-xs sm:tracking-[0.2em]">{t.routeLabel}</p>
+          <div className="mt-4 grid gap-2 sm:mt-5 sm:grid-cols-2 sm:gap-3">
+            <div className="rounded-2xl border border-cyan-300/30 bg-cyan-300/10 p-3 sm:p-4">
+              <p className="text-[0.65rem] font-black uppercase tracking-[0.18em] text-cyan-200 sm:text-xs sm:tracking-[0.2em]">{t.routeLabel}</p>
               <p className="mt-2 break-words text-base font-black text-white sm:text-lg">{t.route}</p>
             </div>
-            <div className="rounded-2xl border border-rose-300/20 bg-rose-300/10 p-3 sm:p-4">
-              <p className="text-[0.65rem] font-bold uppercase tracking-[0.18em] text-rose-100 sm:text-xs sm:tracking-[0.2em]">{t.teamLabel}</p>
+            <div className="rounded-2xl border border-rose-300/30 bg-rose-300/10 p-3 sm:p-4">
+              <p className="text-[0.65rem] font-black uppercase tracking-[0.18em] text-rose-100 sm:text-xs sm:tracking-[0.2em]">{t.teamLabel}</p>
               <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="min-w-0">
                   <p className="text-base font-black text-white sm:text-lg">{t.teamTitle}</p>
@@ -192,11 +192,11 @@ export default function PokemonGuide() {
           </div>
         </section>
 
-        <section className="mb-5 rounded-2xl border border-white/10 bg-slate-950/45 p-2.5 backdrop-blur-xl sm:mb-6 sm:rounded-3xl sm:p-4">
+        <section className="mb-4 rounded-2xl border border-white/15 bg-slate-950/60 p-2.5 backdrop-blur-xl sm:mb-6 sm:rounded-3xl sm:p-4">
           <button
             type="button"
             onClick={() => setShowTips(!showTips)}
-            className="flex w-full items-center justify-between gap-3 rounded-2xl px-2 py-2 text-left transition-colors hover:bg-white/5"
+            className="flex w-full items-center justify-between gap-3 rounded-xl px-2 py-2 text-left transition-colors hover:bg-white/5 sm:rounded-2xl"
           >
             <span className="min-w-0">
               <span className="block text-xs font-black uppercase tracking-[0.16em] text-rose-100 sm:tracking-[0.18em]">{t.tipsTitle}</span>
@@ -228,11 +228,11 @@ export default function PokemonGuide() {
           )}
         </section>
 
-        <section className="mb-5 sm:mb-6">
+        <section className="mb-4 sm:mb-6">
           <div className="mb-3 flex items-center justify-between">
             <h2 className="text-[0.68rem] font-black uppercase tracking-[0.18em] text-slate-400 sm:text-xs sm:tracking-[0.22em]">{t.selectRegion}</h2>
           </div>
-          <div className="grid grid-cols-[repeat(auto-fit,minmax(135px,1fr))] gap-2.5 sm:gap-3">
+          <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 sm:gap-3 lg:grid-cols-5">
             {regions.map((region) => (
               <RegionCard
                 key={region.id}
@@ -245,9 +245,9 @@ export default function PokemonGuide() {
         </section>
 
         {expandedRegion && currentRegion && currentRegion.leaders.length > 0 && (
-          <section className="mb-5 animate-in slide-in-from-top duration-300 sm:mb-6">
+          <section className="mb-4 animate-in slide-in-from-top duration-300 sm:mb-6">
             <h2 className="mb-3 text-[0.68rem] font-black uppercase tracking-[0.18em] text-slate-400 sm:text-xs sm:tracking-[0.22em]">{t.selectLeader}</h2>
-            <div className="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-2.5 sm:grid-cols-[repeat(auto-fit,minmax(145px,1fr))] sm:gap-3">
+            <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 sm:gap-3 lg:grid-cols-5">
               {currentRegion.leaders.map((leader) => (
                 <LeaderCard
                   key={leader.id}
@@ -261,9 +261,9 @@ export default function PokemonGuide() {
         )}
 
         {expandedLeader && (
-          <section className="mb-5 animate-in slide-in-from-top duration-300 sm:mb-6">
+          <section className="mb-4 animate-in slide-in-from-top duration-300 sm:mb-6">
             <h2 className="mb-3 text-[0.68rem] font-black uppercase tracking-[0.18em] text-slate-400 sm:text-xs sm:tracking-[0.22em]">{t.selectPokemon}</h2>
-            <div className="grid grid-cols-[repeat(auto-fit,minmax(86px,1fr))] gap-2 sm:grid-cols-[repeat(auto-fit,minmax(105px,1fr))] sm:gap-3 lg:grid-cols-[repeat(auto-fit,minmax(115px,1fr))]">
+            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 sm:gap-3 md:grid-cols-6 xl:grid-cols-8">
               {currentLeaderPokemons.map((pokemon) => (
                 <PokemonCard
                   key={pokemon.id || pokemon.name}

--- a/src/components/RegionCard.tsx
+++ b/src/components/RegionCard.tsx
@@ -1,11 +1,11 @@
 import type { Region } from '../interfaces/Region'
 
 const regionAccent: Record<string, string> = {
-  kanto: 'from-red-400/25 to-amber-300/10',
-  johto: 'from-yellow-300/25 to-orange-400/10',
-  hoenn: 'from-emerald-300/25 to-cyan-400/10',
-  sinnoh: 'from-indigo-300/25 to-sky-400/10',
-  teselia: 'from-violet-300/25 to-rose-400/10',
+  kanto: 'from-red-400/35 to-amber-300/10',
+  johto: 'from-yellow-300/35 to-orange-400/10',
+  hoenn: 'from-emerald-300/35 to-cyan-400/10',
+  sinnoh: 'from-indigo-300/35 to-sky-400/10',
+  teselia: 'from-violet-300/35 to-rose-400/10',
 }
 
 interface RegionCardProps {
@@ -18,18 +18,18 @@ export const RegionCard = ({ region, isExpanded, onClick }: RegionCardProps) => 
   return (
     <button
       type="button"
-      className={`group relative min-w-0 overflow-hidden rounded-2xl border p-3 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 sm:rounded-3xl sm:p-4 ${
+      className={`group relative min-w-0 overflow-hidden rounded-xl border p-3 text-left shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 sm:rounded-3xl sm:p-4 ${
         isExpanded
-          ? 'border-cyan-200/70 bg-slate-900/90 ring-2 ring-cyan-300/70'
-          : 'border-white/10 bg-slate-950/55 hover:border-white/25 hover:bg-slate-900/80'
+          ? 'border-cyan-200/80 bg-slate-900/95 ring-2 ring-cyan-300/70'
+          : 'border-white/10 bg-slate-950/65 hover:border-white/25 hover:bg-slate-900/90'
       }`}
       onClick={() => onClick(region.id)}
     >
-      <div className={`absolute inset-0 bg-gradient-to-br ${regionAccent[region.id] || 'from-cyan-300/20 to-rose-400/10'} opacity-80`} />
-      <div className="relative flex h-14 items-end sm:h-20 lg:h-24">
+      <div className={`absolute inset-0 bg-gradient-to-br ${regionAccent[region.id] || 'from-cyan-300/25 to-rose-400/10'} opacity-95`} />
+      <div className="relative flex h-16 items-end sm:h-20 lg:h-24">
         <div className="min-w-0">
           <span className="mb-2 block h-1 w-8 rounded-full bg-cyan-200 transition-all duration-300 group-hover:w-14 sm:w-10 sm:group-hover:w-16" />
-          <span className="block truncate text-lg font-black text-white sm:text-xl lg:text-2xl">{region.name}</span>
+          <span className="block truncate text-base font-black text-white min-[390px]:text-lg sm:text-xl lg:text-2xl">{region.name}</span>
         </div>
       </div>
     </button>

--- a/src/components/TrickItem.tsx
+++ b/src/components/TrickItem.tsx
@@ -1,5 +1,5 @@
 import { ChevronRight, ChevronDown } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect, useState, type KeyboardEvent } from "react"
 import type { Language } from "../i18n/translations"
 import type { Tricks } from "../interfaces/Pokemon"
 import { translateFullStrategyText } from "../utils/fullStrategyTranslations"
@@ -18,7 +18,7 @@ export function TrickItem({ trick, language, level = 0 }: TrickItemProps) {
   const strategyText = formatStrategyText(
     translateStrategyText(translateFullStrategyText(trick.detail, language), language),
   )
-  const indentation = level > 0 ? `clamp(${level * 0.35}rem, ${level * 1.5}vw, ${level * 0.85}rem)` : undefined
+  const indentation = level > 0 ? `clamp(${level * 0.2}rem, ${level * 1.2}vw, ${level * 0.65}rem)` : undefined
 
   useEffect(() => {
     setIsExpanded(false)
@@ -28,7 +28,7 @@ export function TrickItem({ trick, language, level = 0 }: TrickItemProps) {
     setIsExpanded(!isExpanded)
   }
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (!hasVariants) return
 
     if (event.key === 'Enter' || event.key === ' ') {
@@ -40,9 +40,9 @@ export function TrickItem({ trick, language, level = 0 }: TrickItemProps) {
   return (
     <div className="w-full min-w-0 overflow-hidden">
       <div
-        className={`group mb-2 rounded-2xl border p-2.5 transition-all duration-300 sm:p-3 ${
+        className={`group mb-2 rounded-xl border p-2 transition-all duration-300 sm:rounded-2xl sm:p-3 ${
           hasVariants
-            ? 'cursor-pointer border-rose-300/20 bg-rose-400/10 hover:border-rose-200/40 hover:bg-rose-400/15'
+            ? 'cursor-pointer border-rose-300/30 bg-rose-400/15 hover:border-rose-200/50 hover:bg-rose-400/20'
             : 'border-white/10 bg-white/5'
         }`}
         style={{ marginLeft: indentation }}
@@ -52,7 +52,7 @@ export function TrickItem({ trick, language, level = 0 }: TrickItemProps) {
         tabIndex={hasVariants ? 0 : undefined}
         aria-expanded={hasVariants ? isExpanded : undefined}
       >
-        <div className="flex min-w-0 items-start gap-2.5 sm:gap-3">
+        <div className="flex min-w-0 items-start gap-2 sm:gap-3">
           {hasVariants ? (
             isExpanded ? (
               <ChevronDown className="mt-0.5 h-4 w-4 flex-shrink-0 text-rose-200 transition-transform duration-300 sm:h-5 sm:w-5" />
@@ -60,16 +60,16 @@ export function TrickItem({ trick, language, level = 0 }: TrickItemProps) {
               <ChevronRight className="mt-0.5 h-4 w-4 flex-shrink-0 text-rose-200 transition-transform duration-300 group-hover:translate-x-0.5 sm:h-5 sm:w-5" />
             )
           ) : (
-            <span className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-cyan-300" />
+            <span className="mt-2 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-cyan-300 sm:h-2 sm:w-2" />
           )}
-          <span className="min-w-0 overflow-hidden break-words text-sm leading-6 text-slate-100 [overflow-wrap:anywhere]">
+          <span className="min-w-0 overflow-hidden break-words text-[0.82rem] leading-5 text-slate-100 [overflow-wrap:anywhere] sm:text-sm sm:leading-6">
             {strategyText}
           </span>
         </div>
       </div>
 
       {hasVariants && isExpanded && (
-        <div className="min-w-0 overflow-hidden border-l border-rose-200/20 pl-2 animate-in slide-in-from-top duration-300 sm:pl-3">
+        <div className="min-w-0 overflow-hidden border-l border-rose-200/30 pl-1.5 animate-in slide-in-from-top duration-300 sm:pl-3">
           {variants.map((variant, index) => (
             <TrickItem
               key={`${variant.detail}-${index}`}


### PR DESCRIPTION
## Summary
- Makes the responsive layout changes more visually noticeable across mobile and tablet widths.
- Uses explicit fixed responsive grids instead of auto-fit behavior:
  - Regions: 2 columns on mobile, 3 on tablet, 5 on desktop.
  - Leaders: 2 columns on mobile, 3 on tablet, 5 on desktop.
  - Pokémon: 3 columns on mobile, 4 on small screens, 6 on tablet, 8 on wide screens.
- Strengthens mobile card contrast and spacing for regions, leaders, and Pokémon.
- Tightens nested strategy route spacing and reduces mobile text density.
- Keeps route sections closed when switching context.

## Scope
Visual/layout components only:
- `src/components/PokemonGuide.tsx`
- `src/components/TrickItem.tsx`
- `src/components/RegionCard.tsx`
- `src/components/LeaderCard.tsx`
- `src/components/PokemonCard.tsx`

## Notes
- No strategy JSON files are changed.
- No assets are changed.
- No `main` or deployment changes are included in this PR.