### PR TITLE
Refine Sixto strategy routes

### DIFF
--- a/src/data/hoenn/sixto/absol.json
+++ b/src/data/hoenn/sixto/absol.json
@@ -63,7 +63,7 @@
               "variant": []
             },
             {
-              "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+              "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
               "variant": []
             }
           ]
@@ -89,7 +89,7 @@
               "variant": []
             },
             {
-              "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+              "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
               "variant": []
             }
           ]

--- a/src/data/hoenn/sixto/luxray.json
+++ b/src/data/hoenn/sixto/luxray.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
           "variant": []
         },
         {

--- a/src/data/hoenn/sixto/metagross.json
+++ b/src/data/hoenn/sixto/metagross.json
@@ -10,10 +10,6 @@
         {
           "detail": "Gengar usa Maquinación hasta +2 y barre con Bola Sombra.",
           "variant": []
-        },
-        {
-          "detail": "Huntail tiene Banda Focus; mantén la ruta preparada antes de intentar cerrar el combate.",
-          "variant": []
         }
       ]
     }

--- a/src/data/hoenn/sixto/sableye.json
+++ b/src/data/hoenn/sixto/sableye.json
@@ -23,16 +23,15 @@
     },
     {
       "detail": "Si sale Aggron, sacrifica a Politoed y entra con Poliwrath para usar Puño Drenaje.",
-      "variant": [
-        {
-          "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas.",
-          "variant": []
-        },
-        {
-          "detail": "Si sale Hariyama, Poliwrath usa Ataque X y termina con Cascada contra Hariyama.",
-          "variant": []
-        }
-      ]
+      "variant": []
+    },
+    {
+      "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Hariyama, Poliwrath usa Ataque X y termina con Cascada contra Hariyama.",
+      "variant": []
     }
   ]
 }

--- a/src/data/hoenn/sixto/salamence.json
+++ b/src/data/hoenn/sixto/salamence.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/sixto/scizor.json
+++ b/src/data/hoenn/sixto/scizor.json
@@ -5,7 +5,7 @@
   "initialMove": "🦋 Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Entra con Volcarona, usa Danza Aleteo x2 y Especial X.",
+      "detail": "Entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X.",
       "variant": [
         {
           "detail": "Usa Gigadrenado contra Luxray.",

--- a/src/data/hoenn/sixto/scrafty.json
+++ b/src/data/hoenn/sixto/scrafty.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/sixto/shiftry.json
+++ b/src/data/hoenn/sixto/shiftry.json
@@ -13,17 +13,15 @@
         },
         {
           "detail": "Si entra Aggron, sacrifica a Politoed y entra con Poliwrath para derrotarlo.",
-          "variant": [
-            {
-              "detail": "Si luego entra Shiftry, cambia a Volcarona, usa Danza Aleteo x2 y Lanzallamas contra Shiftry. Contra el resto de plantas, usa Psíquico. Mantén los PS por encima del 23%.",
-              "variant": [
-                {
-                  "detail": "Si entra Hariyama, Poliwrath usa Ataque X y ataca. Usa Cascada contra Hariyama.",
-                  "variant": []
-                }
-              ]
-            }
-          ]
+          "variant": []
+        },
+        {
+          "detail": "Si entra Shiftry, cambia a Volcarona, usa Danza Aleteo x2 y Lanzallamas contra Shiftry. Contra el resto de plantas, usa Psíquico. Mantén los PS por encima del 23%.",
+          "variant": []
+        },
+        {
+          "detail": "Si entra Hariyama, Poliwrath usa Ataque X y ataca. Usa Cascada contra Hariyama.",
+          "variant": []
         }
       ]
     }

--- a/src/data/hoenn/sixto/spiritomb.json
+++ b/src/data/hoenn/sixto/spiritomb.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si sale Mienshao, Gengar lo derrota con Bola Sombra. Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2.",
+          "detail": "Si sale Mienshao, Gengar lo derrota con Bola Sombra. Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2. Usa Gigadrenado contra Absol.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/sixto/tentacruel.json
+++ b/src/data/hoenn/sixto/tentacruel.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Usa Gigadrenado contra Luxray.",
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
           "variant": []
         }
       ]


### PR DESCRIPTION
## Summary
- Aligns Sixto strategy wording with the reviewed route notes.
- Replaces vague `Especial X` wording with `Ataque Especial X` in Volcarona routes.
- Cleans an extra Metagross note that did not belong to the current route.
- Flattens Sableye and Shiftry route options so Aggron, Shiftry, and Hariyama are easier to follow.
- Adds the missing Gigadrenado note in the Spiritomb route.

## Scope
Changed files:
- `src/data/hoenn/sixto/absol.json`
- `src/data/hoenn/sixto/luxray.json`
- `src/data/hoenn/sixto/metagross.json`
- `src/data/hoenn/sixto/sableye.json`
- `src/data/hoenn/sixto/salamence.json`
- `src/data/hoenn/sixto/scizor.json`
- `src/data/hoenn/sixto/scrafty.json`
- `src/data/hoenn/sixto/shiftry.json`
- `src/data/hoenn/sixto/spiritomb.json`
- `src/data/hoenn/sixto/tentacruel.json`

## Notes
- Strategy-only fix.
- No visual assets, components, CSS, or unrelated strategy files were changed.