### PR TITLE
Polish Johto Bruno compact strategy text

### DIFF
--- a/src/data/johto/bruno/aggron.json
+++ b/src/data/johto/bruno/aggron.json
@@ -5,7 +5,7 @@
   "initialMove": "❤️ Encanto ❤️",
   "tricks": [
     {
-      "detail": "Toma Max Poción ➜ Amortiguador contra Machamp ➜ Cambia a Gengar, Otra vez, +4",
+      "detail": "Toma una Max Poción, usa Amortiguador contra Machamp y luego cambia a Gengar. Usa Otra Vez y Maquinación hasta +4.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/blastoise.json
+++ b/src/data/johto/bruno/blastoise.json
@@ -2,20 +2,19 @@
   "id": "blastoise",
   "name": "Blastoise",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " 🥚 Amortiguador 🥚",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Blaziken ➜ cambiar a Gengar +4 +2 (Blaziken Pañuelo elegido)",
+      "detail": "Si sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Blaziken tiene Pañuelo Elegido.",
       "variant": []
     },
     {
-      "detail": "Hitmonchan ➜ cambiar a Slowbro ➜ Bostezo a Metagros ➜ sacrifica  Politoed ➜ Poliwrath +6",
+      "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo frente a Metagross. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Machamp ➜ cambiar a Gengar, Otra Vez, +4 +2",
+      "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
       "variant": []
-  
     }
   ]
 }

--- a/src/data/johto/bruno/blaziken.json
+++ b/src/data/johto/bruno/blaziken.json
@@ -2,6 +2,6 @@
   "id": "blaziken",
   "name": "Blaziken",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambia a Gengar +4 +2  (Blaziken Pañuelo elegido )",
+  "initialMove": "💡 Cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Blaziken tiene Pañuelo Elegido. 💡",
   "tricks": []
 }

--- a/src/data/johto/bruno/darmanitan.json
+++ b/src/data/johto/bruno/darmanitan.json
@@ -2,18 +2,18 @@
   "id": "darmanitan",
   "name": "Darmanitan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Varias Opciones Mira Abajo 💡",
+  "initialMove": "💡 Varias opciones. Revisa abajo. 💡",
   "tricks": [
     {
-      "detail": "Asegurar ➜ Volcarona +3 🦋🔥",
+      "detail": "Ruta segura de ahorro: entra con Volcarona y usa Danza Aleteo x3.",
       "variant": []
     },
     {
-      "detail": "Estable ➜ Slowbro usa Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊",
+      "detail": "Ruta estable: Slowbro usa Bostezo, luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "⚠️Arriesgar⚠️ ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊",
+      "detail": "Ruta arriesgada: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/eelektross.json
+++ b/src/data/johto/bruno/eelektross.json
@@ -2,35 +2,35 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Blaziken ➜ cambiar a Gengar +4 +2 (Blaziken Pañuelo elegido)",
+      "detail": "Si sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Blaziken tiene Pañuelo Elegido.",
       "variant": []
     },
     {
-      "detail": "Frente a Darmanitan ➜ Varias opciones",
+      "detail": "Frente a Darmanitan, elige una de estas rutas.",
       "variant": [
         {
-          "detail": "Ahorro $? → Volcarona +3 🦋🔥",
+          "detail": "Ruta de ahorro: entra con Volcarona y usa Danza Aleteo x3.",
           "variant": []
         },
         {
-          "detail": "Estable → Slowbro Bostezo → Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
+          "detail": "Ruta estable: Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "RNG → Sacrifica a Politoed Poliwrath +6 🐸🥊",
+          "detail": "Ruta arriesgada: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Hitmonchan ➜ Cambiar a Slowbro Bostezo, sale Metagross → Sacrifica a Politoed Poliwrath +6 🐸🥊",
+      "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo. Cuando salga Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Machamp ➜ cambiar a  👻 Gengar Otra Vez +4 +2 👻",
+      "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/electivire.json
+++ b/src/data/johto/bruno/electivire.json
@@ -2,39 +2,39 @@
   "id": "electivire",
   "name": "Electivire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Metagross ➜ Cambiar a Slowbro y usar Bostezo (repetidamente) hasta que salga Golem → sacrifica a Politoed → entra con Poliwrath +6🐸🥊",
+      "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo repetidamente hasta que salga Golem. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Golem ➜ Encanto, amortiguador → sale Metagross ➜ cambiar a Slowbro bostezo → Sacrifica Politoed ➜ Poliwrath +6🐸🥊",
+      "detail": "Si sale Golem, usa Encanto y Amortiguador. Cuando salga Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Machamp → Gengar, Otra Vez, +2",
+      "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Se queda → Gengar +4 🔔(Barre con Bola Sombra)🔔",
+          "detail": "Si Machamp se queda, usa Maquinación hasta +4 y barre con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Sale Salamence → Barrre hasta que salga Aggron",
+          "detail": "Si sale Salamence, usa Bola Sombra hasta que salga Aggron.",
           "variant": [
             {
-              "detail": "Gengar derrota con critico a Aggron → Termina de Barrer",
+              "detail": "Si Gengar derrota a Aggron con un golpe crítico, termina de barrer.",
               "variant": []
             },
             {
-              "detail": "Aggron derrota a Gengar (no activa cuerpo maldito) → Saca a Volcarona elimina a Aggdron, entra Slowbro enemigo usa danza aleteo y ataca",
+              "detail": "Si Aggron derrota a Gengar y no activa Cuerpo Maldito, entra con Volcarona, derrota a Aggron y usa Danza Aleteo x1 frente al Slowbro rival.",
               "variant": []
             },
             {
-              "detail": "Aggron derrota a Gengar (Activa cuerpo maldito) → Volcarona +1",
+              "detail": "Si Aggron derrota a Gengar y se activa Cuerpo Maldito, entra con Volcarona y usa Danza Aleteo x1.",
               "variant": []
-            } 
-          ]  
+            }
+          ]
         }
       ]
     }

