### PR TITLE
Blend League Farm banner background

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,12 @@ button {
   font: inherit;
 }
 
+img[src*="league-farm-banner"] {
+  mix-blend-mode: screen;
+  filter: brightness(1.12) contrast(1.25) saturate(1.08);
+  background: transparent;
+}
+
 @layer utilities {
   .animate-in {
     animation: fadeIn 0.28s ease-out both;


### PR DESCRIPTION
## Summary
- Adds a small CSS rule for the League Farm banner image.
- Uses blend/filter styling so the dark baked-in banner background visually disappears over the page background.
- Keeps the existing banner asset path unchanged.

## Scope
Only one file is updated:
- `src/index.css`

## Notes
- This is a visual fix for the current PNG background.
- No strategy JSON files are changed.
- No deployment configuration changes are included.