### PR TITLE
Release Johto initial move structure fix

### DIFF
--- a/src/data/johto/bruno/golem.json
+++ b/src/data/johto/bruno/golem.json
@@ -2,8 +2,12 @@
   "id": "golem",
   "name": "Golem",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "❤️ Encanto y Trampa Rocas 🪨",
+  "initialMove": "❤️ Encanto ❤️",
   "tricks": [
+    {
+      "detail": "Luego usa 🪨 Trampa Rocas 🪨.",
+      "variant": []
+    },
     {
       "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []

--- a/src/data/johto/bruno/hitmonchan.json
+++ b/src/data/johto/bruno/hitmonchan.json
@@ -2,11 +2,16 @@
   "id": "hitmonchan",
   "name": "Hitmonchan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro y usa Bostezo.",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Si sale Metagross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-      "variant": []
+      "detail": "Usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Metagross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/absol.json
+++ b/src/data/johto/karen/absol.json
@@ -2,6 +2,11 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Volcarona usa Danza Aleteo x1 y Ataque Especial X. Usa Gigadrenado contra Absol.",
-  "tricks": []
+  "initialMove": "Volcarona usa Danza Aleteo x1.",
+  "tricks": [
+    {
+      "detail": "Luego usa Ataque Especial X. Usa Gigadrenado contra Absol.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/karen/blastoise.json
+++ b/src/data/johto/karen/blastoise.json
@@ -2,6 +2,11 @@
   "id": "blastoise",
   "name": "Blastoise",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Absol. Luego entra con Volcarona, usa Danza Aleteo x2 y Gigadrenado contra Absol. Frente a Houndoom no hay amenaza.",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Absol.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Volcarona, usa Danza Aleteo x2 y Gigadrenado contra Absol. Frente a Houndoom no hay amenaza.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/karen/electrode.json
+++ b/src/data/johto/karen/electrode.json
@@ -2,11 +2,16 @@
   "id": "electrode",
   "name": "Electrode",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego usa Teletransporte hacia Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si Slowbro queda paralizado y no puede usar Bostezo, cambia a Chansey, recupera vida y repite la secuencia.",
-      "variant": []
+      "detail": "Luego usa Teletransporte hacia Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": [
+        {
+          "detail": "Si Slowbro queda paralizado y no puede usar Bostezo, cambia a Chansey, recupera vida y repite la secuencia.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/flareon.json
+++ b/src/data/johto/karen/flareon.json
@@ -2,11 +2,16 @@
   "id": "flareon",
   "name": "Flareon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+  "initialMove": "Gengar usa Otra Vez.",
   "tricks": [
     {
-      "detail": "Si un golpe crítico de Typhlosion deja fuera a Poliwrath 🐸🥊, entra con Gengar, usa Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
-      "variant": []
+      "detail": "Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": [
+        {
+          "detail": "Si un golpe crítico de Typhlosion deja fuera a Poliwrath 🐸🥊, entra con Gengar, usa Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/gallade.json
+++ b/src/data/johto/karen/gallade.json
@@ -2,6 +2,11 @@
   "id": "gallade",
   "name": "Gallade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻 Gengar usa Otra Vez. Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Cura la quemadura si corresponde.",
-  "tricks": []
+  "initialMove": "👻 Gengar usa Otra Vez.",
+  "tricks": [
+    {
+      "detail": "Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Cura la quemadura si corresponde.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/karen/garchomp.json
+++ b/src/data/johto/karen/garchomp.json
@@ -2,6 +2,11 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Luego Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/karen/gengar.json
+++ b/src/data/johto/karen/gengar.json
@@ -2,6 +2,11 @@
   "id": "gengar",
   "name": "Gengar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Absol. Luego entra con Volcarona, usa Danza Aleteo x2.",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Absol.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Volcarona y usa Danza Aleteo x2.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/karen/honchkrow.json
+++ b/src/data/johto/karen/honchkrow.json
@@ -2,6 +2,11 @@
   "id": "honchkrow",
   "name": "Honchkrow",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro y usa Bostezo frente a Houndoom. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Cura la quemadura si corresponde.",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo frente a Houndoom. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Cura la quemadura si corresponde.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/karen/hydreigon.json
+++ b/src/data/johto/karen/hydreigon.json
@@ -2,6 +2,11 @@
   "id": "hydreigon",
   "name": "Hydreigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Chansey usa Amortiguador frente a Primeape. Luego cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
-  "tricks": []
+  "initialMove": "Chansey usa Amortiguador frente a Primeape.",
+  "tricks": [
+    {
+      "detail": "Luego cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/karen/luxray.json
+++ b/src/data/johto/karen/luxray.json
@@ -2,6 +2,11 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Chansey usa Amortiguador. Luego usa 🪨 Trampa Rocas 🪨 frente a un tipo Lucha. Slowbro usa Bostezo, luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-  "tricks": []
+  "initialMove": "Chansey usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Luego usa 🪨 Trampa Rocas 🪨 frente a un tipo Lucha. Slowbro usa Bostezo, luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/karen/mismagius.json
+++ b/src/data/johto/karen/mismagius.json
@@ -8,24 +8,24 @@
       "detail": "Si Mismagius se queda, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Si se mantiene en campo, entra con Volcarona y usa Gigadrenado. Luego cambia a Chansey, usa Teletransporte hacia Slowbro y usa Bostezo. Después deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si se mantiene en campo, entra con Volcarona y usa Gigadrenado. Luego cambia a Chansey, usa Teletransporte hacia Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo. Luego deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si sale Houndoom, deja caer a Politoed. Luego entra con Poliwrath, usa Ataque X y ataca.",
+          "detail": "Si sale Houndoom, entra Politoed como pivote. Luego entra con Poliwrath 🐸🥊, usa Ataque X y ataca.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo. Luego deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": [
         {
-          "detail": "Si sale Houndoom, deja caer a Politoed. Luego entra con Poliwrath, usa Ataque X y ataca.",
+          "detail": "Si sale Houndoom, entra Politoed como pivote. Luego entra con Poliwrath 🐸🥊, usa Ataque X y ataca.",
           "variant": []
         }
       ]
@@ -44,7 +44,7 @@
       ]
     },
     {
-      "detail": "Si sale Primeape, cambia a Slowbro y usa Bostezo. Luego deja caer a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Primeape, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/primeape.json
+++ b/src/data/johto/karen/primeape.json
@@ -2,6 +2,11 @@
   "id": "primeape",
   "name": "Primeape",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻 Gengar usa Otra Vez. Luego usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Primeape tiene Banda Focus.",
-  "tricks": []
+  "initialMove": "👻 Gengar usa Otra Vez.",
+  "tricks": [
+    {
+      "detail": "Luego usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Primeape tiene Banda Focus.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/karen/rhyperior.json
+++ b/src/data/johto/karen/rhyperior.json
@@ -22,11 +22,11 @@
       ]
     },
     {
-      "detail": "Si sale Honchkrow, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Honchkrow, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Si sale Gallade o Roserade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Gallade o Roserade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/sableye.json
+++ b/src/data/johto/karen/sableye.json
@@ -2,8 +2,12 @@
   "id": "sableye",
   "name": "Sableye",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Si Sableye se queda, usa Amortiguador.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
+    {
+      "detail": "Si Sableye se queda, usa Amortiguador.",
+      "variant": []
+    },
     {
       "detail": "Si sale Leafeon, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
       "variant": []

--- a/src/data/johto/karen/salamence.json
+++ b/src/data/johto/karen/salamence.json
@@ -2,11 +2,16 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Absol. Luego entra con Volcarona y usa Danza Aleteo x2.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Absol.",
   "tricks": [
     {
-      "detail": "Usa Danza Aleteo una vez y ataca hasta llegar a Houndoom. Luego usa otra Danza Aleteo (total +2) y termina de barrer.",
-      "variant": []
+      "detail": "Luego entra con Volcarona y usa Danza Aleteo x2.",
+      "variant": [
+        {
+          "detail": "Usa Danza Aleteo una vez y ataca hasta llegar a Houndoom. Luego usa otra Danza Aleteo (total +2) y termina de barrer.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/karen/slowbro.json
+++ b/src/data/johto/karen/slowbro.json
@@ -12,7 +12,7 @@
       "detail": "Si sale Excadrill, revisa su objeto.",
       "variant": [
         {
-          "detail": "Si tiene Globo Helio, usa Encanto y Amortiguador frente a Tyranitar. Luego cambia a Poliwrath para derrotar a Tyranitar.",
+          "detail": "Si tiene Globo Helio, usa Encanto y Amortiguador frente a Tyranitar. Luego cambia a Poliwrath 🐸🥊 para derrotar a Tyranitar.",
           "variant": []
         },
         {
@@ -31,7 +31,7 @@
       ]
     },
     {
-      "detail": "Si sale Tyranitar, entra con Poliwrath para derrotarlo.",
+      "detail": "Si sale Tyranitar, entra con Poliwrath 🐸🥊 para derrotarlo.",
       "variant": [
         {
           "detail": "Si después sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Usa Psíquico contra Gyarados y sigue hasta Houndoom.",

--- a/src/data/johto/karen/tyranitar.json
+++ b/src/data/johto/karen/tyranitar.json
@@ -2,28 +2,33 @@
   "id": "tyranitar",
   "name": "Tyranitar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨 y luego cambia a Poliwrath para derrotar a Tyranitar.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si después sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Usa Psíquico contra Gyarados, sigue hasta Houndoom e ignora la amenaza.",
-      "variant": []
-    },
-    {
-      "detail": "Si sale Victreebel, cambia a Gengar y luego a Slowbro.",
+      "detail": "Luego cambia a Poliwrath 🐸🥊 para derrotar a Tyranitar.",
       "variant": [
         {
-          "detail": "Si Victreebel se queda, usa Bostezo. Luego entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
+          "detail": "Si después sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Usa Psíquico contra Gyarados, sigue hasta Houndoom e ignora la amenaza.",
           "variant": []
         },
         {
-          "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
+          "detail": "Si sale Victreebel, cambia a Gengar y luego a Slowbro.",
+          "variant": [
+            {
+              "detail": "Si Victreebel se queda, usa Bostezo. Luego entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Si sale Excadrill, usa Gigadrenado hasta derrotarlo.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/karen/umbreon.json
+++ b/src/data/johto/karen/umbreon.json
@@ -2,13 +2,17 @@
   "id": "umbreon",
   "name": "Umbreon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Si Umbreon usa Juego Sucio y se queda, usa Amortiguador.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo. Luego sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si Umbreon usa Juego Sucio y se queda, usa Amortiguador.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": [
         {
-          "detail": "Si entra Houndoom, sacrifica a Politoed, entra con Poliwrath, usa Ataque X y barre.",
+          "detail": "Si entra Houndoom, entra Politoed como pivote, entra con Poliwrath 🐸🥊, usa Ataque X y barre.",
           "variant": []
         }
       ]

--- a/src/data/johto/karen/victreebel.json
+++ b/src/data/johto/karen/victreebel.json
@@ -2,14 +2,18 @@
   "id": "victreebel",
   "name": "Victreebel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Si Victreebel se queda, usa Amortiguador.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si sale Excadrill, usa Encanto. Luego usa Amortiguador frente a Tyranitar y cambia a Poliwrath.",
+      "detail": "Si Victreebel se queda, usa Amortiguador.",
       "variant": []
     },
     {
-      "detail": "Si sale Tyranitar, cambia a Poliwrath.",
+      "detail": "Si sale Excadrill, usa Encanto. Luego usa Amortiguador frente a Tyranitar y cambia a Poliwrath 🐸🥊.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Tyranitar, cambia a Poliwrath 🐸🥊.",
       "variant": [
         {
           "detail": "Si después sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Usa Psíquico contra Gyarados y sigue hasta Houndoom.",

--- a/src/data/johto/karen/vileplume.json
+++ b/src/data/johto/karen/vileplume.json
@@ -5,7 +5,7 @@
   "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si sale Honchkrow, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Honchkrow, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
@@ -18,7 +18,7 @@
       ]
     },
     {
-      "detail": "Si sale Gallade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, entra Politoed como pivote y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si sale Gallade, Gengar usa Otra Vez. Luego Slowbro usa Bostezo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/karen/weavile.json
+++ b/src/data/johto/karen/weavile.json
@@ -2,11 +2,16 @@
   "id": "weavile",
   "name": "Weavile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa Amortiguador para recibir el golpe inicial. Luego usa 🪨 Trampa Rocas 🪨 frente a Excadrill. Después usa Teletransporte hacia Slowbro y usa Bostezo.",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Si Weavile se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y ataca hasta Houndoom. Luego usa otra Danza Aleteo y termina de barrer.",
-      "variant": []
+      "detail": "Recibe el golpe inicial. Luego usa 🪨 Trampa Rocas 🪨 frente a Excadrill. Después usa Teletransporte hacia Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Weavile se queda, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y ataca hasta Houndoom. Luego usa otra Danza Aleteo y termina de barrer.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/koga/ariados.json
+++ b/src/data/johto/koga/ariados.json
@@ -2,8 +2,12 @@
   "id": "ariados",
   "name": "Ariados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Si no cambia, usa Amortiguador y revisa si fuerza el cambio.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
+    {
+      "detail": "Si no cambia, usa Amortiguador y revisa si fuerza el cambio.",
+      "variant": []
+    },
     {
       "detail": "Si sale Tangrowth, usa Teletransporte hacia Slowbro y Bostezo. Revisa si Tangrowth acierta el ataque.",
       "variant": [

--- a/src/data/johto/lance/arbok.json
+++ b/src/data/johto/lance/arbok.json
@@ -2,6 +2,11 @@
   "id": "arbok",
   "name": "Arbok",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro y usa Bostezo frente a Eelektross. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo frente a Eelektross. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/lance/arcanine.json
+++ b/src/data/johto/lance/arcanine.json
@@ -2,8 +2,12 @@
   "id": "arcanine",
   "name": "Arcanine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻 Gengar usa Otra Vez. Luego cambia a Chansey y después a Dragonite. Usa 🪨 Trampa Rocas 🪨.",
+  "initialMove": "👻 Gengar usa Otra Vez.",
   "tricks": [
+    {
+      "detail": "Luego cambia a Chansey y después a Dragonite. Usa 🪨 Trampa Rocas 🪨.",
+      "variant": []
+    },
     {
       "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []

--- a/src/data/johto/lance/charizard.json
+++ b/src/data/johto/lance/charizard.json
@@ -2,11 +2,16 @@
   "id": "charizard",
   "name": "Charizard",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Tyranitar. Luego cambia a Poliwrath 🐸🥊 para derrotarlo.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Tyranitar.",
   "tricks": [
     {
-      "detail": "Después entra con Chansey y usa Amortiguador. Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-      "variant": []
+      "detail": "Luego cambia a Poliwrath 🐸🥊 para derrotarlo.",
+      "variant": [
+        {
+          "detail": "Después entra con Chansey y usa Amortiguador. Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/lance/eelektross.json
+++ b/src/data/johto/lance/eelektross.json
@@ -2,6 +2,11 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego usa Teletransporte o entra Politoed como pivote. Entra con Gengar frente a Dragonite, usa Maquinación y barre con Bola Sombra.",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Luego usa Teletransporte o entra Politoed como pivote. Entra con Gengar frente a Dragonite, usa Maquinación y barre con Bola Sombra.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/lance/garchomp.json
+++ b/src/data/johto/lance/garchomp.json
@@ -2,6 +2,11 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro y usa Bostezo frente a Eelektross. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo frente a Eelektross. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/lance/gyarados.json
+++ b/src/data/johto/lance/gyarados.json
@@ -2,6 +2,11 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego usa Teletransporte hacia Slowbro y usa Bostezo. Después usa Teletransporte hacia Gengar, usa Maquinación y ataca.",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Luego usa Teletransporte hacia Slowbro y usa Bostezo. Después usa Teletransporte hacia Gengar, usa Maquinación y ataca.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/lance/haxorus.json
+++ b/src/data/johto/lance/haxorus.json
@@ -2,6 +2,11 @@
   "id": "haxorus",
   "name": "Haxorus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Gengar y usa Bola Sombra. Luego Slowbro usa Bostezo frente a Scizor. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-  "tricks": []
+  "initialMove": "Cambia a Gengar.",
+  "tricks": [
+    {
+      "detail": "Usa Bola Sombra. Luego Slowbro usa Bostezo frente a Scizor. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/lance/infernape.json
+++ b/src/data/johto/lance/infernape.json
@@ -2,6 +2,11 @@
   "id": "infernape",
   "name": "Infernape",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Gengar usa Otra Vez. Luego cambia a Chansey y después a Dragonite. Usa 🪨 Trampa Rocas 🪨 frente a Infernape. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-  "tricks": []
+  "initialMove": "Gengar usa Otra Vez.",
+  "tricks": [
+    {
+      "detail": "Luego cambia a Chansey y después a Dragonite. Usa 🪨 Trampa Rocas 🪨 frente a Infernape. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/lance/kangaskhan.json
+++ b/src/data/johto/lance/kangaskhan.json
@@ -2,6 +2,11 @@
   "id": "kangaskhan",
   "name": "Kangaskhan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/lance/scizor.json
+++ b/src/data/johto/lance/scizor.json
@@ -2,24 +2,29 @@
   "id": "scizor",
   "name": "Scizor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨 y evalúa el daño.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si el daño es cercano al 90%, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Mantén los PS por encima del 51%.",
+      "detail": "Evalúa el daño.",
       "variant": [
         {
-          "detail": "Si Volcarona queda fuera por un golpe crítico, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "detail": "Si el daño es cercano al 90%, usa Teletransporte hacia Volcarona, usa Danza Aleteo x1 y Ataque Especial X. Mantén los PS por encima del 51%.",
+          "variant": [
+            {
+              "detail": "Si Volcarona queda fuera por un golpe crítico, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si el daño es cercano al 60%, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si ocurre golpe crítico antes de poner Trampa Rocas, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
-    },
-    {
-      "detail": "Si el daño es cercano al 60%, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-      "variant": []
-    },
-    {
-      "detail": "Si ocurre golpe crítico antes de poner Trampa Rocas, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-      "variant": []
     }
   ]
 }

--- a/src/data/johto/lance/scrafty.json
+++ b/src/data/johto/lance/scrafty.json
@@ -2,6 +2,11 @@
   "id": "scrafty",
   "name": "Scrafty",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Primeape. Luego Slowbro usa Bostezo frente a Electivire. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Primeape.",
+  "tricks": [
+    {
+      "detail": "Luego Slowbro usa Bostezo frente a Electivire. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/lance/tyranitar.json
+++ b/src/data/johto/lance/tyranitar.json
@@ -2,6 +2,11 @@
   "id": "tyranitar",
   "name": "Tyranitar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa 🪨 Trampa Rocas 🪨. Luego cambia a Poliwrath 🐸🥊 contra Tyranitar. Después cambia a Chansey y usa Amortiguador. Si los PS están bajos, usa Máx Poción. Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Luego cambia a Poliwrath 🐸🥊 contra Tyranitar. Después cambia a Chansey y usa Amortiguador. Si los PS están bajos, usa Máx Poción. Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/will/absol.json
+++ b/src/data/johto/will/absol.json
@@ -2,6 +2,11 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻 Gengar usa Maquinación hasta +4 y Precisión X. No uses Otra Vez. 👻",
-  "tricks": []
+  "initialMove": "👻 Gengar usa Maquinación hasta +4.",
+  "tricks": [
+    {
+      "detail": "Usa Precisión X. No uses Otra Vez. 👻",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/will/claydol.json
+++ b/src/data/johto/will/claydol.json
@@ -2,6 +2,11 @@
   "id": "claydol",
   "name": "Claydol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨. Si Claydol se queda, usa Defensa Especial X y Amortiguador. Frente a Girafarig, Gengar usa Otra Vez. Cambia a Slowbro frente a Mantine, usa Bostezo frente a Magnezone, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-  "tricks": []
+  "initialMove": "🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Si Claydol se queda, usa Defensa Especial X y Amortiguador. Frente a Girafarig, Gengar usa Otra Vez. Cambia a Slowbro frente a Mantine, usa Bostezo frente a Magnezone, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/johto/will/flareon.json
+++ b/src/data/johto/will/flareon.json
@@ -2,15 +2,20 @@
   "id": "flareon",
   "name": "Flareon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Gengar y usa Maquinación hasta +2.",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Si Flareon se queda, Gengar usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X.",
-      "variant": []
-    },
-    {
-      "detail": "Si sale Bronzong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-      "variant": []
+      "detail": "Usa Maquinación hasta +2.",
+      "variant": [
+        {
+          "detail": "Si Flareon se queda, Gengar usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Bronzong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/hypno.json
+++ b/src/data/johto/will/hypno.json
@@ -2,10 +2,10 @@
   "id": "hypno",
   "name": "Hypno",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Sacrifica a Politoed.",
+  "initialMove": "Entra Politoed como pivote.",
   "tricks": [
     {
-      "detail": "Entra con Poliwrath, usa Tambor hasta +6 Ataque y usa Cascada contra Hypno.",
+      "detail": "Entra con Poliwrath 🐸🥊, usa Tambor hasta +6 Ataque y usa Cascada contra Hypno.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/lucario.json
+++ b/src/data/johto/will/lucario.json
@@ -11,7 +11,7 @@
           "detail": "Si tiene Vidasfera y colocaste Trampa Rocas, usa Teletransporte.",
           "variant": [
             {
-              "detail": "Si usa Triturar o Puño Bala, pasa por Poliwrath y luego entra con Gengar. Usa Otra Vez, Maquinación hasta +4 y Precisión X.",
+              "detail": "Si usa Triturar o Puño Bala, pasa por Poliwrath 🐸🥊 y luego entra con Gengar. Usa Otra Vez, Maquinación hasta +4 y Precisión X.",
               "variant": []
             },
             {

--- a/src/data/johto/will/mantine.json
+++ b/src/data/johto/will/mantine.json
@@ -2,10 +2,14 @@
   "id": "mantine",
   "name": "Mantine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨; si Mantine se queda, usa Amortiguador 🥚",
+  "initialMove": "🪨 Trampa Rocas 🪨",
   "tricks": [
     {
-      "detail": "Si sale Girafarig, Gengar usa Otra Vez. Luego cambia a Slowbro frente a Mantine, usa Bostezo frente a Magnezone, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+      "detail": "Si Mantine se queda, usa Amortiguador 🥚.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Girafarig, Gengar usa Otra Vez. Luego cambia a Slowbro frente a Mantine, usa Bostezo frente a Magnezone, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/johto/will/xatu.json
+++ b/src/data/johto/will/xatu.json
@@ -12,7 +12,7 @@
           "variant": []
         },
         {
-          "detail": "Si no tiene Llamasfera, cambia a Slowbro y usa Bostezo. Cuando salga Magnezone, usa Protección y cambia a Chansey. Cuando salga Girafarig, coloca Trampa Rocas. Luego Gengar usa Otra Vez; cambia a Slowbro frente a Mantine y usa Bostezo. Cuando vuelva Girafarig, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si no tiene Llamasfera, cambia a Slowbro y usa Bostezo. Cuando salga Magnezone, usa Protección y cambia a Chansey. Cuando salga Girafarig, coloca Trampa Rocas. Luego Gengar usa Otra Vez; cambia a Slowbro frente a Mantine y usa Bostezo. Cuando vuelva Girafarig, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
@@ -21,11 +21,11 @@
       "detail": "Si sale Flareon, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si Flareon se queda, derrótalo. Si luego sale Absol, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Si sale Bronzong, sacrifica a Politoed y entra con Poliwrath para usar Tambor hasta +6 Ataque.",
+          "detail": "Si sale Bronzong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
@@ -50,7 +50,7 @@
           "variant": []
         },
         {
-          "detail": "Si revela que es Zoroark por un movimiento de tipo Fuego, Gengar usa Otra Vez y luego entra con Poliwrath para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
+          "detail": "Si revela que es Zoroark por un movimiento de tipo Fuego, Gengar usa Otra Vez y luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
           "variant": []
         }
       ]

--- a/src/utils/johtoStrategyTranslations.ts
+++ b/src/utils/johtoStrategyTranslations.ts
@@ -6,7 +6,15 @@ const exactTranslations: Record<string, string> = {
   '💡 Revisa la habilidad 💡': '💡 Check the ability 💡',
   'Cambia a Volcarona.': 'Switch to Volcarona.',
   'Cambia a Gengar.': 'Switch to Gengar.',
-  'Cambia a Slowbro y usa Bostezo.': 'Switch to Slowbro and use Yawn.',
+  'Cambia a Slowbro.': 'Switch to Slowbro.',
+  'Gengar usa Otra Vez.': 'Gengar uses Encore.',
+  '👻 Gengar usa Otra Vez.': '👻 Gengar uses Encore.',
+  'Chansey usa Amortiguador.': 'Chansey uses Soft-Boiled.',
+  'Volcarona usa Danza Aleteo x1.': 'Volcarona uses Quiver Dance x1.',
+  'Usa Amortiguador.': 'Use Soft-Boiled.',
+  'Usa Bostezo.': 'Use Yawn.',
+  'Usa Maquinación hasta +2.': 'Use Nasty Plot to +2.',
+  'Evalúa el daño.': 'Evaluate the damage.',
 }
 
 const moveTranslations: Array<[RegExp, string]> = [
@@ -167,6 +175,7 @@ const phraseTranslations: Array<[RegExp, string]> = [
 
 const normalizeEnglishText = (text: string) => {
   return text
+    .replace(/\b(Gengar|Chansey|Slowbro|Volcarona|Poliwrath|Umbreon|Mismagius|Victreebel|Excadrill|Rhyperior|Dragonite|Ninetales|Crobat|Scizor|Feraligatr) use\b/g, '$1 uses')
     .replace(/Use Belly Drum to \+6 Attack/g, 'Use Belly Drum to reach +6 Attack')
     .replace(/use Belly Drum to \+6 Attack/g, 'use Belly Drum to reach +6 Attack')
     .replace(/to use Belly Drum to \+6 Attack/g, 'to use Belly Drum and reach +6 Attack')


### PR DESCRIPTION
## Summary
- Releases the Johto initialMove structure fix from `develop` to `main`.
- Keeps `initialMove` as the opening action only.
- Publishes follow-up route logic through `tricks` and `variant` so Johto expands correctly in the UI.
- Includes the Johto English translation helper adjustment for the newly split route text.

## Scope
- Release PR from `develop` to `main`.
- Johto strategy JSON structure fixes.
- Johto translation utility adjustment.

## Notes
- Intended to update GitHub Pages so Johto can be reviewed live with the corrected structure.