--- a/src/data/johto/bruno/gliscor.json
+++ b/src/data/johto/bruno/gliscor.json
@@ -2,10 +2,10 @@
   "id": "gliscor",
   "name": "Gliscor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Cambiar a Slowbro Bostezo contra Metagros ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
+      "detail": "Cambia a Slowbro y usa Bostezo contra Metagross. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/golem.json
+++ b/src/data/johto/bruno/golem.json
@@ -2,10 +2,10 @@
   "id": "golem",
   "name": "Golem",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "❤️ Encanto y Trampa rocas 🪨",
+  "initialMove": "❤️ Encanto y Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Metagros → Slowbro Bostezo → Sacrifica Politoed ➜ Poliwrath +6",
+      "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/heracross.json
+++ b/src/data/johto/bruno/heracross.json
@@ -2,76 +2,76 @@
   "id": "heracross",
   "name": "Heracross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Varias Opciones💡",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Ruta Arriesgada → Trampa Rocas",
+      "detail": "Ruta arriesgada: coloca Trampa Rocas.",
       "variant": [
         {
-          "detail": "No crítico → Gengar, Otra Vez, +2 + Precisión X (heracross tiene banda focus)",
+          "detail": "Si no recibes crítico, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Heracross tiene Banda Focus.",
           "variant": []
         },
         {
-          "detail": "Crítico pero usas Trampa Rocas → Politoed (sacrificar), Poliwrath → Gengar, Otra Vez, +2 + Precisión X",
+          "detail": "Si recibes crítico pero colocaste Trampa Rocas, sacrifica a Politoed, entra con Poliwrath y luego cambia a Gengar. Usa Otra Vez, Maquinación hasta +2 y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Crítico pero no usas Trampa Rocas → GG, Rip, Reinicia :)",
+          "detail": "Si recibes crítico y no colocaste Trampa Rocas, reinicia la ruta.",
           "variant": []
         }
       ]
     },
     {
-      "detail": " Ruta Segura → Gengar, Otra Vez, +2",
+      "detail": "Ruta segura: cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Se queda → Derrótalo, sale Steelix → Slowbro, Bostezo → Teletransporte → Chansey, Trampa Rocas",
+          "detail": "Si Heracross se queda, derrótalo. Si luego sale Steelix, cambia a Slowbro, usa Bostezo y después Teletransporte hacia Chansey para colocar Trampa Rocas.",
           "variant": [
             {
-              "detail": "Machamp → Gengar, Otra Vez → Chansey, sale Staraptor → Gengar, Otra Vez, +2 + Precisión X",
+              "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, luego pasa por Chansey. Frente a Staraptor, vuelve a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
               "variant": []
             },
             {
-              "detail": "Staraptor → Gengar, Otra Vez, +2 + Precisión X",
+              "detail": "Si sale Staraptor, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Kangaskhan → Chansey, Trampa Rocas",
+          "detail": "Si sale Kangaskhan, cambia a Chansey y coloca Trampa Rocas.",
           "variant": [
             {
-              "detail": "Heracross → Amortiguador → Teletransporte → Gengar, Otra Vez, +2 + Precisión X",
+              "detail": "Si sale Heracross, usa Amortiguador y luego Teletransporte hacia Gengar. Usa Otra Vez, Maquinación hasta +2 y Precisión X.",
               "variant": []
             },
             {
-              "detail": "Staraptor → Gengar, Otra Vez, +2 + Precisión X",
+              "detail": "Si sale Staraptor, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
               "variant": []
             },
             {
-              "detail": "Machamp → Gengar Otra vez → Chansey y Frente a Staraptor → Gengar Otra vez +2 + Precisión X",
+              "detail": "Si sale Machamp, cambia a Gengar y usa Otra Vez. Luego pasa por Chansey y, frente a Staraptor, vuelve a Gengar. Usa Otra Vez, Maquinación hasta +2 y Precisión X.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Machamp → Chansey → Gengar, Otra Vez, +2",
+          "detail": "Si sale Machamp, pasa por Chansey y luego cambia a Gengar. Usa Otra Vez y Maquinación hasta +2.",
           "variant": [
             {
-              "detail": "Se queda → Derrótalo → si entra Steelix cambia a Slowbro, mantén Bostezo, sale Heracross → Teletransporte → Chansey, Trampa Rocas",
+              "detail": "Si Machamp se queda, derrótalo. Si entra Steelix, cambia a Slowbro, mantén Bostezo y cuando salga Heracross usa Teletransporte hacia Chansey para colocar Trampa Rocas.",
               "variant": [
                 {
-                  "detail": "Machamp → Gengar, Otra Vez → Chansey, frente a Staraptor → Gengar, Otra Vez, +2 + Precisión X",
+                  "detail": "Si vuelve Machamp, cambia a Gengar, usa Otra Vez, pasa por Chansey y frente a Staraptor vuelve a Gengar. Usa Otra Vez, Maquinación hasta +2 y Precisión X.",
                   "variant": []
                 },
                 {
-                  "detail": "Staraptor → Gengar, Otra Vez, +2 + Precisión X",
+                  "detail": "Si sale Staraptor, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
                   "variant": []
                 }
               ]
             },
             {
-              "detail": "Kangaskhan → Chansey → Trampa Rocas → seguir guía de Kangaskhan arriba ",
+              "detail": "Si sale Kangaskhan, cambia a Chansey, coloca Trampa Rocas y sigue la ruta de Kangaskhan indicada arriba.",
               "variant": []
             }
           ]

--- a/src/data/johto/bruno/hitmonchan.json
+++ b/src/data/johto/bruno/hitmonchan.json
@@ -2,10 +2,10 @@
   "id": "hitmonchan",
   "name": "Hitmonchan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro, Bostezo",
+  "initialMove": "Cambia a Slowbro y usa Bostezo.",
   "tricks": [
     {
-      "detail": "Metagross → Politoed (sacrificar), Poliwrath +6",
+      "detail": "Si sale Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/hitmonlee.json
+++ b/src/data/johto/bruno/hitmonlee.json
@@ -2,30 +2,30 @@
   "id": "hitmonlee",
   "name": "Hitmonlee",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar → Slowbro, Bostezo → Chansey, Trampa rocas💡",
+  "initialMove": "💡 Gengar → Slowbro con Bostezo → Chansey con Trampa Rocas 💡",
   "tricks": [
     {
-      "detail": "Hitmonlee → Gengar, derrótalo → sale Machamp, cambia a Chansey → Gengar, otra vez, +2",
+      "detail": "Si sale Hitmonlee, entra con Gengar y derrótalo. Si luego sale Machamp, cambia a Chansey y vuelve a Gengar. Usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Se queda → Gengar +6, utiliza Otra Vez cada que puedas. Derrota a todos con Bola Sombra",
+          "detail": "Si Machamp se queda, usa Maquinación hasta +6, mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Salamence → Derrótalo, sale Machamp → Poliwrath → Gengar +6, utiliza Otra Vez cada que puedas. Derrota a todos con Bola Sombra",
+          "detail": "Si sale Salamence, derrótalo. Cuando salga Machamp, pasa por Poliwrath y vuelve a Gengar. Usa Maquinación hasta +6, mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Machamp/Luxray → Gengar, otra vez, +2",
+      "detail": "Si sale Machamp o Luxray, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Se queda → Gengar +6, utiliza Otra Vez cada que puedas. Derrota a todos con Bola Sombra",
+          "detail": "Si se queda, usa Maquinación hasta +6, mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Salamence → Derrótalo, sale Machamp → Poliwrath → Gengar +6, utiliza Otra Vez cada que puedas. Derrota a todos con Bola Sombra",
+          "detail": "Si sale Salamence, derrótalo. Cuando salga Machamp, pasa por Poliwrath y vuelve a Gengar. Usa Maquinación hasta +6, mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
           "variant": []
         }
       ]

--- a/src/data/johto/bruno/hitmontop.json
+++ b/src/data/johto/bruno/hitmontop.json
@@ -2,10 +2,10 @@
   "id": "hitmontop",
   "name": "Hitmontop",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Machamp → Gengar, Otra Vez, +4",
+      "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez y Maquinación hasta +4.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/kangaskhan.json
+++ b/src/data/johto/bruno/kangaskhan.json
@@ -2,10 +2,10 @@
   "id": "kangaskhan",
   "name": "Kangaskhan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Frente a Heracross ➜ Amortiguador, Teletransporte (recibes el A Bocajarro) → Gengar, otra vez, +2 + precisión x (heracross Banda focus)",
+      "detail": "Frente a Heracross, usa Amortiguador y luego Teletransporte mientras recibes A Bocajarro. Entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Heracross tiene Banda Focus.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/krookodile.json
+++ b/src/data/johto/bruno/krookodile.json
@@ -2,10 +2,10 @@
   "id": "krookodile",
   "name": "Krookodile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🦋 Volcarona +2",
+  "initialMove": "🦋 Volcarona usa Danza Aleteo x2",
   "tricks": [
     {
-      "detail": "-",
+      "detail": "Después de preparar a Volcarona con Danza Aleteo x2, continúa atacando para cerrar la ruta.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/lucario.json
+++ b/src/data/johto/bruno/lucario.json
@@ -5,11 +5,11 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Machamp ➜ Gengar, Otra Vez → Chansey, sale Staraptor → Volcarona +2",
+      "detail": "Si sale Machamp, cambia a Gengar y usa Otra Vez. Luego pasa por Chansey; cuando salga Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
       "variant": []
     },
     {
-      "detail": "Krookodile/Staraptor ➜ Volcarona +2",
+      "detail": "Si sale Krookodile o Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/luxray.json
+++ b/src/data/johto/bruno/luxray.json
@@ -2,14 +2,14 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas → Gengar, otra vez, +2",
+  "initialMove": "🪨 Trampa Rocas → Gengar, Otra Vez y Maquinación hasta +2",
   "tricks": [
     {
-      "detail": "Se queda ➜ Gengar +6, utiliza Otra Vez cada que puedas. Derrota a todos con bola sombra",
+      "detail": "Si Luxray se queda, usa Maquinación hasta +6, mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
       "variant": []
     },
     {
-      "detail": "Salamence → Derrótalo, sale Machamp → Poliwrath → Gengar, otra vez, +6. Utiliza Otra Vez cada que puedas. Derrota a todos con bola sombra",
+      "detail": "Si sale Salamence, derrótalo. Cuando salga Machamp, pasa por Poliwrath y vuelve a Gengar. Usa Otra Vez, Maquinación hasta +6, mantén Otra Vez cada vez que puedas y derrota a todos con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/machamp.json
+++ b/src/data/johto/bruno/machamp.json
@@ -2,66 +2,66 @@
   "id": "machamp",
   "name": "Machamp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar💡",
+  "initialMove": "💡 Gengar 💡",
   "tricks": [
     {
-      "detail": "Puño Dinámico ➜ Cambia a Slowbro, bostezo",
+      "detail": "Si Machamp usa Puño Dinámico, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Vendetta → bostezo, sale metagross/eelektross → Sacrifica a Politoed , Poliwrath +6🐸🥊",
+          "detail": "Si usa Vendetta, vuelve a usar Bostezo. Cuando salga Metagross o Eelektross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Roca Afilada → Bostezo",
+          "detail": "Si usa Roca Afilada, usa Bostezo.",
           "variant": [
             {
-              "detail": "Salamence (sin intimidación) → Chansey, trampa rocas → Gengar frente a hitmonlee → Gengar Bola sombra",
+              "detail": "Si sale Salamence sin Intimidación, cambia a Chansey y coloca Trampa Rocas. Frente a Hitmonlee, entra con Gengar y usa Bola Sombra.",
               "variant": [
                 {
-                  "detail": "si el riva saca a Machamp ➜ cambia a Chansey y cambia a Gengar otra vez +4. Gengar tiene un 20% de probabilidad de debilitar a Steelix ➜ Si gengar muere saca a Volcarona x1 Danza aleteo.",
+                  "detail": "Si el rival saca a Machamp, cambia a Chansey y vuelve a Gengar. Usa Otra Vez y Maquinación hasta +4. Gengar tiene una probabilidad baja de debilitar a Steelix; si Gengar cae, entra con Volcarona y usa Danza Aleteo x1.",
                   "variant": []
                 },
                 {
-                  "detail": "Si el rival usa Patada Salto Alta (o si Hitmonlee huye) Frente Machamp ➜ cambiar a Slowbro y luego a chansey frente Luxray ➜ Gengar otra vez 2 + Precisión X",
+                  "detail": "Si el rival usa Patada Salto Alta, o si Hitmonlee huye frente a Machamp, cambia a Slowbro y luego a Chansey frente a Luxray. Entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
                   "variant": []
                 }
               ]
             },
             {
-              "detail": "Eelektross → Chansey encanto y frente a Aggron usa Amortiguador → Machamp → Gengar Otra Vez +4",
+              "detail": "Si sale Eelektross, usa Encanto con Chansey. Frente a Aggron, usa Amortiguador; cuando vuelva Machamp, entra con Gengar, usa Otra Vez y Maquinación hasta +4.",
               "variant": []
             },
             {
-              "detail": "Metagross → Sacrifica a Politoed, Poliwrath +6🐸🥊",
+              "detail": "Si sale Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Puño Hielo → Bostezo frente a Metagross → Sacrifica a Politoed , Poliwrath +6🐸🥊",
+          "detail": "Si usa Puño Hielo, usa Bostezo frente a Metagross. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Puño Drenaje + Llamaesfera → Gengar, otra vez, +2",
+      "detail": "Si Machamp usa Puño Drenaje y tiene Llamaesfera, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Se queda → Derrótalo → Steelix → Slowbro, bostezo",
+          "detail": "Si se queda, derrótalo. Si luego sale Steelix, cambia a Slowbro y usa Bostezo.",
           "variant": [
             {
-              "detail": "Se queda → Protección → Bostezo → Heracross → Chansey → Gengar +4 + precisión X",
+              "detail": "Si Steelix se queda, usa Protección y luego Bostezo. Cuando salga Heracross, cambia a Chansey y después a Gengar. Usa Maquinación hasta +4 y Precisión X.",
               "variant": []
             },
             {
-              "detail": "Heracross → Chansey → Steelix → Trampa rocas",
+              "detail": "Si sale Heracross, cambia a Chansey. Si luego sale Steelix, coloca Trampa Rocas.",
               "variant": [
                 {
-                  "detail": "Machamp → Gengar → Chansey → Staraptor → Gengar +2 + precisión X",
+                  "detail": "Si vuelve Machamp, cambia a Gengar, luego a Chansey y frente a Staraptor vuelve a Gengar. Usa Maquinación hasta +2 y Precisión X.",
                   "variant": []
                 },
                 {
-                  "detail": "Staraptor → Slowbro → Lucario → Volcarona +2",
+                  "detail": "Si sale Staraptor, cambia a Slowbro. Si luego sale Lucario, entra con Volcarona y usa Danza Aleteo x2.",
                   "variant": []
                 }
               ]
@@ -69,20 +69,20 @@
           ]
         },
         {
-          "detail": "Metagross → Slowbro → Lucario → Volcarona +2",
+          "detail": "Si sale Metagross, cambia a Slowbro. Si luego sale Lucario, entra con Volcarona y usa Danza Aleteo x2.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Puño Drenaje (Sin llamaesfera) → Slowbro, Bostezo",
+      "detail": "Si Machamp usa Puño Drenaje sin Llamaesfera, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Golem → Teletransporte → Chansey, trampa rocas. Sale Metagross → Gengar, Otra Vez, +2 derrota, sale Golem, otro maquinación y derrotalos.",
+          "detail": "Si sale Golem, usa Teletransporte hacia Chansey y coloca Trampa Rocas. Si luego sale Metagross, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Derrótalo; cuando salga Golem, usa otra Maquinación y termina de derrotarlos.",
           "variant": []
         },
         {
-          "detail": "Eelektross/Torrterra → Politoed (sacrificar), Poliwrath +6",
+          "detail": "Si sale Eelektross o Torterra, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/bruno/metagross.json
+++ b/src/data/johto/bruno/metagross.json
@@ -5,49 +5,49 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Se queda → Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6.",
+      "detail": "Si Metagross se queda, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Darmanitan → Varias Opciones ↓",
+      "detail": "Si sale Darmanitan, tienes varias opciones.",
       "variant": [
         {
-          "detail": "Ahorro → Volcarona +3",
+          "detail": "Ruta de ahorro: entra con Volcarona y usa Danza Aleteo x3.",
           "variant": []
         },
         {
-          "detail": "Estable → Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Ruta estable: cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "RNG → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Ruta arriesgada: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Hitmonchan → Slowbro, Bostezo. Sale Metagross → Politoed (sacrificar), Poliwrath +6.",
+      "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo. Cuando salga Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Machamp → Gengar, ver ataque.",
+      "detail": "Si sale Machamp, cambia a Gengar y revisa qué ataque usa.",
       "variant": [
         {
-          "detail": "Puño Dinamico → Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Si usa Puño Dinámico, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Puño Drenaje → Gengar, Otra Vez → Chansey, sale Staraptor → Volcarona +2.",
-          "variant":[]
+          "detail": "Si usa Puño Drenaje, Gengar usa Otra Vez. Luego pasa por Chansey; cuando salga Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
         }
       ]
     },
     {
-      "detail": "Blaziken → Gengar +4 +2 (No uses Otra Vez).",
-      "variant":[]
+      "detail": "Si sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No uses Otra Vez.",
+      "variant": []
     },
     {
-      "detail": "Krokodile/Staraptor → Volcarona +2.",
+      "detail": "Si sale Krookodile o Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/muk.json
+++ b/src/data/johto/bruno/muk.json
@@ -2,18 +2,18 @@
   "id": "muk",
   "name": "Muk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Metagross ➜ cambia a Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6.",
+      "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Puya Nociva  ➜ Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6.",
+      "detail": "Si Muk usa Puya Nociva, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Golem → Encanto, Amortiguador hasta que salga Metagross → cambia a Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6.",
+      "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/poliwrath.json
+++ b/src/data/johto/bruno/poliwrath.json
@@ -2,14 +2,14 @@
   "id": "poliwrath",
   "name": "Poliwrath",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Krookodile/Staraptor ➜ Volcarona +2.",
+      "detail": "Si sale Krookodile o Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
       "variant": []
     },
     {
-      "detail": "Machamp ➜ Gengar, Otra Vez → Chansey, sale Staraptor → Volcarona +2.",
+      "detail": "Si sale Machamp, cambia a Gengar y usa Otra Vez. Luego pasa por Chansey; cuando salga Staraptor, entra con Volcarona y usa Danza Aleteo x2.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/salamence.json
+++ b/src/data/johto/bruno/salamence.json
@@ -2,48 +2,48 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Revisa la Habilidad💡",
+  "initialMove": "💡 Revisa la habilidad 💡",
   "tricks": [
     {
-      "detail": "Intimidación → Amortiguador",
+      "detail": "Si tiene Intimidación, usa Amortiguador.",
       "variant": [
         {
-          "detail": "Machamp → Gengar, Otra Vez, +4 +2. Utiliza Otra Vez cada que puedas.",
+          "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Mantén Otra Vez cada vez que puedas.",
           "variant": [
             {
-              "detail": "Sale Metagross → Chansey, amortiguador. sale Blaziken → Gengar +4 +2. (Otra Vez no es necesario).",
+              "detail": "Si sale Metagross, cambia a Chansey y usa Amortiguador. Si después sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No es necesario usar Otra Vez.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Blaziken → Gengar +4 +2 (Otra Vez no es necesario).",
+          "detail": "Si sale Blaziken, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No es necesario usar Otra Vez.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Sin Intimidación → Trampa Rocas.",
+      "detail": "Si no tiene Intimidación, coloca Trampa Rocas.",
       "variant": [
         {
-          "detail": "Metagross → Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Hitmonlee → Gengar, Bola Sombra.",
+          "detail": "Si sale Hitmonlee, cambia a Gengar y usa Bola Sombra.",
           "variant": [
             {
-              "detail": "Lo derrotas, sale Machamp → Continua bola sombra → Slowbro, Bostezo. sale Salamence → Teletransporte → Volcarona +1.",
+              "detail": "Si lo derrotas y sale Machamp, continúa usando Bola Sombra. Luego cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
               "variant": []
             },
             {
-              "detail": "Cambia a Machamp → Slowbro, Bostezo. sale Salamence → Teletransporte → Volcarona +1.",
+              "detail": "Si cambia a Machamp, cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Golem → Encanto, Amortiguador hasta que salga Metagross → Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/bruno/seismitoad.json
+++ b/src/data/johto/bruno/seismitoad.json
@@ -2,18 +2,18 @@
   "id": "seismitoad",
   "name": "Seismitoad",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Varias Opciones💡",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Ahorro → Amortiguador, sale Darmanitan → Volcarona +3.",
+      "detail": "Ruta de ahorro: usa Amortiguador hasta que salga Darmanitan. Luego entra con Volcarona y usa Danza Aleteo x3.",
       "variant": []
     },
     {
-      "detail": "Estable → Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6.",
+      "detail": "Ruta estable: cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "RNG → Politoed (sacrificar), Poliwrath +6.",
+      "detail": "Ruta arriesgada: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/slowbro.json
+++ b/src/data/johto/bruno/slowbro.json
@@ -2,41 +2,41 @@
   "id": "slowbro",
   "name": "Slowbro",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Hitmonlee ➜ Gengar, bola sombra",
+      "detail": "Si sale Hitmonlee, cambia a Gengar y usa Bola Sombra.",
       "variant": [
         {
-          "detail": "Derrótalo, sale Machamp → Continua Bola Sombra → Slowbro, Bostezo. sale Salamence → Teletransporte → Volcarona +1.",
+          "detail": "Si lo derrotas y sale Machamp, continúa usando Bola Sombra. Luego cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
           "variant": []
         },
         {
-          "detail": "Sale Machamp → Slowbro, Bostezo. sale Salamence → Teletransporte → Volcarona +1.",
+          "detail": "Si sale Machamp, cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Machamp → Gengar, Otra Vez, +2",
+      "detail": "Si sale Machamp, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Se queda → Gengar +4, bola sombra para todos.",
+          "detail": "Si Machamp se queda, usa Maquinación hasta +4 y barre con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Sale Salamence → Bola Sombra hasta que salga Aggron.",
+          "detail": "Si sale Salamence, usa Bola Sombra hasta que salga Aggron.",
           "variant": [
             {
-              "detail": "Gengar derrota con critico a Aggron → Derrótalos a todos.",
+              "detail": "Si Gengar derrota a Aggron con un golpe crítico, termina de derrotar al resto.",
               "variant": []
             },
             {
-              "detail": "Aggron derrota a Gengar (no activa Cuerpo Maldito) → Volcarona, derrótalo. sale Slowbro, +1.",
+              "detail": "Si Aggron derrota a Gengar y no activa Cuerpo Maldito, entra con Volcarona, derrota a Aggron y usa Danza Aleteo x1 frente al Slowbro rival.",
               "variant": []
             },
             {
-              "detail": "Aggron derrota a Gengar (Se activa Cuerpo Maldito) → Volcarona +1.",
+              "detail": "Si Aggron derrota a Gengar y se activa Cuerpo Maldito, entra con Volcarona y usa Danza Aleteo x1.",
               "variant": []
             }
           ]
@@ -44,7 +44,7 @@
       ]
     },
     {
-      "detail": "Heracross → Amortiguador, Teletransporte → Gengar, Otra Vez, +2 + Precisión X. (Otra Vez de nuevo, tiene Banda Focus)",
+      "detail": "Si sale Heracross, usa Amortiguador y luego Teletransporte hacia Gengar. Gengar usa Otra Vez, Maquinación hasta +2 y Precisión X. Usa Otra Vez de nuevo cuando sea necesario; Heracross tiene Banda Focus.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/staraptor.json
+++ b/src/data/johto/bruno/staraptor.json
@@ -2,24 +2,24 @@
   "id": "staraptor",
   "name": "Staraptor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro y Mira que Objeto tiene",
+  "initialMove": "Cambia a Slowbro y revisa qué objeto tiene.",
   "tricks": [
     {
-      "detail": "Tiene Vidaesfera → Bostezo.",
+      "detail": "Si tiene Vidasfera, usa Bostezo.",
       "variant": [
         {
-          "detail": "Se queda → Teletransporte → Chansey, trampa rocas, Teletransporte → Gengar, Otra Vez, +2 + precisión X(heracross Banda focus)",
+          "detail": "Si Staraptor se queda, usa Teletransporte hacia Chansey, coloca Trampa Rocas y vuelve a usar Teletransporte hacia Gengar. Usa Otra Vez, Maquinación hasta +2 y Precisión X. Heracross tiene Banda Focus.",
           "variant": []
         },
         {
-          "detail": "Heracross ➜ Protección, cambia a Chansey, sale Steelix. Pon trampa rocas y manten Amortiguador hasta el cambio.",
+          "detail": "Si sale Heracross, usa Protección, cambia a Chansey y espera a Steelix. Coloca Trampa Rocas y mantén Amortiguador hasta que el rival cambie.",
           "variant": [
             {
-              "detail": "Heracross ➜ Continua usando amortiguador",
+              "detail": "Si vuelve Heracross, continúa usando Amortiguador.",
               "variant": []
             },
             {
-              "detail": "Staraptor/Machamp ➜ Gengar, Otra Vez, +4 + precisión X.",
+              "detail": "Si sale Staraptor o Machamp, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
               "variant": []
             }
           ]
@@ -27,7 +27,7 @@
       ]
     },
     {
-      "detail": "No tiene Vidasfera ➜ Slowbro Bostezo ➜ sale Lucario ➜ Teletransporte ➜ Volcarona x2 danza aleteo (HP por encima 17%).",
+      "detail": "Si no tiene Vidasfera, Slowbro usa Bostezo. Cuando salga Lucario, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2. Mantén los PS por encima del 17%.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/steelix.json
+++ b/src/data/johto/bruno/steelix.json
@@ -5,22 +5,22 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Terremoto → Encanto → Amortiguador hasta que salga Heracross → Amortiguador → Teletransporte (recibes A Bocajarro) → Gengar: Otra Vez +2 + Precisión X",
+      "detail": "Si usa Terremoto, usa Encanto y luego Amortiguador hasta que salga Heracross. Después usa Amortiguador y Teletransporte mientras recibes A Bocajarro. Entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
       "variant": []
     },
     {
-      "detail": "Heracross → Amortiguador → Teletransporte (recibes A Bocajarro) → Gengar: Otra Vez +2 + Precisión X",
+      "detail": "Si sale Heracross, usa Amortiguador y Teletransporte mientras recibes A Bocajarro. Entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
       "variant": []
     },
     {
-      "detail": "Hitmonlee → Gengar: Bola Sombra",
+      "detail": "Si sale Hitmonlee, cambia a Gengar y usa Bola Sombra.",
       "variant": [
         {
-          "detail": "Derrótalo → sale Machamp → continuar Bola Sombra → Slowbro: Bostezo → sale Salamence → Teletransporte → Volcarona +1",
+          "detail": "Si lo derrotas y sale Machamp, continúa usando Bola Sombra. Luego cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
           "variant": []
         },
         {
-          "detail": "Sale Machamp → Slowbro: Bostezo → sale Salamence → Teletransporte → Volcarona +1",
+          "detail": "Si sale Machamp, cambia a Slowbro y usa Bostezo. Cuando salga Salamence, usa Teletransporte hacia Volcarona y usa Danza Aleteo x1.",
           "variant": []
         }
       ]

--- a/src/data/johto/bruno/torterra.json
+++ b/src/data/johto/bruno/torterra.json
@@ -2,14 +2,14 @@
   "id": "torterra",
   "name": "Torterra",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Varias Opciones💡",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Ahorro → Amortiguador, sale Darmanitan → Volcarona +3.",
+      "detail": "Ruta de ahorro: usa Amortiguador hasta que salga Darmanitan. Luego entra con Volcarona y usa Danza Aleteo x3.",
       "variant": []
     },
     {
-      "detail": "Estable → Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6.",
+      "detail": "Ruta estable: cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]


### PR DESCRIPTION
## Summary
- Polishes the text for Johto Bruno strategy routes after applying the compact structure.
- Preserves the compact `tricks` / `variant` hierarchy from the uploaded comparison branch.
- Expands unclear boosts and shorthand into explicit route text.

## Scope
Changed files:
- `src/data/johto/bruno/*.json`

## Notes
- Strategy text only.
- The compact route structure is preserved.
- No visual assets, components, CSS, or unrelated trainer files were changed.