### PR TITLE
Release Johto Will opening fixes

### DIFF
--- a/src/data/johto/will/absol.json
+++ b/src/data/johto/will/absol.json
@@ -2,8 +2,12 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻 Gengar usa Maquinación hasta +4.",
+  "initialMove": "Cambia a Gengar 👻.",
   "tricks": [
+    {
+      "detail": "Usa Maquinación hasta +4.",
+      "variant": []
+    },
     {
       "detail": "Usa Precisión X. No uses Otra Vez. 👻",
       "variant": []

--- a/src/data/johto/will/espeon.json
+++ b/src/data/johto/will/espeon.json
@@ -2,15 +2,20 @@
   "id": "espeon",
   "name": "Espeon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Slowbro usa Bostezo para presionar el cambio.",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Cambia a Chansey y coloca Trampa Rocas. Cuando salga Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
-      "variant": []
-    },
-    {
-      "detail": "Si no cambia mientras colocas Trampa Rocas, usa Amortiguador hasta forzar el cambio y sigue la ruta anterior.",
-      "variant": []
+      "detail": "Usa Bostezo para presionar el cambio.",
+      "variant": [
+        {
+          "detail": "Cambia a Chansey y coloca Trampa Rocas. Cuando salga Lucario, cambia a Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si no cambia mientras colocas Trampa Rocas, usa Amortiguador hasta forzar el cambio y sigue la ruta anterior.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/johto/will/golurk.json
+++ b/src/data/johto/will/golurk.json
@@ -2,15 +2,20 @@
   "id": "golurk",
   "name": "Golurk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 → Revisa el porcentaje de daño",
+  "initialMove": "🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si hace alrededor de 50% de daño, toma una Max Poción si fue crítico. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
-      "variant": []
-    },
-    {
-      "detail": "Si hace alrededor de 35% de daño, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
-      "variant": []
+      "detail": "Revisa el porcentaje de daño.",
+      "variant": [
+        {
+          "detail": "Si hace alrededor de 50% de daño, toma una Max Poción si fue crítico. Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": []
+        },
+        {
+          "detail": "Si hace alrededor de 35% de daño, cambia a Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/utils/johtoStrategyTranslations.ts
+++ b/src/utils/johtoStrategyTranslations.ts
@@ -6,6 +6,7 @@ const exactTranslations: Record<string, string> = {
   '💡 Revisa la habilidad 💡': '💡 Check the ability 💡',
   'Cambia a Volcarona.': 'Switch to Volcarona.',
   'Cambia a Gengar.': 'Switch to Gengar.',
+  'Cambia a Gengar 👻.': 'Switch to Gengar 👻.',
   'Cambia a Slowbro.': 'Switch to Slowbro.',
   'Gengar usa Otra Vez.': 'Gengar uses Encore.',
   '👻 Gengar usa Otra Vez.': '👻 Gengar uses Encore.',
@@ -13,7 +14,10 @@ const exactTranslations: Record<string, string> = {
   'Volcarona usa Danza Aleteo x1.': 'Volcarona uses Quiver Dance x1.',
   'Usa Amortiguador.': 'Use Soft-Boiled.',
   'Usa Bostezo.': 'Use Yawn.',
+  'Usa Bostezo para presionar el cambio.': 'Use Yawn to pressure the switch.',
   'Usa Maquinación hasta +2.': 'Use Nasty Plot to +2.',
+  'Usa Maquinación hasta +4.': 'Use Nasty Plot to +4.',
+  'Revisa el porcentaje de daño.': 'Check the damage percentage.',
   'Evalúa el daño.': 'Evaluate the damage.',
 }
 


### PR DESCRIPTION
## Summary
- Releases the Johto Will opening fixes from `develop` to `main`.
- Publishes the structure updates for Absol, Golurk, and Espeon.
- Keeps opening moves short and follow-up route logic in tricks and variants.
- Includes the small Johto English translation helper updates.

## Scope
- Release PR from `develop` to `main`.
- Johto Will strategy JSON fixes.
- Johto translation helper adjustment.

## Notes
- Intended to update GitHub Pages so Johto can be reviewed live with these corrections.