### PR TITLE
Polish Johto Koga strategy text

### DIFF
--- a/src/data/johto/koga/ariados.json
+++ b/src/data/johto/koga/ariados.json
@@ -2,17 +2,17 @@
   "id": "ariados",
   "name": "Ariados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " Usa 🪨Trampa Rocas🪨 si no cambia usa Amortiguador y ver si cambia",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Si no cambia, usa Amortiguador y revisa si fuerza el cambio.",
   "tricks": [
     {
-      "detail": "Sale Tangrowth ➜ Teletransporte → Slowbro, Bostezo  🔔Mira la precisión de Tangrowth🔔 ",
+      "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y Bostezo. Revisa si Tangrowth acierta el ataque.",
       "variant": [
         {
-          "detail": "Golpea ➜ Teletransporte → Poliwrath +6 ➜ Puño Drenaje a Tangrowth  ➜ sale sharpedo ➜ usa Velocidad X y puño drenaje 🔔Sharpedo Banda Focus🔔",
+          "detail": "Si acierta, usa Teletransporte hacia Poliwrath, usa Tambor hasta +6 Ataque y Puño Drenaje contra Tangrowth. Cuando salga Sharpedo, usa Velocidad X y Puño Drenaje. Sharpedo tiene Banda Focus.",
           "variant": []
         },
         {
-          "detail": "Falla ➜ Volcarona x2  danza aleteo 🦋🔥 ",
+          "detail": "Si falla, entra con Volcarona y usa Danza Aleteo x2.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/bisharp.json
+++ b/src/data/johto/koga/bisharp.json
@@ -2,10 +2,10 @@
   "id": "bisharp",
   "name": "Bisharp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Crobat ➜ Cambia a Slowbro ➜ Manten Bostezo hasta que salga Gengar/Lapras ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 (Puño Hielo a Gengar)",
+      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Gengar o Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/crobat.json
+++ b/src/data/johto/koga/crobat.json
@@ -2,82 +2,82 @@
   "id": "crobat",
   "name": "Crobat",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Se queda → Mira el ataque",
+      "detail": "Si Crobat se queda, revisa qué ataque usa.",
       "variant": [
         {
-          "detail": "Superdiente → Cambia a Slowbro",
-          "variant": [  
-            {
-              "detail": "Se queda → Slowbro usa Bostezo frente a Magmortar → Sacrifica Politoed → Poliwrath Toma un Ataque X y luego Barre 🔔(Puño Drenaje a Magmortar // Si sale Ditto, cambia a Gengar y lo Derrotas)🔔",
-              "variant": []
-            },    
-            {
-              "detail": "Rhyperior ➜ Slowbro usa Bostezo y recibe Megacuerno ➜ luego usar Protección y Bostezo ➜ frente a Gengar/Lapras ➜ sacrifica a politoed ➜ Poliwrath +6 🔔(Puño Hielo contra Gengar)🔔",
-               "variant": []
-            }
-          ]  
-        },
-        {
-          "detail": "Puya Nociva / Pájaro Osado ➜ Cambiar a Slowbro y usar Bostezo",
+          "detail": "Si usa Superdiente, cambia a Slowbro.",
           "variant": [
             {
-              "detail": " Si se Queda ➜ Volcarona +1 y usa Psíquico ➜ frente a Electrode usar Danza Aleteo y termina de Barrer",
+              "detail": "Si se queda, Slowbro usa Bostezo frente a Magmortar. Luego sacrifica a Politoed, entra con Poliwrath, toma un Ataque X y barre. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
               "variant": []
             },
             {
-              "detail": "Slowbro bostezo frente a Zoroark ➜ Volcarona +1 y usa Gigadrenado para derrotarlo ➜ frente a Electrode/Tentacruel usa Danza Aleteo y Termina de Barrer 🚨(Si Volcarona retrocede, cambia a Chansey y cura a Volcarona)🚨",
+              "detail": "Si sale Rhyperior, Slowbro usa Bostezo y recibe Megacuerno. Luego usa Protección y Bostezo. Frente a Gengar o Lapras, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
               "variant": []
-            }    
-          ] 
+            }
+          ]
         },
-        { 
-          "detail": "Pulso Umbrío/Lanzallamas de Zoroark ➜ Usar Teletransporte para sacar a Volcarona +1 y usa Gigadrenado ➜ frente a Electrode/Tentacruel usa Danza Aleteo y Termina de Barrer",
-          "variant": [] 
-        }  
-      ]   
-    },
-    {
-      "detail": "Samurott ➜ Slowbro, Bostezo ➜ sacrifica a Palpitoad ➜ Poliwrath +6 🐸🥊",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ Gengar, Otra Vez, 4+2 🔔(Barre con Bola Sombra)🔔",
-      "variant": []
-    },
-    {
-      "detail": " Ariados ➜ Encanto y Amortiguador para forzar el cambio",
-      "variant": [
         {
-          "detail": " Rhyperior → Slowbro, Bostezo → Teletransporte → Poliwrath +6 y usa Puño Drenaje → Toma un velocidad X frente a Sharpedo y Termina de Barrer",
-          "variant": []
-        },    
+          "detail": "Si usa Puya Nociva o Pájaro Osado, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si se queda, entra con Volcarona, usa Danza Aleteo x1 y Psíquico. Frente a Electrode, usa otra Danza Aleteo y termina de barrer.",
+              "variant": []
+            },
+            {
+              "detail": "Si Slowbro usa Bostezo frente a Zoroark, entra con Volcarona, usa Danza Aleteo x1 y Gigadrenado para derrotarlo. Frente a Electrode o Tentacruel, usa otra Danza Aleteo y termina de barrer. Si Volcarona retrocede, cambia a Chansey y cura a Volcarona.",
+              "variant": []
+            }
+          ]
+        },
         {
-          "detail": "Tangrowth → ⬇️Mira la Solucion Abajo⬇️",
+          "detail": "Si revela que es Zoroark por Pulso Umbrío o Lanzallamas, usa Teletransporte para sacar a Volcarona. Usa Danza Aleteo x1 y Gigadrenado. Frente a Electrode o Tentacruel, usa otra Danza Aleteo y termina de barrer.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Tangrowth → Teletransporte → Slowbro usa Bostezo 🔔(Mira Si Acierta el Ataque)🔔",
+      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Ariados, usa Encanto y Amortiguador para forzar el cambio.",
       "variant": [
         {
-          "detail": "Acierta → Teletransporte → Volcarona +2",
+          "detail": "Si sale Rhyperior, cambia a Slowbro y usa Bostezo. Luego usa Teletransporte hacia Poliwrath, usa Tambor hasta +6 Ataque y Puño Drenaje. Frente a Sharpedo, usa Velocidad X y termina de barrer.",
           "variant": []
         },
         {
-          "detail": "Falla → Volcarona +2",
+          "detail": "Si sale Tangrowth, sigue la solución de Tangrowth indicada abajo.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Scizor → Volcarona +1 + Ataque Especial X",
+      "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y Bostezo. Revisa si Tangrowth acierta el ataque.",
       "variant": [
         {
-          "detail": "☠️Volcarona Muere☠️ → Entra Poliwrath → Politoed (sacrificar), Poliwrath +6",
+          "detail": "Si acierta, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        },
+        {
+          "detail": "Si falla, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
+      "variant": [
+        {
+          "detail": "Si Volcarona cae, entra con Poliwrath, sacrifica a Politoed y vuelve a Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/ditto.json
+++ b/src/data/johto/koga/ditto.json
@@ -2,23 +2,23 @@
   "id": "ditto",
   "name": "Ditto",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Se queda → Teletransporte",
+      "detail": "Si Ditto se queda, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Se queda → Poliwrath, +6 +2 🥊Puño Drenaje a Magmortar🥊",
+          "detail": "Si aún se queda, entra con Poliwrath, usa Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad. Usa Puño Drenaje contra Magmortar.",
           "variant": []
         },
         {
-          "detail": "Sale Crobat → Mira abajo ↓",
+          "detail": "Si sale Crobat, sigue la ruta indicada abajo.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Crobat ➜ Saca a Slowbro y usa Bostezo hasta que salga Magmortar ➜ sacrifica a Palpitoad ➜ Poliwrath usa Ataque X 🔔Puño drenaje en magmortar ,sale ditoo cambia a gengar y matalo🔔",
+      "detail": "Si sale Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Luego sacrifica a Politoed, entra con Poliwrath y usa Ataque X. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/electrode.json
+++ b/src/data/johto/koga/electrode.json
@@ -2,19 +2,19 @@
   "id": "electrode",
   "name": "Electrode",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Lanzallamas/Pulso umbrio es (Zoroark) → Teletransporte → Volcarona x1 danza aleteo usa gigadrenado para matar a zoruark ➜ frente a electrode /Tentacruel usa Danza Aleteo una vez más.",
+      "detail": "Si usa Lanzallamas o Pulso Umbrío, revela que es Zoroark. Usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y Gigadrenado para derrotar a Zoroark. Frente a Electrode o Tentacruel, usa Danza Aleteo una vez más.",
       "variant": [
         {
-          "detail": "Si Volcarona recibe retrocesos, cambia a Chansey → Max pocion a Volcarona y repite el proceso",
+          "detail": "Si Volcarona recibe retrocesos, cambia a Chansey, cura a Volcarona con Max Poción y repite el proceso.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Usa Rayo → Teletransporte → Volcarona x2 danza aleteo 🔔 Mantener los PS por encima del 50% de lo contrario, Electrode usará Autodestrucción 🔔",
+      "detail": "Si usa Rayo, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2. Mantén los PS por encima del 50%; de lo contrario, Electrode puede usar Autodestrucción.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/ferrothorn.json
+++ b/src/data/johto/koga/ferrothorn.json
@@ -2,13 +2,13 @@
   "id": "ferrothorn",
   "name": "Ferrothorn",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Frente a Crobat ➜ Cambia a Slowbro usa Bostezo hasta tener en frente a Magmortar ➜ sacrifica a Palpitoad ➜ Poliwrath ➜ usa Ataque X y atacar",
+      "detail": "Frente a Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Luego sacrifica a Politoed, entra con Poliwrath, usa Ataque X y ataca.",
       "variant": [
         {
-          "detail": "🔔Puño drenaje a magmortar Frente a ditto cambia a gengar y matalo 🔔",
+          "detail": "Usa Puño Drenaje contra Magmortar. Frente a Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/floatzel.json
+++ b/src/data/johto/koga/floatzel.json
@@ -2,16 +2,16 @@
   "id": "floatzel",
   "name": "Floatzel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Crobat ➜ Cambiar a Slowbro ➜ usar Bostezo hasta que salga Magmortar ➜ sacrifica a Palpitoad ➜ Poliwrath Ataque X y ataca 🔔 puño drenaje a magmortar frente a ditto cambia a gengar y matalo 🔔",
+      "detail": "Si sale Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Luego sacrifica a Politoed, entra con Poliwrath, usa Ataque X y ataca. Usa Puño Drenaje contra Magmortar. Frente a Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
       "variant": [
         {
-          "detail": "Sale Scizor ➜ Volcarona x1 danza aleteo + Especial X",
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
           "variant": [
             {
-              "detail": "Crítico derrota a Volcarona → Poliwrath → Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
+              "detail": "Si un golpe crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]

--- a/src/data/johto/koga/forretress.json
+++ b/src/data/johto/koga/forretress.json
@@ -2,10 +2,10 @@
   "id": "forretress",
   "name": "Forretress",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Samurott ➜ Slowbro, Bostezo ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊",
+      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/gengar.json
+++ b/src/data/johto/koga/gengar.json
@@ -2,10 +2,10 @@
   "id": "gengar",
   "name": "Gengar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Crobat ➜ Slowbro, Mantener con Bostezo hasta que salga Gengar/Lapras ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊 (Puño hielo gengar)",
+      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Gengar o Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/gliscor.json
+++ b/src/data/johto/koga/gliscor.json
@@ -2,10 +2,10 @@
   "id": "gliscor",
   "name": "Gliscor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Lucario → Gengar, Otra Vez, +4 +2. (Bola Sombra a todos)",
+      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/hypno.json
+++ b/src/data/johto/koga/hypno.json
@@ -2,10 +2,10 @@
   "id": "hypno",
   "name": "Hypno",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Samurott ➜ Slowbro, Bostezo ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
+      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/lanturn.json
+++ b/src/data/johto/koga/lanturn.json
@@ -2,10 +2,10 @@
   "id": "lanturn",
   "name": "Lanturn",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Lucario ➜ Gengar, Otra Vez, +4 +2. (Bola Sombra a todos)",
+      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/lapras.json
+++ b/src/data/johto/koga/lapras.json
@@ -2,10 +2,10 @@
   "id": "lapras",
   "name": "Lapras",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Crobat ➜ Slowbro, mantener con Bostezo hasta que salga Gengar/Lapras ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊",
+      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Gengar o Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/lucario.json
+++ b/src/data/johto/koga/lucario.json
@@ -2,20 +2,20 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Varias Opciones💡",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Opción rápida ➜ Gengar, Otra vez, +6 +2 💡Bola Sombra a todos💡",
+      "detail": "Ruta rápida: Gengar usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad. 💡Bola Sombra a todo💡",
       "variant": [
         {
-          "detail": "Crítico de Crobat ➜ Slowbro, Bostezo ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊",
+          "detail": "Si Crobat hace crítico, cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Opción estable ➜ Gengar, Otra Vez ➜ Slowbro ➜ Chansey, trampa rocas ➜ sale Lucario ➜ Slowbro, Bostezo ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊",
+      "detail": "Ruta estable: Gengar usa Otra Vez → cambia a Slowbro → cambia a Chansey y coloca Trampa Rocas. Cuando salga Lucario, Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
       "variant": []
     }
   ]
- }
+}

--- a/src/data/johto/koga/magmortar.json
+++ b/src/data/johto/koga/magmortar.json
@@ -2,10 +2,10 @@
   "id": "magmortar",
   "name": "Magmortar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " 🪨 Trampa Rocas 🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Crobat → Slowbro, Manten Bostezo hasta que salga Magmortar ➜ Sacrifica a Politoed ➜ Poliwrath Ataque X  (Puño Drenaje a Magmortar Si Sale ditto Cambia a Gengar y matalo con bola sombra)",
+      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Magmortar. Luego sacrifica a Politoed, entra con Poliwrath y usa Ataque X. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/muk.json
+++ b/src/data/johto/koga/muk.json
@@ -2,10 +2,10 @@
   "id": "muk",
   "name": "Muk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Samurott ➜ Slowbro, Bostezo ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊(Aqui no Sale Ditto)",
+      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊 (Aquí no aparece Ditto)",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/nidoking.json
+++ b/src/data/johto/koga/nidoking.json
@@ -2,10 +2,10 @@
   "id": "nidoking",
   "name": "Nidoking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " 🪨 Trampa Rocas 🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Crobat ➜ Slowbro, usa Bostezo hasta que salga Magmortar ➜ Sacrifica a Politoed ➜ Poliwrath usar Ataque X ➜ Usa Puño Drenaje en Magmortar Si entra ditto cambia a gengar y matalo🔔",
+      "detail": "Si sale Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Luego sacrifica a Politoed, entra con Poliwrath, usa Ataque X y ataca. Usa Puño Drenaje contra Magmortar. Si aparece Ditto, cambia a Gengar y derrótalo con Bola Sombra. 🔔",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/nidoqueen.json
+++ b/src/data/johto/koga/nidoqueen.json
@@ -2,18 +2,18 @@
   "id": "nidoqueen",
   "name": "Nidoqueen",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Tierra Viva / Bomba Lodo ➜ Teletransporte ➜ Slowbro usa Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 usar Cascada contra Skarmory / Tentacruel",
+      "detail": "Si usa Tierra Viva o Bomba Lodo, usa Teletransporte hacia Slowbro y Bostezo. Luego sacrifica a Politoed, entra con Poliwrath, usa Tambor hasta +6 Ataque y usa Cascada contra Skarmory o Tentacruel.",
       "variant": []
     },
     {
-      "detail": "Lanzallamas/ Pulso Umbrío (zoroark) ➜Teletransporte; enviar a Volcarona x1 danza aleteo y gigadrenado a zoruak ➜ barrer hasta electrode/ Tentacruel y usar otro  Danza Aleteo una vez para barrer",
+      "detail": "Si usa Lanzallamas o Pulso Umbrío, revela que es Zoroark. Usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y Gigadrenado para derrotar a Zoroark. Frente a Electrode o Tentacruel, usa otra Danza Aleteo y termina de barrer.",
       "variant": []
     },
     {
-      "detail": "Si Volcarona retrocede por retroceso ➜ Cambiar a Chansey ➜recuperar vida al máximo y repetir la operación anterior",
+      "detail": "Si Volcarona retrocede, cambia a Chansey, cura a Volcarona al máximo y repite la ruta anterior.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/ninetales.json
+++ b/src/data/johto/koga/ninetales.json
@@ -2,17 +2,17 @@
   "id": "ninetales",
   "name": "Ninetales",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Tangrowth ➜ Teletransporte ➜ Slowbro usa Bostezo 🔔Observar si Latigazo acierta 🔔 ",
+      "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y Bostezo. Observa si Latigazo acierta.",
       "variant": [
         {
-          "detail": "Golpea ➜ Teletransporte ➜ Volcarona x2 danza aleteo 🦋🔥",
+          "detail": "Si golpea, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2. 🦋🔥",
           "variant": []
         },
         {
-          "detail": "Falla ➜ Volcarona x2 danza aleteo 🦋🔥",
+          "detail": "Si falla, entra con Volcarona y usa Danza Aleteo x2. 🦋🔥",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/parasect.json
+++ b/src/data/johto/koga/parasect.json
@@ -2,23 +2,23 @@
   "id": "parasect",
   "name": "Parasect",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Se queda ➜ Teletransporte",
+      "detail": "Si se queda, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Aun se queda ➜ Volcarona +1 + Especial X",
+          "detail": "Si aún se queda, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
           "variant": []
         },
         {
-          "detail": "Lucario ➜ Poliwrath ➜ Gengar Otra Vez +4 +2 (Bola sombra a todos)",
+          "detail": "Si sale Lucario, pasa por Poliwrath y luego entra con Gengar. Usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Lucario ➜ Gengar Otra Vez +4 +2 (Bola sombra a todos) ",
+      "detail": "Si sale Lucario, cambia a Gengar y repite la misma ruta de boosteo.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/rhyperior.json
+++ b/src/data/johto/koga/rhyperior.json
@@ -2,25 +2,25 @@
   "id": "rhyperior",
   "name": "Rhyperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Samurott ➜ Slowbro, Bostezo ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊  (Cascada a Hypno)",
+      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed, entra con Poliwrath y usa Tambor hasta +6 Ataque. Usa Cascada contra Hypno.",
       "variant": []
     },
     {
-      "detail": "Terremoto ➜ Encanto ➜ Slowbro, Bostezo ➜ Frente a Gengar/Lapras ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 (Puño hielo Gengar)",
+      "detail": "Si usa Terremoto, usa Encanto, luego cambia a Slowbro y usa Bostezo. Frente a Gengar o Lapras, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
       "variant": []
     },
     {
-      "detail": "Sale Tangrowth ➜ Teletransporte ➜ Slowbro, Bostezo 🔔Mira la precisión de Tangrowth🔔 ",
+      "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y Bostezo. Revisa si Tangrowth acierta el ataque.",
       "variant": [
         {
-          "detail": "Golpea ➜ Teletransporte ➜ Volcarona x2 Danza aleteo🦋🔥",
+          "detail": "Si acierta, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2.",
           "variant": []
         },
         {
-          "detail": "Falla ➜ Volcarona x2 Danza aleteo🦋🔥",
+          "detail": "Si falla, entra con Volcarona y usa Danza Aleteo x2.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/samurott.json
+++ b/src/data/johto/koga/samurott.json
@@ -2,10 +2,10 @@
   "id": "samurott",
   "name": "Samurott",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Cambia a Slowbro, bostezo ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊",
+      "detail": "Cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/scizor.json
+++ b/src/data/johto/koga/scizor.json
@@ -2,13 +2,13 @@
   "id": "scizor",
   "name": "Scizor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🦋Cambia a Volcarona🦋",
+  "initialMove": "🦋 Cambia a Volcarona 🦋",
   "tricks": [
     {
-      "detail": "Danza Aleteo + Especial X",
+      "detail": "Usa Danza Aleteo x1 y Ataque Especial X.",
       "variant": [
         {
-          "detail": "Crítico derrota a Volcarona ➜ Poliwrath ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
+          "detail": "Si un golpe crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/sharpedo.json
+++ b/src/data/johto/koga/sharpedo.json
@@ -2,17 +2,17 @@
   "id": "sharpedo",
   "name": "Sharpedo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Tangrowth ➜ Teletransporte ➜ Slowbro, Bostezo (Mira la precisión de Tangrowth) ",
+      "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y Bostezo. Observa la precisión de Tangrowth.",
       "variant": [
         {
-          "detail": "Golpea → Teletransporte ➜ Volcarona x2 Danza aleteo🦋🔥",
+          "detail": "Si acierta, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2. 🦋🔥",
           "variant": []
         },
         {
-          "detail": "Falla ➜ Volcarona x2 Danza aleteo🦋🔥",
+          "detail": "Si falla, entra con Volcarona y usa Danza Aleteo x2. 🦋🔥",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/skarmory.json
+++ b/src/data/johto/koga/skarmory.json
@@ -2,20 +2,20 @@
   "id": "skarmory",
   "name": "Skarmory",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Pico Taladro ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrifica a Palpitoad ➜ Poliwrath +6 🐸🥊🔔Cascada a skarmory o Tentacruel🔔",
+      "detail": "Si usa Pico Taladro, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊 Usa Cascada contra Skarmory o Tentacruel.",
       "variant": [
         {
-          "detail": "Lanzallamas/ Pulso Umbrío (zoroark) ➜ Teletransporte ➜ Volcarona x1 danza aleteo y gigadrenado a zoruak ➜ barrer hasta electrode/ Tentacruel y usar otro Danza Aleteo una vez para barrer",
+          "detail": "Si usa Lanzallamas o Pulso Umbrío, revela que es Zoroark. Usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y Gigadrenado. Luego barre hasta Electrode o Tentacruel y usa otra Danza Aleteo para cerrar.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Si Volcarona recibe retrocesos, cambia a Chansey → Max pocion a Volcarona y repite el proceso.",
+      "detail": "Si Volcarona recibe retrocesos, cambia a Chansey, usa Max Poción en Volcarona y repite el proceso.",
       "variant": []
     }
   ]
- }
+}

--- a/src/data/johto/koga/skuntank.json
+++ b/src/data/johto/koga/skuntank.json
@@ -2,10 +2,10 @@
   "id": "skuntank",
   "name": "Skuntank",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Lucario → Gengar, Otra Vez, +4 +2 (Bola Sombra a todos) 🔔Skuntank Tiene Pañuelo 🔔",
+      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra. 🔔Skuntank tiene Pañuelo Elegido🔔",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/starmie.json
+++ b/src/data/johto/koga/starmie.json
@@ -2,10 +2,10 @@
   "id": "starmie",
   "name": "Starmie",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Sale Toxicroak → Gengar, Otra Vez, +2 +2 +precision X 🔔Toxicroak tiene banda Focus🔔",
+      "detail": "Si sale Toxicroak, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. 🔔Toxicroak tiene Banda Focus🔔",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/stunfisk.json
+++ b/src/data/johto/koga/stunfisk.json
@@ -2,13 +2,13 @@
   "id": "stunfisk",
   "name": "Stunfisk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🦋Cambia a Volcarona🦋",
+  "initialMove": "Cambiar a Volcarona",
   "tricks": [
     {
-      "detail": "Sale Scizor → Volcarona Danza Aleteo + Ataque Especial X.",
+      "detail": "Si sale Scizor, usa Volcarona con Danza Aleteo y Ataque Especial X.",
       "variant": [
         {
-          "detail": "Crítico derrota a Volcarona → Poliwrath → Politoed → Poliwrath +6 🐸🥊",
+          "detail": "Si Volcarona cae por crítico, usa Poliwrath con Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/swalot.json
+++ b/src/data/johto/koga/swalot.json
@@ -2,13 +2,13 @@
   "id": "swalot",
   "name": "Swalot",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🦋 Cambia a Volcarona 🦋",
+  "initialMove": "Cambia a Volcarona.",
   "tricks": [
     {
-      "detail": "Sale Scizor ➜ Danza Aleteo + Ataque Especial X.",
+      "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
       "variant": [
         {
-          "detail": "Crítico derrota a Volcarona ➜ Poliwrath ➜ Politoed  Poliwrath +6🐸🥊",
+          "detail": "Si un golpe crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/tangrowth.json
+++ b/src/data/johto/koga/tangrowth.json
@@ -2,17 +2,17 @@
   "id": "tangrowth",
   "name": "Tangrowth",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Teletransporte ➜ Slowbro, Bostezo. (Mira la precisión de Tangrowth) ",
+      "detail": "Usa Teletransporte hacia Slowbro y Bostezo. Revisa si Tangrowth acierta el ataque.",
       "variant": [
         {
-          "detail": "Golpea ➜ Teletransporte ➜ Volcarona x2 Danza Aleteo 🦋🔥",
+          "detail": "Si acierta, usa Teletransporte hacia Volcarona y usa Danza Aleteo x2.",
           "variant": []
         },
         {
-          "detail": "Falla ➜ Volcarona x2 Danza Aleteo 🦋🔥",
+          "detail": "Si falla, entra con Volcarona y usa Danza Aleteo x2.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/tentacruel.json
+++ b/src/data/johto/koga/tentacruel.json
@@ -2,30 +2,30 @@
   "id": "tentacruel",
   "name": "Tentacruel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda ➜ Ver qué habilidad/movimiento usa",
+      "detail": "Si se queda, revisa qué movimiento usa.",
       "variant": [
         {
-          "detail": "Escaldar ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔usar Cascada contra Skarmory / Tentacruel🔔",
+          "detail": "Si usa Escaldar, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed, entra con Poliwrath y usa Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
           "variant": []
         },
         {
-          "detail": "Lanzallamas/ Pulso Umbrío (zoroark) ➜ Teletransporte; enviar a Volcarona Danza aleteo usa gigadrenado y frente a electrode/ Tentacruel ➜ Danza Aleteo una vez para barrer 🔔 si Volcarona retrocede cambiar a Chansey, recuperar vida al máximo y repetir🔔",
+          "detail": "Si usa Lanzallamas o Pulso Umbrío, revela que es Zoroark. Usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y Gigadrenado. Frente a Electrode o Tentacruel, usa otra Danza Aleteo y termina de barrer.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Crobat ➜ Teletransporte para ver movimiento",
+      "detail": "Si sale Crobat, usa Teletransporte para ver qué movimiento usa.",
       "variant": [
         {
-          "detail": "Veneno X / Puya Nociva ➜ Slowbro usa Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔 Cascada contra Skarmory / Tentacruel🔔",
+          "detail": "Si usa movimientos de Veneno, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
           "variant": []
         },
         {
-          "detail": "Lanzallamas/ Pulso Umbrío (zoroark) ➜ Teletransporte ➜ enviar a Volcarona Danza aleteo usa gigadrenado y frente a electrode/ Tentacruel ➜ Danza Aleteo una vez para barrer 🔔 si Volcarona retrocede cambiar a Chansey, recuperar vida al máximo y repetir🔔",
+          "detail": "Si usa Lanzallamas o Pulso Umbrío, revela que es Zoroark. Usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y Gigadrenado. Frente a Electrode o Tentacruel, usa otra Danza Aleteo y termina de barrer.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/venomoth.json
+++ b/src/data/johto/koga/venomoth.json
@@ -2,7 +2,16 @@
   "id": "venomoth",
   "name": "Venomoth",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar de Volcarona ➜ Frente a Scizor ➜ Volcarona x1 danza aleteo + Especial X 🔔 Si el Crítico debilita a volcarona cambiar a Politoed y Poliwrath +6 🔔",
-  "tricks": []
+  "initialMove": "Cambia a Volcarona.",
+  "tricks": [
+    {
+      "detail": "Frente a Scizor, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
+      "variant": [
+        {
+          "detail": "Si un golpe crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }
-  

--- a/src/data/johto/koga/weezing.json
+++ b/src/data/johto/koga/weezing.json
@@ -2,6 +2,11 @@
   "id": "weezing",
   "name": "Weezing",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Poner Trampa Rocas🪨 frente a Crobat ➜ cambiar a Slowbro y usar Bostezo constantemente hasta que salgan Gengar o Lapras ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 👻 Puño Hielo a Gengar 👻",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Crobat, cambia a Slowbro y usa Bostezo hasta que salga Gengar o Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+      "variant": []
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Normalized all Johto Koga strategy JSON text.
- Rewrote old arrow-style notes into clear Spanish instructions.
- Expanded boosts and setup steps explicitly.
- Preserved the existing compact JSON structure and route logic.

## Scope
- Text-only updates in `src/data/johto/koga/`.
- No asset or frontend changes.