### PR TITLE
Clarify Will strategy routes

### DIFF
--- a/src/data/johto/will/clefable.json
+++ b/src/data/johto/will/clefable.json
@@ -11,7 +11,7 @@
           "detail": "Si entra Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +6 y Precisión X. Mantén Otra Vez cada vez que puedas."
         },
         {
-          "detail": "Si el movimiento principal no sirve contra Xatu, usa la cobertura especial dos veces."
+          "detail": "Si Bola Sombra queda bloqueada contra Xatu, usa Onda Certera dos veces para derrotarlo."
         },
         {
           "detail": "Si entra Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X. Mantén Otra Vez cada vez que puedas."

--- a/src/data/johto/will/gardevoir.json
+++ b/src/data/johto/will/gardevoir.json
@@ -11,7 +11,7 @@
           "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +6 y Precisión X."
         },
         {
-          "detail": "Si la cobertura principal queda limitada, usa Onda Certera para cubrir a Xatu."
+          "detail": "Si Bola Sombra queda bloqueada contra Xatu, usa Onda Certera para derrotarlo."
         }
       ]
     }

--- a/src/data/johto/will/typhlosion.json
+++ b/src/data/johto/will/typhlosion.json
@@ -8,7 +8,7 @@
       "detail": "Coloca Trampa Rocas y prepara la entrada segura de Poliwrath.",
       "variant": [
         {
-          "detail": "Entra con Poliwrath y usa Tambor hasta +6 Ataque."
+          "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     }

--- a/src/data/johto/will/xatu.json
+++ b/src/data/johto/will/xatu.json
@@ -11,7 +11,7 @@
           "detail": "Si tiene Llamasfera, usa Amortiguador hasta que salga Golurk. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X."
         },
         {
-          "detail": "Si no tiene Llamasfera, cambia a Slowbro y usa Bostezo. Cuando salga Magnezone, usa Protección y cambia a Chansey. Cuando salga Girafarig, coloca Trampa Rocas. Luego usa Gengar con Otra Vez, cambia a Slowbro frente a Mantine y usa Bostezo. Después entra con Poliwrath para usar Tambor hasta +6 Ataque."
+          "detail": "Si no tiene Llamasfera, cambia a Slowbro y usa Bostezo. Cuando salga Magnezone, usa Protección y cambia a Chansey. Cuando salga Girafarig, coloca Trampa Rocas. Luego usa Gengar con Otra Vez, cambia a Slowbro frente a Mantine y usa Bostezo. Después sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     },
@@ -19,7 +19,7 @@
       "detail": "Si entra Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol o Bronzong, entra con Poliwrath para usar Tambor hasta +6 Ataque."
+          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol o Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque."
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Clarifies Xatu coverage in Will routes for Clefable and Gardevoir.
- Makes Politoed sacrifice steps explicit in Typhlosion and Xatu routes.
- Keeps the strategy wording aligned with the current JSON structure.

## Scope
Changed files:
- `src/data/johto/will/clefable.json`
- `src/data/johto/will/gardevoir.json`
- `src/data/johto/will/typhlosion.json`
- `src/data/johto/will/xatu.json`

## Notes
- Strategy-only fix.
- No visual assets, components, CSS, or unrelated JSON files were changed.