### PR TITLE
Release banner background blend fix

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,12 @@ button {
   font: inherit;
 }
 
+img[src*="league-farm-banner"] {
+  mix-blend-mode: screen;
+  filter: brightness(1.12) contrast(1.25) saturate(1.08);
+  background: transparent;
+}
+
 @layer utilities {
   .animate-in {
     animation: fadeIn 0.28s ease-out both;


### PR DESCRIPTION
## Summary
- Releases the League Farm banner background blend fix from `develop` to `main`.
- Adds a CSS rule so the dark baked-in PNG background visually blends into the page.

## Scope
Only one file is updated:
- `src/index.css`

## Validation
- Compared `main` against `develop`.
- Confirmed the release only includes the banner CSS blend fix.
- No strategy JSON files, assets, or deployment configuration changes are included.

## Notes
- This publishes the visual banner background fix to the GitHub Pages deploy through `main`.