### PR TITLE
Polish Johto Will compact strategy text

### DIFF
--- a/src/data/johto/will/absol.json
+++ b/src/data/johto/will/absol.json
@@ -2,6 +2,6 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Gengar +4 + precisión X. (No usar Otra Vez)👻",
+  "initialMove": "👻 Gengar usa Maquinación hasta +4 y Precisión X. No uses Otra Vez. 👻",
   "tricks": []
 }

--- a/src/data/johto/will/altaria.json
+++ b/src/data/johto/will/altaria.json
@@ -5,24 +5,24 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Stantler ➜ 👻 Gengar ➜ Otra Vez ➜ sale Alakazam",
+      "detail": "Si sale Stantler, cambia a Gengar y usa Otra Vez. Luego sale Alakazam.",
       "variant": [
         {
-          "detail": "Estable → Cambiar a Chansey ➜ usar Teletransporte y sacar a Slowbro ➜ usar Bostezo ➜ Protección alakazam se duerme usa bostezo frente a Roserade; sacrificar a Politoed y entrar con Poliwrath +6",
+          "detail": "Ruta estable: cambia a Chansey, usa Teletransporte hacia Slowbro y usa Bostezo. Usa Protección para dormir a Alakazam. Luego usa Bostezo frente a Roserade, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "RNG → Slowbro, Bostezo, Protección. Sale Roserade →  Sacrificar a Politoed ➜ 🐸 Poliwrath +6 🐸  ",
+          "detail": "Ruta RNG: entra con Slowbro, usa Bostezo y Protección. Cuando salga Roserade, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Lucario → 👻Gengar, Otra Vez, +6 + precisión X.",
+      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +6 y Precisión X.",
       "variant": []
     },
     {
-      "detail": "Cambia a Gengar, Lucario → que use ataque de fuego (Zoroark) → Gengar, Otra Vez → 🐸 Poliwrath +6 +2 🐸 ",
+      "detail": "Si Lucario revela que es Zoroark por un movimiento de tipo Fuego, Gengar usa Otra Vez. Luego entra con Poliwrath para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/bronzong.json
+++ b/src/data/johto/will/bronzong.json
@@ -5,19 +5,19 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Absol ➜ Gengar +4 + Precisión (absol pañuelo elegido)",
+      "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. Absol tiene Pañuelo Elegido.",
       "variant": []
     },
     {
-      "detail": "Flareon ➜ 👻 Gengar Otra Vez +2 👻",
+      "detail": "Si sale Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": []
     },
     {
-      "detail": "Si se queda ➜ Usar bola sombra frente a Absol ➜ sacrifica a Politoed ➜ Poliwrath +6 (absol pañuelo elegido)",
+      "detail": "Si Bronzong se queda, usa Bola Sombra frente a Absol. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Absol tiene Pañuelo Elegido.",
       "variant": []
     },
     {
-      "detail": "Cambia a Bronzong ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊  🔔 Cascada contra Bronzong🔔 ",
+      "detail": "Si cambia a Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Bronzong.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/chansey.json
+++ b/src/data/johto/will/chansey.json
@@ -2,10 +2,10 @@
   "id": "chansey",
   "name": "Chansey",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Electivire → Gengar, Otra Vez, +2 + precisión X.",
+      "detail": "Si sale Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/claydol.json
+++ b/src/data/johto/will/claydol.json
@@ -2,6 +2,6 @@
   "id": "claydol",
   "name": "Claydol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨🔔 Si Claydol se queda: aguantar con x defensa especial  y usar Amortiguador 🔔 frente a Girafarig; Gengar usa Otra Vez; cambiar a Slowbro frente a Mantine; usar Bostezo frente a Magnezone; sacrificar a Politoed; Poliwrath +6",
+  "initialMove": "🪨 Trampa Rocas 🪨 🔔 Si Claydol se queda, aguanta con Defensa Especial X y usa Amortiguador. Frente a Girafarig, Gengar usa Otra Vez. Cambia a Slowbro frente a Mantine, usa Bostezo frente a Magnezone, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🔔",
   "tricks": []
 }

--- a/src/data/johto/will/clefable.json
+++ b/src/data/johto/will/clefable.json
@@ -5,15 +5,15 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Lucario --> Gengar, Otra Vez, +6 + Precisión (Usa Otra Vez cada que puedas); Si Bola Sombra se queda bloqueado → Onda Certera dos veces para golpear a Xatu",
+      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +6 y Precisión X. Usa Otra Vez cada vez que puedas. Si Bola Sombra queda bloqueada contra Xatu, usa Onda Certera dos veces para derrotarlo.",
       "variant": []
     },
     {
-      "detail": "Golurk --> Gengar, Otra Vez, +4 + Precisión (Usa Otra Vez cada que puedas)",
+      "detail": "Si sale Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X. Usa Otra Vez cada vez que puedas.",
       "variant": []
     },
     {
-      "detail": "Cambiar de Gengar si Lucario;  usa movimiento de fuego (es zoroark) --> Gengar usa Otra Vez al movimiento de fuego; Poliwrath +6 +2",
+      "detail": "Si Lucario revela que es Zoroark por un movimiento de tipo Fuego, cambia desde Gengar cuando corresponda. Luego Gengar usa Otra Vez sobre el movimiento de tipo Fuego y entra con Poliwrath para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/electivire.json
+++ b/src/data/johto/will/electivire.json
@@ -2,29 +2,29 @@
   "id": "electivire",
   "name": "Electivire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Se queda → Ver Item",
+      "detail": "Si Electivire se queda, revisa su objeto.",
       "variant": [
         {
-          "detail": "Vidaesfera → ver si es crítico.",
+          "detail": "Si tiene Vidasfera, revisa si el golpe fue crítico.",
           "variant": [
             {
-              "detail": "No crítico → Gengar, Otra Vez, +2 + precisión X.",
+              "detail": "Si no fue crítico, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
               "variant": []
             },
             {
-              "detail": "Crítico → Toma Max Poción → Gengar, Otra Vez, +2 + precisión X.",
+              "detail": "Si fue crítico, toma una Max Poción. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "No vidaesfera → Gengar, +2 +2 + precisión X (no es necesario Otra Vez).",
+          "detail": "Si no tiene Vidasfera, cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. No es necesario usar Otra Vez.",
           "variant": [
             {
-              "detail": "Gengar, sale Lucario → Poliwrath → Gengar → Poliwrath → Gengar, Otra Vez, +2 +2 + precisión X.",
+              "detail": "Si sale Lucario, alterna Poliwrath y Gengar hasta dejar a Gengar seguro. Luego usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
               "variant": []
             }
           ]
@@ -32,7 +32,7 @@
       ]
     },
     {
-      "detail": "Lucario → Gengar, Otra Vez, +2 +2 + precisión X.",
+      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/empoleon.json
+++ b/src/data/johto/will/empoleon.json
@@ -2,38 +2,38 @@
   "id": "empoleon",
   "name": "Empoleon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Se queda → mira el ataque",
+      "detail": "Si Empoleon se queda, revisa qué ataque usa.",
       "variant": [
         {
-          "detail": "Surf → Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Si usa Surf, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Hidrobomba → Teletransporte → Slowbro, Bostezo → Protección, sale Clefable, Bostezo → Politoed (sacrificar), Poliwrath +6. (Cascada Hypno)",
+          "detail": "Si usa Hidrobomba, usa Teletransporte hacia Slowbro, usa Bostezo y luego Protección. Cuando salga Clefable, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Hypno.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Absol → Gengar, +4 + precisión X. (No es necesario Otra Vez).",
+      "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No es necesario usar Otra Vez.",
       "variant": []
     },
     {
-      "detail": "Electivire → Gengar, Otra Vez, +4 + precisión X.",
+      "detail": "Si sale Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
       "variant": []
     },
     {
-      "detail": "Flareon → Gengar, Otra Vez, +2.",
+      "detail": "Si sale Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Se queda → Derrótalo, sale Absol → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Sale Bronzong → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/will/espeon.json
+++ b/src/data/johto/will/espeon.json
@@ -2,14 +2,14 @@
   "id": "espeon",
   "name": "Espeon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Slowbro, Bostezo (Presiona al cambio)",
+  "initialMove": "Slowbro usa Bostezo para presionar el cambio.",
   "tricks": [
     {
-      "detail": "Cambia a Chansey, trampa rocas, sale Lucario → Gengar, otra vez, +2 +2 + precisión X",
+      "detail": "Cambia a Chansey y coloca Trampa Rocas. Cuando salga Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
       "variant": []
     },
     {
-      "detail": "Si en trampa rocas no cambia, usa amortiguador hasta que cambie → sigue la guía ↑",
+      "detail": "Si no cambia mientras colocas Trampa Rocas, usa Amortiguador hasta forzar el cambio y sigue la ruta anterior.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/exeggutor.json
+++ b/src/data/johto/will/exeggutor.json
@@ -5,18 +5,18 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Absol → Gengar, +4 + precisión X. (No es necesario Otra Vez).",
+      "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No es necesario usar Otra Vez.",
       "variant": []
     },
     {
-      "detail": "Flareon → Gengar, Otra Vez, +2.",
+      "detail": "Si sale Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Se queda → Derrótalo, sale Absol → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Sale Bronzong → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/will/flareon.json
+++ b/src/data/johto/will/flareon.json
@@ -2,14 +2,14 @@
   "id": "flareon",
   "name": "Flareon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Gengar, +2 ",
+  "initialMove": "Cambia a Gengar y usa Maquinación hasta +2.",
   "tricks": [
     {
-      "detail": "Se queda → Gengar, Otra Vez, +4 +2 + precisión X",
+      "detail": "Si Flareon se queda, Gengar usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X.",
       "variant": []
     },
     {
-      "detail": "Sale Bronzong → Politoed (sacrificar), Poliwrath +6.",
+      "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/gardevoir.json
+++ b/src/data/johto/will/gardevoir.json
@@ -5,10 +5,10 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Sale Lucario ➜ cambiar a Gengar, otra vez +6 + precisión X",
+      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +6 y Precisión X.",
       "variant": [
         {
-          "detail": "Si te bloquean Bola sombra, Onda certera derrota a Xatu.",
+          "detail": "Si Bola Sombra queda bloqueada contra Xatu, usa Onda Certera para derrotarlo.",
           "variant": []
         }
       ]

--- a/src/data/johto/will/girafarig.json
+++ b/src/data/johto/will/girafarig.json
@@ -2,10 +2,10 @@
   "id": "girafarig",
   "name": "Girafarig",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Cambia a Gengar, Otra Vez → Cambia a Slowbro, Bostezo, sale Mantine → Bostezo, sale Magnezone → Politoed (sacrificar), Poliwrath +6.",
+      "detail": "Cambia a Gengar y usa Otra Vez. Luego cambia a Slowbro y usa Bostezo. Cuando salga Mantine, usa Bostezo; cuando salga Magnezone, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/golduck.json
+++ b/src/data/johto/will/golduck.json
@@ -2,23 +2,23 @@
   "id": "golduck",
   "name": "Golduck",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Tajo Cruzado → Teletransporte",
+      "detail": "Si usa Tajo Cruzado, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Se queda → Gengar, Otra Vez, +2 +2 + precisión X.",
+          "detail": "Si Golduck se queda, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Lucario → Poliwrath → Gengar, Otra Vez, +2 +2 + precisión X.",
+          "detail": "Si sale Lucario, pasa por Poliwrath y luego entra con Gengar. Usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Lucario → Gengar, Otra Vez, +2 +2 + precisión X.",
+      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/golurk.json
+++ b/src/data/johto/will/golurk.json
@@ -2,14 +2,14 @@
   "id": "golurk",
   "name": "Golurk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 → Ver % Daño",
+  "initialMove": "🪨 Trampa Rocas 🪨 → Revisa el porcentaje de daño",
   "tricks": [
     {
-      "detail": "50% (75% Crítico, toma Max Poción) → Gengar, Otra Vez, +4 +2.",
+      "detail": "Si hace alrededor de 50% de daño, toma una Max Poción si fue crítico. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
       "variant": []
     },
     {
-      "detail": "35% → Gengar, Otra Vez, +4 + precisión X.",
+      "detail": "Si hace alrededor de 35% de daño, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/grumpig.json
+++ b/src/data/johto/will/grumpig.json
@@ -2,10 +2,10 @@
   "id": "grumpig",
   "name": "Grumpig",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Electivire ➜ Gengar, Otra Vez, +2 + precisión X.",
+      "detail": "Si sale Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/hypno.json
+++ b/src/data/johto/will/hypno.json
@@ -2,10 +2,10 @@
   "id": "hypno",
   "name": "Hypno",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Politoed (sacrificar)",
+  "initialMove": "Sacrifica a Politoed.",
   "tricks": [
     {
-      "detail": "Poliwrath +6. (Cascada a Hypno)",
+      "detail": "Entra con Poliwrath, usa Tambor hasta +6 Ataque y usa Cascada contra Hypno.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/jolteon.json
+++ b/src/data/johto/will/jolteon.json
@@ -2,10 +2,10 @@
   "id": "jolteon",
   "name": "Jolteon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Golurk ➜ Gengar Otra Vez +4 +2. (Bola Sombra a todos)",
+      "detail": "Si sale Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/jynx.json
+++ b/src/data/johto/will/jynx.json
@@ -2,10 +2,10 @@
   "id": "jynx",
   "name": "Jynx",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Electivire ➜ Gengar, Otra Vez, +2 + precisión X.",
+      "detail": "Si sale Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/liepard.json
+++ b/src/data/johto/will/liepard.json
@@ -2,10 +2,10 @@
   "id": "liepard",
   "name": "Liepard",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Golurk ➜ Gengar Otra Vez +4 +2. (Bola sombra a todos)",
+      "detail": "Si sale Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/lucario.json
+++ b/src/data/johto/will/lucario.json
@@ -2,40 +2,40 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "A Bocajarro → Mira el item",
+      "detail": "Si usa A Bocajarro, revisa el objeto.",
       "variant": [
         {
-          "detail": "Vidaesfera + colocaste trampa rocas → Teletransporte",
+          "detail": "Si tiene Vidasfera y colocaste Trampa Rocas, usa Teletransporte.",
           "variant": [
             {
-              "detail": "Triturar/Puño Bala → Poliwrath → Gengar, Otra Vez, +4 + precisión X.",
+              "detail": "Si usa Triturar o Puño Bala, pasa por Poliwrath y luego entra con Gengar. Usa Otra Vez, Maquinación hasta +4 y Precisión X.",
               "variant": []
             },
             {
-              "detail": "A Bocajarro/Velocidad Extrema → Gengar, Otra Vez, +4 + precisión X.",
+              "detail": "Si usa A Bocajarro o Velocidad Extrema, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Vidaesfera + NO colocaste trampa rocas → Gengar, Otra Vez, +4 + precisión X.",
+          "detail": "Si tiene Vidasfera y no colocaste Trampa Rocas, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Sin Vidasfera → Teletransporte → Gengar, Otra Vez, +2 +2 + precisión X.",
+          "detail": "Si no tiene Vidasfera, usa Teletransporte hacia Gengar. Luego usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Golurk → Gengar, Otra Vez, +4 +2. (Bola sombra a todos).",
+      "detail": "Si sale Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
       "variant": []
     },
     {
-      "detail": "Segundo Lucario → Gengar, Otra Vez, +4 + precisión X.",
+      "detail": "Si aparece un segundo Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/magnezone.json
+++ b/src/data/johto/will/magnezone.json
@@ -5,19 +5,19 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Se Queda Magnezone ➜ usa Teletransporte",
+      "detail": "Si Magnezone se queda, usa Teletransporte.",
       "variant": []
     },
     {
-      "detail": "Si aún se queda Slowbro bostezo ➜ entra volcarona x1 danza aleteo 🔔ataca con psiquico y lanzallamas🔔 Si entra Typhlosion ; sacrifica a Politoed ➜ Poliwrath +6",
+      "detail": "Si Magnezone aún se queda, Slowbro usa Bostezo. Luego entra con Volcarona, usa Danza Aleteo x1 y ataca con Psíquico y Lanzallamas. Si entra Typhlosion, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Girafarig ➜ Cambia de Volcarona a Gengar y usa Otra Vez y cambia a Slowbro, frente a Mantine ➜ usa Bostezo y frente a Magnezone , sacrifica a Politoed ➜ Poliwrath +6",
+      "detail": "Si sale Girafarig, cambia de Volcarona a Gengar y usa Otra Vez. Luego cambia a Slowbro; frente a Mantine usa Bostezo y frente a Magnezone sacrifica a Politoed. Entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Girafarig ➜ Gengar usa Otra Vez y cambia a Slowbro ➜ frente a Mantine usar Bostezo ➜ frente a Magnezone ➜ sacrifica a Politoed ➜ Poliwrath +6",
+      "detail": "Si sale Girafarig, Gengar usa Otra Vez y cambia a Slowbro. Frente a Mantine usa Bostezo; frente a Magnezone sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/mantine.json
+++ b/src/data/johto/will/mantine.json
@@ -2,10 +2,10 @@
   "id": "mantine",
   "name": "Mantine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨; si se queda, usar Amortiguador🥚",
+  "initialMove": "🪨 Trampa Rocas 🪨; si Mantine se queda, usa Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Girafarig --> Gengar usa Otra Vez; cambiar a Slowbro frente a Mantine; usar Bostezo frente a Magnezone; sacrificar a Politoed; Poliwrath +6",
+      "detail": "Si sale Girafarig, Gengar usa Otra Vez. Luego cambia a Slowbro frente a Mantine, usa Bostezo frente a Magnezone, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/slowbro.json
+++ b/src/data/johto/will/slowbro.json
@@ -2,10 +2,10 @@
   "id": "slowbro",
   "name": "Slowbro",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Golurk ➜ cambiar a Gengar ; usar Otra Vez +4 +2 (Bola sombra a todos)",
+      "detail": "Si sale Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/typhlosion.json
+++ b/src/data/johto/will/typhlosion.json
@@ -2,10 +2,10 @@
   "id": "typhlosion",
   "name": "Typhlosion",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Saca a Politoed (Sacrificar), Poliwrath +6.",
+      "detail": "Sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/umbreon.json
+++ b/src/data/johto/will/umbreon.json
@@ -5,15 +5,15 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Golurk ➜ Gengar ➜ Otra Vez ➜ +4 +2 usar precisión X.",
+      "detail": "Si sale Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X.",
       "variant": []
     },
     {
-      "detail": "Lucario ➜ Gengar ➜ Otra Vez ➜ +2 +2 Usar precision x  (Lucario Banda Focus).",
+      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Lucario tiene Banda Focus.",
       "variant": []
     },
     {
-      "detail": "Se queda → Slowbro ➜ Bostezo → Politoed (sacrificar), Poliwrath +6.",
+      "detail": "Si Umbreon se queda, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/xatu.json
+++ b/src/data/johto/will/xatu.json
@@ -2,62 +2,62 @@
   "id": "xatu",
   "name": "Xatu",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Se queda → Mira el Item",
+      "detail": "Si Xatu se queda, revisa su objeto.",
       "variant": [
         {
-          "detail": "Llamaesfera → Amortiguador hasta que salga Golurk → Gengar, Otra Vez, +4 + precisión X.",
+          "detail": "Si tiene Llamasfera, usa Amortiguador hasta que salga Golurk. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Sin Llamaesfera → Cambia a Slowbro, Bostezo. sale Magnezone → Protección, cambia a Chansey. sale Girafarig → Trampa rocas → Gengar, Otra Vez → Slowbro, sale Mantine → Bostezo, sale Girafarig → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Si no tiene Llamasfera, cambia a Slowbro y usa Bostezo. Cuando salga Magnezone, usa Protección y cambia a Chansey. Cuando salga Girafarig, coloca Trampa Rocas. Luego Gengar usa Otra Vez; cambia a Slowbro frente a Mantine y usa Bostezo. Cuando vuelva Girafarig, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Flareon → Gengar, Otra Vez, +2.",
+      "detail": "Si sale Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Se queda → Derrótalo, sale Absol → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Sale Bronzong → Politoed (sacrificar), Poliwrath +6.",
+          "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
-   {
-    "detail": "Absol → Gengar, +4 + precisión X. (No es necesario Otra Vez).",
-    "variant": []
-   },
-   {
-    "detail": "Golurk → Gengar, Otra Vez, +4 +2 + precisión X. (Otra Vez cada que puedas)",
-    "variant": []
-   },
-   {
-    "detail": "Lucario → Teletransporte → Mira el item",
-    "variant": [
-     {
-      "detail": "Vidaesfera → Gengar, Otra Vez, +4 + precisión X. (Otra Vez cada que puedas)",
+    {
+      "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Precisión X. No es necesario usar Otra Vez.",
       "variant": []
-     },
-     {
-      "detail": "Sin Vidaesfera → Gengar, Otra Vez, +2 +2 + precisión X. (Otra Vez cada que puedas)",
+    },
+    {
+      "detail": "Si sale Golurk, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Usa Otra Vez cada vez que puedas.",
       "variant": []
-     },
-     {
-      "detail": "Inesperadamente usa Ataque tipo Fuego → Gengar, Otra Vez → Poliwrath +6 +2.",
+    },
+    {
+      "detail": "Si sale Lucario, usa Teletransporte y revisa su objeto.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidasfera, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X. Usa Otra Vez cada vez que puedas.",
+          "variant": []
+        },
+        {
+          "detail": "Si no tiene Vidasfera, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Usa Otra Vez cada vez que puedas.",
+          "variant": []
+        },
+        {
+          "detail": "Si revela que es Zoroark por un movimiento de tipo Fuego, Gengar usa Otra Vez y luego entra con Poliwrath para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Electivire, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Usa Otra Vez cada vez que puedas.",
       "variant": []
-     }
-    ]
-   },
-   {
-    "detail": "Electivire → Gengar, Otra Vez, +2 + Precisión X. (Otra Vez cada que puedas)",
-    "variant": []
-   }
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Polishes the text for Johto Will strategy routes after applying the compact structure.
- Preserves the compact `tricks` / `variant` hierarchy from the uploaded comparison branch.
- Expands shorthand boosts and route notes into explicit text without adding new dropdown levels.

## Scope
Changed files:
- `src/data/johto/will/*.json`

## Notes
- Strategy text only.
- The compact route structure is preserved.
- No visual assets, components, CSS, or unrelated trainer files were changed.