### PR TITLE
Clean Johto strategy wording and emoji markers

### DIFF
--- a/src/data/johto/bruno/blastoise.json
+++ b/src/data/johto/bruno/blastoise.json
@@ -9,7 +9,7 @@
       "variant": []
     },
     {
-      "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo frente a Metagross. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo frente a Metagross. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {

--- a/src/data/johto/bruno/darmanitan.json
+++ b/src/data/johto/bruno/darmanitan.json
@@ -9,11 +9,11 @@
       "variant": []
     },
     {
-      "detail": "Ruta estable: Slowbro usa Bostezo, luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Ruta estable: Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Ruta arriesgada: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Ruta arriesgada: entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/eelektross.json
+++ b/src/data/johto/bruno/eelektross.json
@@ -16,17 +16,17 @@
           "variant": []
         },
         {
-          "detail": "Ruta estable: Slowbro usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Ruta estable: Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Ruta arriesgada: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Ruta arriesgada: entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo. Cuando salga Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo. Cuando salga Metagross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {

--- a/src/data/johto/bruno/electivire.json
+++ b/src/data/johto/bruno/electivire.json
@@ -5,11 +5,11 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo repetidamente hasta que salga Golem. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo repetidamente hasta que salga Golem. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si sale Golem, usa Encanto y Amortiguador. Cuando salga Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Golem, usa Encanto y Amortiguador. Cuando salga Metagross, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {

--- a/src/data/johto/bruno/gliscor.json
+++ b/src/data/johto/bruno/gliscor.json
@@ -5,7 +5,7 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Cambia a Slowbro y usa Bostezo contra Metagross. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Cambia a Slowbro y usa Bostezo contra Metagross. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/golem.json
+++ b/src/data/johto/bruno/golem.json
@@ -5,7 +5,7 @@
   "initialMove": "❤️ Encanto y Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/hitmonchan.json
+++ b/src/data/johto/bruno/hitmonchan.json
@@ -5,7 +5,7 @@
   "initialMove": "Cambia a Slowbro y usa Bostezo.",
   "tricks": [
     {
-      "detail": "Si sale Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Metagross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/machamp.json
+++ b/src/data/johto/bruno/machamp.json
@@ -8,7 +8,7 @@
       "detail": "Si Machamp usa Puño Dinámico, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Si usa Vendetta, vuelve a usar Bostezo. Cuando salga Metagross o Eelektross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si usa Vendetta, vuelve a usar Bostezo. Cuando salga Metagross o Eelektross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
@@ -32,13 +32,13 @@
               "variant": []
             },
             {
-              "detail": "Si sale Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "detail": "Si sale Metagross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Si usa Puño Hielo, usa Bostezo frente a Metagross. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si usa Puño Hielo, usa Bostezo frente a Metagross. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
@@ -82,7 +82,7 @@
           "variant": []
         },
         {
-          "detail": "Si sale Eelektross o Torterra, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si sale Eelektross o Torterra, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/bruno/metagross.json
+++ b/src/data/johto/bruno/metagross.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si Metagross se queda, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si Metagross se queda, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
@@ -16,24 +16,24 @@
           "variant": []
         },
         {
-          "detail": "Ruta estable: cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Ruta estable: cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Ruta arriesgada: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Ruta arriesgada: entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo. Cuando salga Metagross, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Hitmonchan, cambia a Slowbro y usa Bostezo. Cuando salga Metagross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
       "detail": "Si sale Machamp, cambia a Gengar y revisa qué ataque usa.",
       "variant": [
         {
-          "detail": "Si usa Puño Dinámico, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si usa Puño Dinámico, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {

--- a/src/data/johto/bruno/muk.json
+++ b/src/data/johto/bruno/muk.json
@@ -5,15 +5,15 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si Muk usa Puya Nociva, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si Muk usa Puya Nociva, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/salamence.json
+++ b/src/data/johto/bruno/salamence.json
@@ -26,7 +26,7 @@
       "detail": "Si no tiene Intimidación, coloca Trampa Rocas.",
       "variant": [
         {
-          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
@@ -43,7 +43,7 @@
           ]
         },
         {
-          "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si sale Golem, usa Encanto y Amortiguador hasta que salga Metagross. Luego cambia a Slowbro, usa Bostezo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/bruno/seismitoad.json
+++ b/src/data/johto/bruno/seismitoad.json
@@ -9,11 +9,11 @@
       "variant": []
     },
     {
-      "detail": "Ruta estable: cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Ruta estable: cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Ruta arriesgada: sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Ruta arriesgada: entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/bruno/torterra.json
+++ b/src/data/johto/bruno/torterra.json
@@ -9,7 +9,7 @@
       "variant": []
     },
     {
-      "detail": "Ruta estable: cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Ruta estable: cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/electrode.json
+++ b/src/data/johto/karen/electrode.json
@@ -2,7 +2,7 @@
   "id": "electrode",
   "name": "Electrode",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego usa Teletransporte hacia Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego usa Teletransporte hacia Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": [
     {
       "detail": "Si Slowbro queda paralizado y no puede usar Bostezo, cambia a Chansey, recupera vida y repite la secuencia.",

--- a/src/data/johto/karen/excadrill.json
+++ b/src/data/johto/karen/excadrill.json
@@ -5,7 +5,7 @@
   "initialMove": "Revisa qué objeto tiene Excadrill.",
   "tricks": [
     {
-      "detail": "Si tiene Globo Helio, usa Encanto. Luego usa Trampa Rocas. Si Excadrill se queda, usa Amortiguador. Frente a Tyranitar, cambia a Poliwrath para derrotarlo.",
+      "detail": "Si tiene Globo Helio, usa Encanto. Luego usa Trampa Rocas. Si Excadrill se queda, usa Amortiguador. Frente a Tyranitar, cambia a Poliwrath 🐸🥊 para enfrentarlo.",
       "variant": [
         {
           "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Usa Psíquico contra Gyarados, sigue hasta Houndoom e ignora la amenaza.",
@@ -27,7 +27,7 @@
       ]
     },
     {
-      "detail": "Si Excadrill se queda sin Globo Helio, sigue usando Gigadrenado hasta derrotarlo.",
+      "detail": "Si Excadrill se queda sin Globo Helio, sigue usando Gigadrenado hasta enfrentarlo.",
       "variant": []
     },
     {
@@ -37,7 +37,7 @@
           "detail": "Si sale Slowbro, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Mantén Otra Vez activo mientras haces el setup.",
           "variant": [
             {
-              "detail": "Si cambia a Excadrill mientras intentas boostearte, cambia a Slowbro, luego a Chansey y usa Encanto. Vuelve a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "detail": "Si cambia a Excadrill mientras intentas boostearte, cambia a Slowbro, luego a Chansey y usa Encanto. Vuelve a Slowbro, usa Bostezo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]

--- a/src/data/johto/karen/feraligatr.json
+++ b/src/data/johto/karen/feraligatr.json
@@ -5,11 +5,11 @@
   "initialMove": "Usa ❤️ Encanto ❤️.",
   "tricks": [
     {
-      "detail": "Si el daño es menor a 36% o el crítico es menor a 54%, usa 🪨 Trampa Rocas 🪨. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si el daño es menor a 36% o el crítico es menor a 54%, usa 🪨 Trampa Rocas 🪨. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si el daño es mayor a 39% o el crítico es mayor a 59%, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque. Cura la quemadura si corresponde.",
+      "detail": "Si el daño es mayor a 39% o el crítico es mayor a 59%, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Cura la quemadura si corresponde.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/flareon.json
+++ b/src/data/johto/karen/flareon.json
@@ -2,10 +2,10 @@
   "id": "flareon",
   "name": "Flareon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": [
     {
-      "detail": "Si un golpe crítico de Typhlosion derrota a Poliwrath, entra con Gengar, usa Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+      "detail": "Si un golpe crítico de Typhlosion deja fuera a Poliwrath 🐸🥊, entra con Gengar, usa Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/gallade.json
+++ b/src/data/johto/karen/gallade.json
@@ -2,6 +2,6 @@
   "id": "gallade",
   "name": "Gallade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻 Gengar usa Otra Vez. Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque. Cura la quemadura si corresponde.",
+  "initialMove": "👻 Gengar usa Otra Vez. Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Cura la quemadura si corresponde.",
   "tricks": []
 }

--- a/src/data/johto/karen/garchomp.json
+++ b/src/data/johto/karen/garchomp.json
@@ -2,6 +2,6 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": []
 }

--- a/src/data/johto/karen/gyarados.json
+++ b/src/data/johto/karen/gyarados.json
@@ -31,7 +31,7 @@
       ]
     },
     {
-      "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo.",
+      "detail": "Si sale Tyranitar, cambia a Poliwrath 🐸🥊 para enfrentarlo.",
       "variant": [
         {
           "detail": "Si después sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Usa Psíquico contra Gyarados, sigue hasta Houndoom e ignora la amenaza.",
@@ -51,13 +51,13 @@
           ]
         },
         {
-          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta enfrentarlo.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Si sale Excadrill, usa Encanto. Luego usa Amortiguador frente a Tyranitar y cambia a Poliwrath para derrotarlo.",
+      "detail": "Si sale Excadrill, usa Encanto. Luego usa Amortiguador frente a Tyranitar y cambia a Poliwrath 🐸🥊 para enfrentarlo.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/honchkrow.json
+++ b/src/data/johto/karen/honchkrow.json
@@ -2,6 +2,6 @@
   "id": "honchkrow",
   "name": "Honchkrow",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro y usa Bostezo frente a Houndoom. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque. Cura la quemadura si corresponde.",
+  "initialMove": "Cambia a Slowbro y usa Bostezo frente a Houndoom. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Cura la quemadura si corresponde.",
   "tricks": []
 }

--- a/src/data/johto/karen/houndoom.json
+++ b/src/data/johto/karen/houndoom.json
@@ -11,7 +11,7 @@
           "detail": "Si tiene Vidasfera, usa Amortiguador 2 veces.",
           "variant": [
             {
-              "detail": "Si se queda, sacrifica a Politoed, entra con Poliwrath y usa Ataque X.",
+              "detail": "Si se queda, entra Politoed como pivote, entra con Poliwrath 🐸🥊 y usa Ataque X.",
               "variant": []
             },
             {
@@ -19,7 +19,7 @@
               "variant": []
             },
             {
-              "detail": "Si sale Feraligatr, usa Encanto, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "detail": "Si sale Feraligatr, usa Encanto, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
@@ -29,13 +29,13 @@
           "variant": []
         },
         {
-          "detail": "Si sale Honchkrow, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si sale Honchkrow, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Si sale Tyranitar, cambia a Poliwrath y derrótalo.",
+      "detail": "Si sale Tyranitar, cambia a Poliwrath 🐸🥊 y derrótalo.",
       "variant": [
         {
           "detail": "Si después sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Usa Psíquico contra Gyarados, sigue hasta Houndoom e ignora la amenaza.",
@@ -64,7 +64,7 @@
       "detail": "Si sale Excadrill, revisa su objeto.",
       "variant": [
         {
-          "detail": "Si tiene Globo Helio, usa Encanto. Luego usa Amortiguador frente a Tyranitar y cambia a Poliwrath para derrotarlo.",
+          "detail": "Si tiene Globo Helio, usa Encanto. Luego usa Amortiguador frente a Tyranitar y cambia a Poliwrath 🐸🥊 para derrotarlo.",
           "variant": [
             {
               "detail": "Si después sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Usa Psíquico contra Gyarados, sigue hasta Houndoom e ignora la amenaza.",
@@ -126,7 +126,7 @@
       "variant": []
     },
     {
-      "detail": "Si sale Primeape, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Primeape, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
@@ -134,7 +134,7 @@
       "variant": []
     },
     {
-      "detail": "Si sale Gallade o Roserade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Gallade o Roserade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/luxray.json
+++ b/src/data/johto/karen/luxray.json
@@ -2,6 +2,6 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Chansey usa Amortiguador. Luego usa 🪨 Trampa Rocas 🪨 frente a un tipo Lucha. Slowbro usa Bostezo, luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Chansey usa Amortiguador. Luego usa 🪨 Trampa Rocas 🪨 frente a un tipo Lucha. Slowbro usa Bostezo, luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": []
 }

--- a/src/data/johto/koga/ariados.json
+++ b/src/data/johto/koga/ariados.json
@@ -8,7 +8,7 @@
       "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y Bostezo. Revisa si Tangrowth acierta el ataque.",
       "variant": [
         {
-          "detail": "Si acierta, usa Teletransporte hacia Poliwrath, usa Tambor hasta +6 Ataque y Puño Drenaje contra Tangrowth. Cuando salga Sharpedo, usa Velocidad X y Puño Drenaje. Sharpedo tiene Banda Focus.",
+          "detail": "Si acierta, usa Teletransporte hacia Poliwrath 🐸🥊, usa Tambor hasta +6 Ataque y Puño Drenaje contra Tangrowth. Cuando salga Sharpedo, usa Velocidad X y Puño Drenaje. Sharpedo tiene Banda Focus.",
           "variant": []
         },
         {

--- a/src/data/johto/koga/bisharp.json
+++ b/src/data/johto/koga/bisharp.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Gengar o Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Gengar o Lapras. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/crobat.json
+++ b/src/data/johto/koga/crobat.json
@@ -11,11 +11,11 @@
           "detail": "Si usa Superdiente, cambia a Slowbro.",
           "variant": [
             {
-              "detail": "Si se queda, Slowbro usa Bostezo frente a Magmortar. Luego sacrifica a Politoed, entra con Poliwrath, toma un Ataque X y barre. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
+              "detail": "Si se queda, Slowbro usa Bostezo frente a Magmortar. Luego entra Politoed como pivote, entra con Poliwrath 🐸🥊, usa Ataque X y barre. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
               "variant": []
             },
             {
-              "detail": "Si sale Rhyperior, Slowbro usa Bostezo y recibe Megacuerno. Luego usa Protección y Bostezo. Frente a Gengar o Lapras, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+              "detail": "Si sale Rhyperior, Slowbro usa Bostezo y recibe Megacuerno. Luego usa Protección y Bostezo. Frente a Gengar o Lapras, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
               "variant": []
             }
           ]
@@ -40,7 +40,7 @@
       ]
     },
     {
-      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
@@ -51,7 +51,7 @@
       "detail": "Si sale Ariados, usa Encanto y Amortiguador para forzar el cambio.",
       "variant": [
         {
-          "detail": "Si sale Rhyperior, cambia a Slowbro y usa Bostezo. Luego usa Teletransporte hacia Poliwrath, usa Tambor hasta +6 Ataque y Puño Drenaje. Frente a Sharpedo, usa Velocidad X y termina de barrer.",
+          "detail": "Si sale Rhyperior, cambia a Slowbro y usa Bostezo. Luego usa Teletransporte hacia Poliwrath 🐸🥊, usa Tambor hasta +6 Ataque y Puño Drenaje. Frente a Sharpedo, usa Velocidad X y termina de barrer.",
           "variant": []
         },
         {
@@ -77,7 +77,7 @@
       "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
       "variant": [
         {
-          "detail": "Si Volcarona cae, entra con Poliwrath, sacrifica a Politoed y vuelve a Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si Volcarona queda fuera, entra Politoed como pivote y vuelve a Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/ferrothorn.json
+++ b/src/data/johto/koga/ferrothorn.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Frente a Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Luego sacrifica a Politoed, entra con Poliwrath, usa Ataque X y ataca.",
+      "detail": "Frente a Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Luego entra Politoed como pivote, entra con Poliwrath 🐸🥊, usa Ataque X y ataca.",
       "variant": [
         {
           "detail": "Usa Puño Drenaje contra Magmortar. Frente a Ditto, cambia a Gengar y derrótalo con Bola Sombra.",

--- a/src/data/johto/koga/floatzel.json
+++ b/src/data/johto/koga/floatzel.json
@@ -5,13 +5,13 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Luego sacrifica a Politoed, entra con Poliwrath, usa Ataque X y ataca. Usa Puño Drenaje contra Magmortar. Frente a Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
+      "detail": "Si sale Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Luego entra Politoed como pivote, entra con Poliwrath 🐸🥊, usa Ataque X y ataca. Usa Puño Drenaje contra Magmortar. Frente a Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
       "variant": [
         {
           "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
           "variant": [
             {
-              "detail": "Si un golpe crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+              "detail": "Si un golpe crítico deja fuera a Volcarona, entra Politoed como pivote y vuelve con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]

--- a/src/data/johto/koga/forretress.json
+++ b/src/data/johto/koga/forretress.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/gengar.json
+++ b/src/data/johto/koga/gengar.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Gengar o Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Gengar o Lapras. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/hypno.json
+++ b/src/data/johto/koga/hypno.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
+      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/lapras.json
+++ b/src/data/johto/koga/lapras.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Gengar o Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
+      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Gengar o Lapras. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/lucario.json
+++ b/src/data/johto/koga/lucario.json
@@ -5,16 +5,16 @@
   "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Ruta rápida: Gengar usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad. 💡Bola Sombra a todo💡",
+      "detail": "Ruta rápida: Gengar usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad. Usa Bola Sombra contra todo.",
       "variant": [
         {
-          "detail": "Si Crobat hace crítico, cambia a Slowbro, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
+          "detail": "Si Crobat hace golpe crítico, cambia a Slowbro, usa Bostezo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Ruta estable: Gengar usa Otra Vez → cambia a Slowbro → cambia a Chansey y coloca Trampa Rocas. Cuando salga Lucario, Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
+      "detail": "Ruta estable: Gengar usa Otra Vez. Luego cambia a Slowbro, cambia a Chansey y coloca Trampa Rocas. Cuando salga Lucario, Slowbro usa Bostezo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/magmortar.json
+++ b/src/data/johto/koga/magmortar.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Magmortar. Luego sacrifica a Politoed, entra con Poliwrath y usa Ataque X. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
+      "detail": "Si sale Crobat, cambia a Slowbro y mantén Bostezo hasta que salga Magmortar. Luego entra Politoed como pivote, entra con Poliwrath 🐸🥊 y usa Ataque X. Usa Puño Drenaje contra Magmortar. Si sale Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/muk.json
+++ b/src/data/johto/koga/muk.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊 (Aquí no aparece Ditto)",
+      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Aquí no aparece Ditto.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/nidoking.json
+++ b/src/data/johto/koga/nidoking.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Luego sacrifica a Politoed, entra con Poliwrath, usa Ataque X y ataca. Usa Puño Drenaje contra Magmortar. Si aparece Ditto, cambia a Gengar y derrótalo con Bola Sombra. 🔔",
+      "detail": "Si sale Crobat, cambia a Slowbro y usa Bostezo hasta que salga Magmortar. Luego entra Politoed como pivote, entra con Poliwrath 🐸🥊, usa Ataque X y ataca. Usa Puño Drenaje contra Magmortar. Si aparece Ditto, cambia a Gengar y derrótalo con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/nidoqueen.json
+++ b/src/data/johto/koga/nidoqueen.json
@@ -5,7 +5,7 @@
   "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si usa Tierra Viva o Bomba Lodo, usa Teletransporte hacia Slowbro y Bostezo. Luego sacrifica a Politoed, entra con Poliwrath, usa Tambor hasta +6 Ataque y usa Cascada contra Skarmory o Tentacruel.",
+      "detail": "Si usa Tierra Viva o Bomba Lodo, usa Teletransporte hacia Slowbro y Bostezo. Luego entra Politoed como pivote, entra con Poliwrath 🐸🥊, usa Tambor hasta +6 Ataque y usa Cascada contra Skarmory o Tentacruel.",
       "variant": []
     },
     {

--- a/src/data/johto/koga/parasect.json
+++ b/src/data/johto/koga/parasect.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si sale Lucario, pasa por Poliwrath y luego entra con Gengar. Usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "detail": "Si sale Lucario, pasa por Poliwrath 🐸🥊 y luego entra con Gengar. Usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/rhyperior.json
+++ b/src/data/johto/koga/rhyperior.json
@@ -5,11 +5,11 @@
   "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed, entra con Poliwrath y usa Tambor hasta +6 Ataque. Usa Cascada contra Hypno.",
+      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote, entra con Poliwrath 🐸🥊 y usa Tambor hasta +6 Ataque. Usa Cascada contra Hypno.",
       "variant": []
     },
     {
-      "detail": "Si usa Terremoto, usa Encanto, luego cambia a Slowbro y usa Bostezo. Frente a Gengar o Lapras, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+      "detail": "Si usa Terremoto, usa Encanto, luego cambia a Slowbro y usa Bostezo. Frente a Gengar o Lapras, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
       "variant": []
     },
     {

--- a/src/data/johto/koga/samurott.json
+++ b/src/data/johto/koga/samurott.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
+      "detail": "Cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/scizor.json
+++ b/src/data/johto/koga/scizor.json
@@ -8,7 +8,7 @@
       "detail": "Usa Danza Aleteo x1 y Ataque Especial X.",
       "variant": [
         {
-          "detail": "Si un golpe crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊",
+          "detail": "Si un golpe crítico deja fuera a Volcarona, entra Politoed como pivote y vuelve con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/skarmory.json
+++ b/src/data/johto/koga/skarmory.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si usa Pico Taladro, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🐸🥊 Usa Cascada contra Skarmory o Tentacruel.",
+      "detail": "Si usa Pico Taladro, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
       "variant": [
         {
           "detail": "Si usa Lanzallamas o Pulso Umbrío, revela que es Zoroark. Usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y Gigadrenado. Luego barre hasta Electrode o Tentacruel y usa otra Danza Aleteo para cerrar.",

--- a/src/data/johto/koga/skuntank.json
+++ b/src/data/johto/koga/skuntank.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra. 🔔Skuntank tiene Pañuelo Elegido🔔",
+      "detail": "Si sale Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra. Skuntank tiene Pañuelo Elegido.",
       "variant": []
     }
   ]

--- a/src/data/johto/koga/stunfisk.json
+++ b/src/data/johto/koga/stunfisk.json
@@ -2,13 +2,13 @@
   "id": "stunfisk",
   "name": "Stunfisk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Volcarona",
+  "initialMove": "Cambia a Volcarona.",
   "tricks": [
     {
-      "detail": "Si sale Scizor, usa Volcarona con Danza Aleteo y Ataque Especial X.",
+      "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
       "variant": [
         {
-          "detail": "Si Volcarona cae por crítico, usa Poliwrath con Tambor hasta +6 Ataque.",
+          "detail": "Si Volcarona queda fuera por un golpe crítico, entra con Poliwrath 🐸🥊 y usa Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/swalot.json
+++ b/src/data/johto/koga/swalot.json
@@ -8,7 +8,7 @@
       "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
       "variant": [
         {
-          "detail": "Si un golpe crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si un golpe crítico deja fuera a Volcarona, entra Politoed como pivote y vuelve con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/tentacruel.json
+++ b/src/data/johto/koga/tentacruel.json
@@ -8,7 +8,7 @@
       "detail": "Si se queda, revisa qué movimiento usa.",
       "variant": [
         {
-          "detail": "Si usa Escaldar, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed, entra con Poliwrath y usa Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
+          "detail": "Si usa Escaldar, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote, entra con Poliwrath 🐸🥊 y usa Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
           "variant": []
         },
         {
@@ -21,7 +21,7 @@
       "detail": "Si sale Crobat, usa Teletransporte para ver qué movimiento usa.",
       "variant": [
         {
-          "detail": "Si usa movimientos de Veneno, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
+          "detail": "Si usa movimientos de Veneno, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory o Tentacruel.",
           "variant": []
         },
         {

--- a/src/data/johto/koga/venomoth.json
+++ b/src/data/johto/koga/venomoth.json
@@ -8,7 +8,7 @@
       "detail": "Frente a Scizor, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
       "variant": [
         {
-          "detail": "Si un golpe crítico derrota a Volcarona, entra con Poliwrath, sacrifica a Politoed y vuelve con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si un golpe crítico deja fuera a Volcarona, entra Politoed como pivote y vuelve con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/koga/weezing.json
+++ b/src/data/johto/koga/weezing.json
@@ -5,7 +5,7 @@
   "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Frente a Crobat, cambia a Slowbro y usa Bostezo hasta que salga Gengar o Lapras. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+      "detail": "Frente a Crobat, cambia a Slowbro y usa Bostezo hasta que salga Gengar o Lapras. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/aerodactyl.json
+++ b/src/data/johto/lance/aerodactyl.json
@@ -9,7 +9,7 @@
       "variant": []
     },
     {
-      "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Steelix.",
+      "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Steelix.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/ampharos.json
+++ b/src/data/johto/lance/ampharos.json
@@ -5,15 +5,15 @@
   "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si sale Tyranitar, cambia a Poliwrath para derrotarlo. Luego cambia a Chansey, usa Amortiguador y espera a Metagross. Usa Teletransporte hacia Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Tyranitar, cambia a Poliwrath 🐸🥊 para derrotarlo. Luego cambia a Chansey, usa Amortiguador y espera a Metagross. Usa Teletransporte hacia Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si sale Feraligatr, usa Encanto. Luego Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Feraligatr, usa Encanto. Luego Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/arbok.json
+++ b/src/data/johto/lance/arbok.json
@@ -2,6 +2,6 @@
   "id": "arbok",
   "name": "Arbok",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro y usa Bostezo frente a Eelektross. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Cambia a Slowbro y usa Bostezo frente a Eelektross. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": []
 }

--- a/src/data/johto/lance/arcanine.json
+++ b/src/data/johto/lance/arcanine.json
@@ -5,20 +5,20 @@
   "initialMove": "👻 Gengar usa Otra Vez. Luego cambia a Chansey y después a Dragonite. Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
       "detail": "Si sale Scizor, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Mantén los PS de Volcarona por encima del 51%.",
       "variant": [
         {
-          "detail": "Si Volcarona cae por un golpe crítico, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si Volcarona cae por un golpe crítico, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Si sale Feraligatr, usa Encanto. Luego Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Feraligatr, usa Encanto. Luego Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/charizard.json
+++ b/src/data/johto/lance/charizard.json
@@ -2,10 +2,10 @@
   "id": "charizard",
   "name": "Charizard",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Tyranitar. Luego cambia a Poliwrath para derrotarlo.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Tyranitar. Luego cambia a Poliwrath 🐸🥊 para derrotarlo.",
   "tricks": [
     {
-      "detail": "Después entra con Chansey y usa Amortiguador. Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Después entra con Chansey y usa Amortiguador. Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/dragonite.json
+++ b/src/data/johto/lance/dragonite.json
@@ -8,11 +8,11 @@
       "detail": "Si Dragonite no cambia, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Si sale Scizor, entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si sale Scizor, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si sale Flygon, usa Protección y luego Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si sale Flygon, usa Protección y luego Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {

--- a/src/data/johto/lance/electivire.json
+++ b/src/data/johto/lance/electivire.json
@@ -5,11 +5,11 @@
   "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si usa Tajo Cruzado, cambia a Slowbro, usa Bostezo, Protección y luego Bostezo. Frente a Lucario, entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si usa Tajo Cruzado, cambia a Slowbro, usa Bostezo, Protección y luego Bostezo. Frente a Lucario, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si sale Infernape, cambia a Slowbro y usa Bostezo frente a Electivire. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Infernape, cambia a Slowbro y usa Bostezo frente a Electivire. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/feraligatr.json
+++ b/src/data/johto/lance/feraligatr.json
@@ -5,7 +5,7 @@
   "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si Feraligatr se queda, revisa su movimiento. Si usa Cascada, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si Feraligatr se queda, revisa su movimiento. Si usa Cascada, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
@@ -13,7 +13,7 @@
       "variant": []
     },
     {
-      "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo. Frente a Flygon, usa Protección y Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo. Frente a Flygon, usa Protección y Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {

--- a/src/data/johto/lance/flygon.json
+++ b/src/data/johto/lance/flygon.json
@@ -9,7 +9,7 @@
       "variant": []
     },
     {
-      "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/garchomp.json
+++ b/src/data/johto/lance/garchomp.json
@@ -2,6 +2,6 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro y usa Bostezo frente a Eelektross. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Cambia a Slowbro y usa Bostezo frente a Eelektross. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": []
 }

--- a/src/data/johto/lance/haxorus.json
+++ b/src/data/johto/lance/haxorus.json
@@ -2,6 +2,6 @@
   "id": "haxorus",
   "name": "Haxorus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Gengar y usa Bola Sombra. Luego Slowbro usa Bostezo frente a Scizor. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Cambia a Gengar y usa Bola Sombra. Luego Slowbro usa Bostezo frente a Scizor. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": []
 }

--- a/src/data/johto/lance/hydreigon.json
+++ b/src/data/johto/lance/hydreigon.json
@@ -5,11 +5,11 @@
   "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si sale Feraligatr, usa Encanto. Luego Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Feraligatr, usa Encanto. Luego Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si sale Arcanine, Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Arcanine, Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {

--- a/src/data/johto/lance/infernape.json
+++ b/src/data/johto/lance/infernape.json
@@ -2,6 +2,6 @@
   "id": "infernape",
   "name": "Infernape",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Gengar usa Otra Vez. Luego cambia a Chansey y después a Dragonite. Usa 🪨 Trampa Rocas 🪨 frente a Infernape. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Gengar usa Otra Vez. Luego cambia a Chansey y después a Dragonite. Usa 🪨 Trampa Rocas 🪨 frente a Infernape. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": []
 }

--- a/src/data/johto/lance/kangaskhan.json
+++ b/src/data/johto/lance/kangaskhan.json
@@ -2,6 +2,6 @@
   "id": "kangaskhan",
   "name": "Kangaskhan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": []
 }

--- a/src/data/johto/lance/kingdra.json
+++ b/src/data/johto/lance/kingdra.json
@@ -8,7 +8,7 @@
       "detail": "Si sale Scizor, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Mantén los PS de Volcarona por encima del 51%.",
       "variant": [
         {
-          "detail": "Si Volcarona queda fuera por un golpe crítico, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si Volcarona queda fuera por un golpe crítico, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/lance/lapras.json
+++ b/src/data/johto/lance/lapras.json
@@ -5,11 +5,11 @@
   "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si sale Tyranitar, cambia a Poliwrath para enfrentarlo. Luego cambia a Chansey, usa Amortiguador y espera a Metagross. Usa Teletransporte hacia Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Tyranitar, cambia a Poliwrath 🐸🥊 para enfrentarlo. Luego cambia a Chansey, usa Amortiguador y espera a Metagross. Usa Teletransporte hacia Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si sale Scizor, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Scizor, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/lucario.json
+++ b/src/data/johto/lance/lucario.json
@@ -5,15 +5,15 @@
   "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Si usa A Bocajarro, Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Flygon. Después cambia a Chansey y usa Trampa Rocas. Luego Slowbro usa Bostezo y continúas con Politoed y Poliwrath para Tambor hasta +6 Ataque.",
+      "detail": "Si usa A Bocajarro, Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo frente a Flygon. Después cambia a Chansey y usa Trampa Rocas. Luego Slowbro usa Bostezo y continúas con Politoed y Poliwrath 🐸🥊 para Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si sale Infernape, cambia a Slowbro y usa Bostezo. Luego continúa con Politoed y Poliwrath para Tambor hasta +6 Ataque.",
+      "detail": "Si sale Infernape, cambia a Slowbro y usa Bostezo. Luego continúa con Politoed y Poliwrath 🐸🥊 para Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego continúa con Politoed y Poliwrath para Tambor hasta +6 Ataque.",
+      "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego continúa con Politoed y Poliwrath 🐸🥊 para Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/metagross.json
+++ b/src/data/johto/lance/metagross.json
@@ -8,11 +8,11 @@
       "detail": "Si usa Puño Meteoro, usa Teletransporte hacia Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Frente a Tyranitar, usa Bostezo con Slowbro. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Frente a Tyranitar, usa Bostezo con Slowbro. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si sale Ampharos, Scizor, Dragonite o Lapras, entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si sale Ampharos, Scizor, Dragonite o Lapras, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
@@ -22,11 +22,11 @@
       ]
     },
     {
-      "detail": "Si sale Scizor, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Scizor, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si sale Tyranitar, cambia a Poliwrath y usa Puño Drenaje. Luego cambia a Chansey, usa Amortiguador y espera a Metagross. Usa Teletransporte hacia Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Tyranitar, cambia a Poliwrath 🐸🥊 y usa Puño Drenaje. Luego cambia a Chansey, usa Amortiguador y espera a Metagross. Usa Teletransporte hacia Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/scizor.json
+++ b/src/data/johto/lance/scizor.json
@@ -8,17 +8,17 @@
       "detail": "Si el daño es cercano al 90%, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Mantén los PS por encima del 51%.",
       "variant": [
         {
-          "detail": "Si Volcarona queda fuera por un golpe crítico, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si Volcarona queda fuera por un golpe crítico, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Si el daño es cercano al 60%, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si el daño es cercano al 60%, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si ocurre golpe crítico antes de poner Trampa Rocas, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si ocurre golpe crítico antes de poner Trampa Rocas, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/scrafty.json
+++ b/src/data/johto/lance/scrafty.json
@@ -2,6 +2,6 @@
   "id": "scrafty",
   "name": "Scrafty",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Primeape. Luego Slowbro usa Bostezo frente a Electivire. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Primeape. Luego Slowbro usa Bostezo frente a Electivire. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": []
 }

--- a/src/data/johto/lance/steelix.json
+++ b/src/data/johto/lance/steelix.json
@@ -8,7 +8,7 @@
       "detail": "Si usa Terremoto, usa Encanto y Amortiguador. Espera a Scizor y usa Teletransporte para evaluar el daño.",
       "variant": [
         {
-          "detail": "Si el daño es cercano al 60%, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si el daño es cercano al 60%, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
@@ -22,7 +22,7 @@
       "variant": []
     },
     {
-      "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo. Después entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo frente a Flygon. Luego usa Protección y Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/lance/tyranitar.json
+++ b/src/data/johto/lance/tyranitar.json
@@ -2,6 +2,6 @@
   "id": "tyranitar",
   "name": "Tyranitar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego cambia a Poliwrath contra Tyranitar. Después cambia a Chansey y usa Amortiguador. Si los PS están bajos, usa Máx Poción. Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego cambia a Poliwrath 🐸🥊 contra Tyranitar. Después cambia a Chansey y usa Amortiguador. Si los PS están bajos, usa Máx Poción. Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": []
 }

--- a/src/data/johto/will/altaria.json
+++ b/src/data/johto/will/altaria.json
@@ -8,11 +8,11 @@
       "detail": "Si sale Stantler, cambia a Gengar y usa Otra Vez. Luego sale Alakazam.",
       "variant": [
         {
-          "detail": "Ruta estable: cambia a Chansey, usa Teletransporte hacia Slowbro y usa Bostezo. Usa Protección para dormir a Alakazam. Luego usa Bostezo frente a Roserade, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Ruta estable: cambia a Chansey, usa Teletransporte hacia Slowbro y usa Bostezo. Usa Protección para dormir a Alakazam. Luego usa Bostezo frente a Roserade, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Ruta RNG: entra con Slowbro, usa Bostezo y Protección. Cuando salga Roserade, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Ruta RNG: entra con Slowbro, usa Bostezo y Protección. Cuando salga Roserade, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
@@ -22,7 +22,7 @@
       "variant": []
     },
     {
-      "detail": "Si Lucario revela que es Zoroark por un movimiento de tipo Fuego, Gengar usa Otra Vez. Luego entra con Poliwrath para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
+      "detail": "Si Lucario revela que es Zoroark por un movimiento de tipo Fuego, Gengar usa Otra Vez. Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/bronzong.json
+++ b/src/data/johto/will/bronzong.json
@@ -13,11 +13,11 @@
       "variant": []
     },
     {
-      "detail": "Si Bronzong se queda, usa Bola Sombra frente a Absol. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Absol tiene Pañuelo Elegido.",
+      "detail": "Si Bronzong se queda, usa Bola Sombra frente a Absol. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Absol tiene Pañuelo Elegido.",
       "variant": []
     },
     {
-      "detail": "Si cambia a Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Bronzong.",
+      "detail": "Si cambia a Bronzong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Bronzong.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/claydol.json
+++ b/src/data/johto/will/claydol.json
@@ -2,6 +2,6 @@
   "id": "claydol",
   "name": "Claydol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 🔔 Si Claydol se queda, aguanta con Defensa Especial X y usa Amortiguador. Frente a Girafarig, Gengar usa Otra Vez. Cambia a Slowbro frente a Mantine, usa Bostezo frente a Magnezone, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. 🔔",
+  "initialMove": "🪨 Trampa Rocas 🪨. Si Claydol se queda, usa Defensa Especial X y Amortiguador. Frente a Girafarig, Gengar usa Otra Vez. Cambia a Slowbro frente a Mantine, usa Bostezo frente a Magnezone, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
   "tricks": []
 }

--- a/src/data/johto/will/empoleon.json
+++ b/src/data/johto/will/empoleon.json
@@ -8,11 +8,11 @@
       "detail": "Si Empoleon se queda, revisa qué ataque usa.",
       "variant": [
         {
-          "detail": "Si usa Surf, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si usa Surf, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si usa Hidrobomba, usa Teletransporte hacia Slowbro, usa Bostezo y luego Protección. Cuando salga Clefable, usa Bostezo, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque. Usa Cascada contra Hypno.",
+          "detail": "Si usa Hidrobomba, usa Teletransporte hacia Slowbro, usa Bostezo y luego Protección. Cuando salga Clefable, usa Bostezo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Hypno.",
           "variant": []
         }
       ]
@@ -29,11 +29,11 @@
       "detail": "Si sale Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si Flareon se queda, enfréntalo. Si luego sale Absol, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si sale Bronzong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/will/exeggutor.json
+++ b/src/data/johto/will/exeggutor.json
@@ -12,11 +12,11 @@
       "detail": "Si sale Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si Flareon se queda, enfréntalo. Si luego sale Absol, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si sale Bronzong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/johto/will/flareon.json
+++ b/src/data/johto/will/flareon.json
@@ -9,7 +9,7 @@
       "variant": []
     },
     {
-      "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Bronzong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/girafarig.json
+++ b/src/data/johto/will/girafarig.json
@@ -5,7 +5,7 @@
   "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Cambia a Gengar y usa Otra Vez. Luego cambia a Slowbro y usa Bostezo. Cuando salga Mantine, usa Bostezo; cuando salga Magnezone, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Cambia a Gengar y usa Otra Vez. Luego cambia a Slowbro y usa Bostezo. Cuando salga Mantine, usa Bostezo; cuando salga Magnezone, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]


### PR DESCRIPTION
## Summary
- Cleaned remaining Johto strategy wording issues after the trainer/champion normalization pass.
- Restored standard Poliwrath emoji markers in setup routes.
- Replaced leftover sacrifice wording with clearer pivot instructions.
- Cleaned a few compact notes and arrow-style route text.

## Scope
- Johto strategy JSON text only.
- No asset changes.
- No frontend changes.
- Preserved compact JSON structure and existing route logic.

## Areas reviewed
- Will
- Bruno
- Koga
- Karen
- Lance