### PR TITLE
Fix Johto Lance nested route details

### DIFF
--- a/src/data/johto/lance/charizard.json
+++ b/src/data/johto/lance/charizard.json
@@ -6,14 +6,15 @@
   "tricks": [
     {
       "detail": "Frente a Tyranitar.",
-      "variant": []
-    },
-    {
-      "detail": "Luego cambia a Poliwrath 🐸🥊 para derrotarlo.",
       "variant": [
         {
-          "detail": "Después entra con Chansey y usa Amortiguador. Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-          "variant": []
+          "detail": "Luego cambia a Poliwrath 🐸🥊 para derrotarlo.",
+          "variant": [
+            {
+              "detail": "Después entra con Chansey y usa Amortiguador. Espera a Metagross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/johto/lance/infernape.json
+++ b/src/data/johto/lance/infernape.json
@@ -6,11 +6,12 @@
   "tricks": [
     {
       "detail": "Usa Otra Vez.",
-      "variant": []
-    },
-    {
-      "detail": "Luego cambia a Chansey y después a Dragonite. Usa 🪨 Trampa Rocas 🪨 frente a Infernape. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-      "variant": []
+      "variant": [
+        {
+          "detail": "Luego cambia a Chansey y después a Dragonite. Usa 🪨 Trampa Rocas 🪨 frente a Infernape. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adjusts Johto Lance Charizard and Infernape route nesting.
- Keeps `initialMove` as the opening action only.
- Makes context lines like `Frente a Tyranitar.` and `Usa Otra Vez.` expandable by moving their follow-up steps into `variant`.

## Scope
- Johto Lance strategy JSON only.
- No translation changes.
- No asset changes.
- No frontend layout changes.

## Notes
- This follows the updated route structure pattern where immediate follow-up actions live under the contextual detail that should expand in the UI.