### PR TITLE
Fix League Farm banner transparency

### DIFF
--- a/src/assets/league-farm-banner.svg
+++ b/src/assets/league-farm-banner.svg
@@ -1,0 +1,74 @@
+<svg width="1200" height="360" viewBox="0 0 1200 360" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">League Farm</title>
+  <desc id="desc">Transparent League Farm banner with PokeMMO inspired styling.</desc>
+
+  <defs>
+    <linearGradient id="titleFill" x1="118" y1="116" x2="1018" y2="292" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7dd3fc"/>
+      <stop offset="0.34" stop-color="#f0f9ff"/>
+      <stop offset="0.58" stop-color="#f9a8d4"/>
+      <stop offset="1" stop-color="#fb7185"/>
+    </linearGradient>
+    <linearGradient id="cyanStroke" x1="168" y1="70" x2="1072" y2="310" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#22d3ee"/>
+      <stop offset="0.5" stop-color="#818cf8"/>
+      <stop offset="1" stop-color="#fb7185"/>
+    </linearGradient>
+    <linearGradient id="logoFill" x1="42" y1="28" x2="250" y2="96" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fde047"/>
+      <stop offset="0.45" stop-color="#facc15"/>
+      <stop offset="1" stop-color="#f97316"/>
+    </linearGradient>
+    <filter id="softGlow" x="-20%" y="-40%" width="140%" height="190%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="0" stdDeviation="7" flood-color="#22d3ee" flood-opacity="0.65"/>
+      <feDropShadow dx="0" dy="12" stdDeviation="15" flood-color="#020617" flood-opacity="0.95"/>
+    </filter>
+    <filter id="hotGlow" x="-30%" y="-50%" width="160%" height="210%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="0" stdDeviation="5" flood-color="#fb7185" flood-opacity="0.72"/>
+      <feDropShadow dx="0" dy="10" stdDeviation="18" flood-color="#020617" flood-opacity="0.9"/>
+    </filter>
+    <filter id="logoShadow" x="-30%" y="-40%" width="160%" height="190%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="2" stdDeviation="1.4" flood-color="#1e3a8a" flood-opacity="1"/>
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#020617" flood-opacity="0.9"/>
+    </filter>
+  </defs>
+
+  <g opacity="0.9">
+    <path d="M88 244 C205 186 339 177 487 210 C684 254 830 244 1042 128" stroke="#22d3ee" stroke-width="8" stroke-linecap="round" opacity="0.28"/>
+    <path d="M128 284 C286 220 441 222 592 252 C785 291 913 248 1102 170" stroke="#fb7185" stroke-width="7" stroke-linecap="round" opacity="0.32"/>
+    <path d="M162 94 C315 134 494 112 667 88 C832 65 956 76 1098 116" stroke="#a78bfa" stroke-width="5" stroke-linecap="round" opacity="0.28"/>
+  </g>
+
+  <g opacity="0.96" filter="url(#softGlow)">
+    <path d="M170 254 L212 224 L188 216 L243 178 L224 210 L255 217 L170 254Z" fill="#67e8f9" opacity="0.78"/>
+    <path d="M974 102 L1018 76 L995 69 L1056 38 L1030 68 L1066 75 L974 102Z" fill="#fb7185" opacity="0.76"/>
+    <path d="M971 278 L1011 250 L987 243 L1042 205 L1020 237 L1055 245 L971 278Z" fill="#f9a8d4" opacity="0.72"/>
+  </g>
+
+  <g opacity="0.75">
+    <circle cx="130" cy="138" r="7" fill="#22d3ee"/>
+    <circle cx="1068" cy="231" r="8" fill="#fb7185"/>
+    <circle cx="900" cy="72" r="5" fill="#fef3c7"/>
+    <circle cx="310" cy="76" r="4" fill="#f9a8d4"/>
+    <path d="M754 66 L762 84 L781 91 L763 99 L756 118 L748 100 L729 93 L747 85 Z" fill="#fef9c3" opacity="0.85"/>
+    <path d="M410 296 L416 310 L431 315 L417 322 L412 338 L405 323 L390 318 L405 311 Z" fill="#bae6fd" opacity="0.8"/>
+    <path d="M1103 155 L1109 168 L1124 173 L1110 180 L1105 195 L1098 181 L1083 176 L1097 168 Z" fill="#fecdd3" opacity="0.82"/>
+  </g>
+
+  <g filter="url(#logoShadow)">
+    <text x="40" y="63" font-family="Impact, Haettenschweiler, 'Arial Black', sans-serif" font-size="34" font-weight="900" letter-spacing="-1.4" fill="url(#logoFill)" stroke="#1d4ed8" stroke-width="5" paint-order="stroke fill">PokeMMO</text>
+    <text x="44" y="89" font-family="Verdana, Arial, sans-serif" font-size="9" font-weight="900" letter-spacing="2.6" fill="#f8fafc" stroke="#020617" stroke-width="2" paint-order="stroke fill">NO BULLSHIT JUST GAMES</text>
+  </g>
+
+  <g filter="url(#hotGlow)">
+    <text x="86" y="228" font-family="Impact, Haettenschweiler, 'Arial Black', sans-serif" font-size="146" font-weight="900" letter-spacing="-3.5" fill="url(#titleFill)" stroke="#020617" stroke-width="18" paint-order="stroke fill">League Farm</text>
+    <text x="86" y="228" font-family="Impact, Haettenschweiler, 'Arial Black', sans-serif" font-size="146" font-weight="900" letter-spacing="-3.5" fill="transparent" stroke="url(#cyanStroke)" stroke-width="4" paint-order="stroke fill">League Farm</text>
+  </g>
+
+  <g opacity="0.64">
+    <path d="M96 250 H303" stroke="#7dd3fc" stroke-width="3" stroke-linecap="round"/>
+    <path d="M793 253 H1084" stroke="#fb7185" stroke-width="3" stroke-linecap="round"/>
+    <path d="M114 268 H246" stroke="#f9a8d4" stroke-width="2" stroke-linecap="round"/>
+    <path d="M852 272 H1046" stroke="#67e8f9" stroke-width="2" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/components/PokemonGuide.tsx
+++ b/src/components/PokemonGuide.tsx
@@ -6,7 +6,7 @@ import type { Region } from "../interfaces/Region"
 import type { Language } from "../i18n/translations"
 
 import { translations } from "../i18n/translations"
-import leagueFarmBanner from "../assets/league-farm-banner.png"
+import leagueFarmBanner from "../assets/league-farm-banner.svg"
 import { validatePokemonStrategy } from "../utils/strategyValidation"
 import { useDynamicImports } from "../hooks/useDynamicImports"
 import { RegionCard } from "./RegionCard"

--- a/src/index.css
+++ b/src/index.css
@@ -31,12 +31,6 @@ button {
   font: inherit;
 }
 
-img[src*="league-farm-banner"] {
-  mix-blend-mode: screen;
-  filter: brightness(1.12) contrast(1.25) saturate(1.08);
-  background: transparent;
-}
-
 @layer utilities {
   .animate-in {
     animation: fadeIn 0.28s ease-out both;


### PR DESCRIPTION
## Summary
- Adds a new SVG League Farm banner with a real transparent background.
- Updates the header to use the transparent SVG instead of the PNG with a baked-in background.
- Removes the `mix-blend-mode` banner workaround from global CSS.

## Scope
Changed files:
- `src/assets/league-farm-banner.svg`
- `src/components/PokemonGuide.tsx`
- `src/index.css`

## Notes
- This is a visual-only fix.
- No strategy JSON files were changed.
- Existing PNG asset is left untouched, but it is no longer used by the header.