### PR TITLE
Release Hoenn Spanish structure preview

### DIFF
--- a/src/data/hoenn/fatima/arcanine.json
+++ b/src/data/hoenn/fatima/arcanine.json
@@ -2,6 +2,16 @@
   "id": "arcanine",
   "name": "Arcanine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Cambiar a Slowbro Bostezo ➜ frente a Raichu ➜ sacrificar a Politoed ➜ Poliwrath +6🐸🥊 💡",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Raichu, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/fatima/banette.json
+++ b/src/data/hoenn/fatima/banette.json
@@ -2,6 +2,16 @@
   "id": "banette",
   "name": "Banette",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 frente a Honchkrow ➜ sacrificar a Politoed ➜ 🐸Poliwrath🐸 cuando entre Hydreigon ➜ usar Ataque X  y completar (puño hielo para eliminar a Honchkrow)",
-  "tricks": []
-}   
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Honchkrow.",
+      "variant": [
+        {
+          "detail": "Entra Politoed como pivote. Cuando entre Hydreigon, entra con Poliwrath 🐸🥊, usa Ataque X y completa la ruta. Usa Puño Hielo para eliminar a Honchkrow.",
+          "variant": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/hoenn/sixto/absol.json
+++ b/src/data/hoenn/sixto/absol.json
@@ -2,28 +2,33 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambiar a Slowbro💡",
+  "initialMove": "💡 Cambia a Slowbro 💡",
   "tricks": [
     {
-      "detail": "Vidasfera --> Usar Bostezo",
+      "detail": "Si Absol tiene Vidasfera, usa Bostezo.",
       "variant": [
         {
-          "detail": "Tajo Umbrío --> 💕Cambiar a Chansey y usar Encanto frente a Garchomp💕; poner 🪨Trampa Rocas🪨, cambiar a Slowbro y usar Bostezo frente a Magnezone; sacrificar a Politoed, entra Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Electivire --> Sacrificar a Politoed, entra Poliwrath +6 🔔(Puño Drenaje a Electivire/Toxicroak)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Gyarados --> Cambiar a Chansey y usar 🪨Trampa Rocas🪨",
+          "detail": "Si usa Tajo Umbrío, cambia a Chansey y usa Encanto frente a Garchomp. Luego coloca 🪨 Trampa Rocas 🪨, cambia a Slowbro y usa Bostezo frente a Magnezone.",
           "variant": [
             {
-              "detail": "Absol --> Gengar Otra Vez +2 🔔(Barre con Bola Sombra)🔔",
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Electivire, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Electivire o Toxicroak.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gyarados, cambia a Chansey y usa 🪨 Trampa Rocas 🪨.",
+          "variant": [
+            {
+              "detail": "Si sale Absol, entra con Gengar, usa Otra Vez, Maquinación hasta +2 y barre con Bola Sombra.",
               "variant": []
             },
             {
-              "detail": "Luxray --> Gengar Otra Vez +4 🔔(Barre con Bola Sombra)🔔",
+              "detail": "Si sale Luxray, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y barre con Bola Sombra.",
               "variant": []
             }
           ]
@@ -31,78 +36,78 @@
       ]
     },
     {
-      "detail": "Sin Vidasfera --> Usar Teletransporte",
+      "detail": "Si Absol no tiene Vidasfera, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Tajo Umbrío --> Chansey usa Trampa Rocas 🔔(Si el Golpe es Critico usar Max Pocion y luego cambiar a Gengar)🔔",
+          "detail": "Si usa Tajo Umbrío, Chansey usa 🪨 Trampa Rocas 🪨. Si el golpe es crítico, usa Max Poción y luego cambia a Gengar.",
           "variant": [
             {
-              "detail": "Recibir A Bocajarro --> Gengar Otra Vez +2 + Precisión X 💰(Si quieres Ahorrar: Gengar +6)💰",
+              "detail": "Si recibes A Bocajarro, Gengar usa Otra Vez, Maquinación hasta +2 y Precisión X. Ruta de ahorro: Gengar usa Maquinación hasta +6.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Persecución --> Enviar a Chansey, cambiar a Gengar, usar Otra Vez + Bola Sombra; cambiar a Slowbro y usar Bostezo.",
+          "detail": "Si usa Persecución, envía a Chansey, cambia a Gengar, usa Otra Vez y Bola Sombra. Luego cambia a Slowbro y usa Bostezo.",
           "variant": [
             {
-              "detail": "Si se queda --> Usar Protección y Bostezo frente a Huntail/Excadrill; sacrificar a Politoed; entrar con Poliwrath +6",
+              "detail": "Si Absol se queda, usa Protección y Bostezo frente a Huntail o Excadrill. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             },
             {
-              "detail": "Huntail --> Sacrificar a Politoed; entrar con Poliwrath +6",
+              "detail": "Si sale Huntail, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Luxray --> Enviar a Chansey y usar Amortiguador.",
+          "detail": "Si sale Luxray, envía a Chansey y usa Amortiguador.",
           "variant": [
             {
-              "detail": "Absol --> Gengar +4 + Precisión X 🔔(No usar Otra Vez)🔔",
+              "detail": "Si sale Absol, entra con Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
               "variant": []
             },
             {
-              "detail": "Scizor --> Volcarona +2 + Ataque Especial X 🔔(Gigadrenado a Luxray)🔔",
+              "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Magnezone --> Enviar a Chansey y usar 🪨Trampa Rocas🪨",
+          "detail": "Si sale Magnezone, envía a Chansey y usa 🪨 Trampa Rocas 🪨.",
           "variant": [
             {
-              "detail": "Darmanitan --> Gengar +2 + Precisión X 🔔(No usar Otra Vez)🔔; 💰(Si quieres Ahorrar: Gengar +6)💰",
+              "detail": "Si sale Darmanitan, entra con Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Ruta de ahorro: Gengar usa Maquinación hasta +6.",
               "variant": []
             },
             {
-              "detail": "Absol --> Gengar usa Otra Vez, 2+2 + Precisión X 💰(Si quieres Ahorrar: Gengar 6+2)💰",
+              "detail": "Si sale Absol, Gengar usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Ruta de ahorro: Gengar usa Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Salamence (Intimidación) --> Enviar a Chansey y usar Amortiguador.",
+          "detail": "Si sale Salamence con Intimidación, envía a Chansey y usa Amortiguador.",
           "variant": [
             {
-              "detail": "Absol --> Gengar +4 + Precisión X 🔔(No usar Otra Vez)🔔",
+              "detail": "Si sale Absol, entra con Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
               "variant": []
             },
             {
-              "detail": "Scizor --> Volcarona +2 + Ataque Especial X 🔔(Gigadrenado a Luxray)🔔",
+              "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Salamence (sin Intimidación) --> Enviar a Chansey; sacrificar a Politoed; Poliwrath usa Puño Hielo.",
+          "detail": "Si sale Salamence sin Intimidación, envía a Chansey y entra Politoed como pivote. Luego entra con Poliwrath 🐸🥊 y usa Puño Hielo.",
           "variant": [
             {
-              "detail": "Shiftry --> Volcarona +2",
+              "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2.",
               "variant": []
             },
             {
-              "detail": "Hariyama --> Gengar Otra Vez 4+2 🔔(Barre con Bola Sombra)🔔",
+              "detail": "Si sale Hariyama, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
               "variant": []
             }
           ]

--- a/src/data/hoenn/sixto/aggron.json
+++ b/src/data/hoenn/sixto/aggron.json
@@ -2,14 +2,18 @@
   "id": "aggron",
   "name": "Aggron",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 TRAMPA ROCAS 🪨 Sacrificar a Politoed; Poliwrath absorbe y debilita",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Shiftry --> Volcarona +2  (Mantener HP por encima del 23%)",
+      "detail": "Entra Politoed como pivote. Luego entra con Poliwrath 🐸🥊 para absorber el golpe y debilitar a Aggron.",
       "variant": []
     },
     {
-      "detail": "Hariyama --> Recibir Ataque X; completar (Cascada  Hariyama)",
+      "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Mantén los PS por encima del 23%.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Hariyama, recibe el Ataque X y completa la ruta. Usa Cascada contra Hariyama.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/sixto/cacturne.json
+++ b/src/data/hoenn/sixto/cacturne.json
@@ -2,14 +2,14 @@
   "id": "cacturne",
   "name": "Cacturne",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Opciones para resolver",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Rápido --> Trampa Rocas; Gengar +2 +2 + Precisión; usar movimientos súper eficaces",
+      "detail": "Ruta rápida: usa 🪨 Trampa Rocas 🪨. Luego entra con Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Usa movimientos súper eficaces para cerrar.",
       "variant": []
     },
     {
-      "detail": "Ahorrar dinero --> Encanto + Amortiguador; Trampa Rocas frente a Darmanitan; Gengar +6 (No usar Otra Vez); Bola Sombra a todo",
+      "detail": "Ruta de ahorro: usa Encanto y Amortiguador. Luego coloca 🪨 Trampa Rocas 🪨 frente a Darmanitan. Entra con Gengar, usa Maquinación hasta +6 y barre con Bola Sombra. No uses Otra Vez.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/sixto/crawdaunt.json
+++ b/src/data/hoenn/sixto/crawdaunt.json
@@ -2,6 +2,16 @@
   "id": "crawdaunt",
   "name": "Crawdaunt",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨; Gengar +2 + Precisión (No usar Otra Vez); para ahorrar dinero: Gengar +6",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Entra con Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa movimientos súper eficaces para cerrar.",
+      "variant": [
+        {
+          "detail": "Ruta de ahorro: Gengar usa Maquinación hasta +6 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/sixto/darmanitan.json
+++ b/src/data/hoenn/sixto/darmanitan.json
@@ -2,14 +2,14 @@
   "id": "darmanitan",
   "name": "Darmanitan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Rápido --> Gengar +2 + Precisión (No usar Otra Vez); usar movimientos súper eficaces",
+      "detail": "Ruta rápida: entra con Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa movimientos súper eficaces para cerrar.",
       "variant": []
     },
     {
-      "detail": "Ahorrar dinero --> Gengar +6 (No usar Otra Vez); Bola Sombra a todo",
+      "detail": "Ruta de ahorro: entra con Gengar, usa Maquinación hasta +6 y barre con Bola Sombra. No uses Otra Vez.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/sixto/electivire.json
+++ b/src/data/hoenn/sixto/electivire.json
@@ -2,6 +2,16 @@
   "id": "electivire",
   "name": "Electivire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 TRAMPA ROCAS 🪨 Frente a Absol; Gengar +4 (Bola Sombra a todo)",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Absol.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/sixto/excadrill.json
+++ b/src/data/hoenn/sixto/excadrill.json
@@ -2,18 +2,23 @@
   "id": "excadrill",
   "name": "Excadrill",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa rocas 🪨.",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Mienshao ➜ entra con Gengar bola sombra a mienshao y frente a Mandibuzz / Spiritomb ➜ Volcarona x2 Danza aleteo 🔔gigadrenado para  Absol🔔",
+      "detail": "Si sale Mienshao, entra con Gengar y usa Bola Sombra contra Mienshao.",
+      "variant": [
+        {
+          "detail": "Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2. Usa Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Absol, entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Absol no tiene Banda Focus.",
       "variant": []
     },
     {
-      "detail": "Absol ➜ Gengar, otra vez +2 + Precisión X 🔔No tiene banda focus🔔",
-      "variant": []
-    },
-    {
-      "detail": "Luxray ➜ Amortiguador y espera tener en frente a Absol o Crawdaunt y entra con Gengar Otra Vez +2 + Precisión X",
+      "detail": "Si sale Luxray, usa Amortiguador y espera tener enfrente a Absol o Crawdaunt. Luego entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/sixto/garchomp.json
+++ b/src/data/hoenn/sixto/garchomp.json
@@ -2,21 +2,21 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 TRAMPA ROCAS 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Colmillo Ígneo --> Encanto + Amortiguador frente a Absol; Gengar +2 y 🔔Bola Sombra a todo🔔",
+      "detail": "Si usa Colmillo Ígneo, usa Encanto y Amortiguador frente a Absol. Luego entra con Gengar, usa Maquinación hasta +2 y barre con Bola Sombra.",
       "variant": []
     },
     {
-      "detail": "Absol --> Opciones para resolver",
+      "detail": "Si sale Absol, elige una ruta para resolver.",
       "variant": [
         {
-          "detail": "Rápido --> Gengar +2 +2 + Precisión",
+          "detail": "Ruta rápida: entra con Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Ahorrar dinero --> Gengar +6 +2 y 🔔Bola Sombra a todo🔔",
+          "detail": "Ruta de ahorro: entra con Gengar, usa Maquinación hasta +6, Velocidad X para +2 Velocidad y barre con Bola Sombra.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/sixto/golurk.json
+++ b/src/data/hoenn/sixto/golurk.json
@@ -2,19 +2,24 @@
   "id": "golurk",
   "name": "Golurk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔 Opciones para resolver 🔔",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Rápido --> Trampa Rocas; Gengar +2 +2 + Precisión; usar movimientos súper eficaces",
+      "detail": "Ruta rápida: usa 🪨 Trampa Rocas 🪨. Luego entra con Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Usa movimientos súper eficaces para cerrar.",
       "variant": []
     },
     {
-      "detail": "Ahorrar dinero --> Encanto + Amortiguador; Trampa Rocas frente a Darmanitan; Gengar +6; Bola Sombra a todo",
+      "detail": "Ruta de ahorro: usa Encanto y Amortiguador. Luego coloca 🪨 Trampa Rocas 🪨 frente a Darmanitan. Entra con Gengar, usa Maquinación hasta +6 y barre con Bola Sombra.",
       "variant": []
     },
     {
-      "detail": "Amortiguador frente a Darmanitan --> Cambiar a Gengar con Otra Vez +2 y derrotar; frente a Absol cambiar a Chansey, luego cambiar a Gengar +6",
-      "variant": []
+      "detail": "Si usas Amortiguador frente a Darmanitan, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y derrótalo.",
+      "variant": [
+        {
+          "detail": "Frente a Absol, cambia a Chansey. Luego vuelve a Gengar, usa Maquinación hasta +6 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/gyarados.json
+++ b/src/data/hoenn/sixto/gyarados.json
@@ -2,57 +2,67 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Ver habilidad 💡",
+  "initialMove": "💡 Revisa la habilidad 💡",
   "tricks": [
     {
-      "detail": "Intimidación ➜ Trampa Rocas",
+      "detail": "Si tiene Intimidación, usa 🪨 Trampa Rocas 🪨.",
       "variant": [
         {
-          "detail": "Absol ➜ Gengar +2 🔔(Bola Sombra a todo)🔔",
+          "detail": "Si sale Absol, entra con Gengar, usa Maquinación hasta +2 y barre con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Luxray ➜ Gengar +4 🔔(Bola Sombra a todo)🔔",
+          "detail": "Si sale Luxray, entra con Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Sin Intimidación ➜ Trampa Rocas",
+      "detail": "Si no tiene Intimidación, usa 🪨 Trampa Rocas 🪨.",
       "variant": [
         {
-          "detail": "Acua Cola ➜ Amortiguador frente a Absol, Gengar +4 🔔(Bola Sombra a todo)🔔",
+          "detail": "Si usa Acua Cola, usa Amortiguador frente a Absol. Luego entra con Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Darmanitan ➜ 💊Gengar +2 + Precisión X💊 (No usar Otra Vez) 🔔(Usar movimientos súper eficaces)🔔 💰(Ahorrar dinero: Gengar +6)💰",
-          "variant": []
-        },
-        {
-          "detail": "Absol ➜ Cambiar a Slowbro y usar Bostezo",
+          "detail": "Si sale Darmanitan, entra con Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa movimientos súper eficaces para cerrar.",
           "variant": [
             {
-              "detail": "Si el Bostezo fuerza la salida de un atacante especial del enemigo ➜ Sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
+              "detail": "Ruta de ahorro: Gengar usa Maquinación hasta +6.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Absol, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si Bostezo fuerza la salida de un atacante especial rival, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             },
             {
-              "detail": "Tajo Umbrío ➜ Ver estado de Slowbro",
+              "detail": "Si usa Tajo Umbrío, revisa el estado de Slowbro.",
               "variant": [
                 {
-                  "detail": "✅Slowbro vive✅ ➜ Sacrificar a Politoed; Poliwrath +6 🐸🥊 ⚠️(Golpe Bajo no es amenaza)⚠️",
+                  "detail": "Si Slowbro sobrevive, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Golpe Bajo no es amenaza.",
                   "variant": []
                 },
                 {
-                  "detail": "☠️Slowbro se debilita☠️ ➜ Cambiar a Chansey, 💊cambia a Gengar +2 +2 y Precisión X💊 💰(Ahorrar dinero: +6 +2)💰",
+                  "detail": "Si Slowbro se debilita, cambia a Chansey. Luego cambia a Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Ruta de ahorro: Gengar usa Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
                   "variant": []
-                }  
-              ]  
-            } 
-          ]  
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Luxray ➜ Amortiguador, esperar a Absol, 💊Gengar +2 + Precisión X💊  💰ahorrar dinero: Gengar +6 💰",
-          "variant": []
+          "detail": "Si sale Luxray, usa Amortiguador y espera a Absol. Luego entra con Gengar, usa Maquinación hasta +2 y Precisión X.",
+          "variant": [
+            {
+              "detail": "Ruta de ahorro: Gengar usa Maquinación hasta +6.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/hoenn/sixto/hariyama.json
+++ b/src/data/hoenn/sixto/hariyama.json
@@ -2,22 +2,22 @@
   "id": "hariyama",
   "name": "Hariyama",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Absol --> Gengar +4 (No usar Otra Vez); Bola Sombra a todo",
+      "detail": "Si sale Absol, entra con Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
       "variant": []
     },
     {
-      "detail": "Aggron --> Sacrificar a Politoed; Poliwrath entra a matar a aggron",
+      "detail": "Si sale Aggron, entra Politoed como pivote. Luego entra con Poliwrath 🐸🥊 para derrotar a Aggron.",
       "variant": []
     },
     {
-      "detail": "Shiftry --> Volcarona +2; lanzallamas contra Shiftry y el resto de plantas usar Psíquico (Mantener HP por encima del 23%)",
+      "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas. Mantén los PS por encima del 23%.",
       "variant": []
     },
     {
-      "detail": "Hariyama --> Recibir Ataque X; completar con Cascada contra Hariyama",
+      "detail": "Si sale Hariyama, recibe el Ataque X y completa la ruta con Cascada contra Hariyama.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/sixto/huntail.json
+++ b/src/data/hoenn/sixto/huntail.json
@@ -2,15 +2,20 @@
   "id": "huntail",
   "name": "Huntail",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Absol --> Gengar, Otra Vez, +2; 🔔con Bola Sombra🔔",
+      "detail": "Si sale Absol, entra con Gengar, usa Otra Vez, Maquinación hasta +2 y barre con Bola Sombra.",
       "variant": []
     },
     {
-      "detail": "Mienshao --> Gengar, bola sombra , frente a Mandibuzz / Spiritomb; Volcarona +2; 🔔Gigadrenado contra Absol🔔",
-      "variant": []
+      "detail": "Si sale Mienshao, entra con Gengar y usa Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2. Usa Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/luxray.json
+++ b/src/data/hoenn/sixto/luxray.json
@@ -2,34 +2,34 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔 Ver habilidad 🔔",
+  "initialMove": "💡 Revisa la habilidad 💡",
   "tricks": [
     {
-      "detail": "Intimidación ➜ Amortiguador",
+      "detail": "Si tiene Intimidación, usa Amortiguador.",
       "variant": [
         {
-          "detail": "Fuerza Bruta ➜ Trampa Rocas y frente a Absol cambia Gengar otra vez +2 + Precisión X ",
+          "detail": "Si usa Fuerza Bruta, coloca 🪨 Trampa Rocas 🪨. Frente a Absol, cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Scizor ➜ Volcarona x2 Danza aleteo + Especial X 🔔gigadrenado a Luxray🔔",
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
           "variant": []
         },
         {
-          "detail": "Absol ➜ Gengar +4 + Precisión X (No usar Otra Vez)",
+          "detail": "Si sale Absol, entra con Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Sin Intimidación ➜ Opciones para resolver",
+      "detail": "Si no tiene Intimidación, elige una ruta para resolver.",
       "variant": [
         {
-          "detail": "Ruta Segura ➜ Trampa Rocas entra Gengar otra vez  +2 y mata a luxray y frente a Absol cambia a Chansey y luego mete a Gengar otra vez  +2",
+          "detail": "Ruta segura: coloca 🪨 Trampa Rocas 🪨. Entra con Gengar, usa Otra Vez, Maquinación hasta +2 y derrota a Luxray. Frente a Absol, cambia a Chansey y luego vuelve a Gengar para usar Otra Vez y Maquinación hasta +2.",
           "variant": []
         },
         {
-          "detail": "Prueba ➜ Cambiar a Slowbro y usar Bostezo frente a Gyarados; sacrificar a Politoed; Poliwrath +6",
+          "detail": "Ruta de prueba: cambia a Slowbro y usa Bostezo frente a Gyarados. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/sixto/magnezone.json
+++ b/src/data/hoenn/sixto/magnezone.json
@@ -2,14 +2,14 @@
   "id": "magnezone",
   "name": "Magnezone",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Darmanitan ➜ Gengar +2 + Precisión X (No usar Otra Vez) 🔔usar movimientos súper eficaces🔔",
+      "detail": "Si sale Darmanitan, entra con Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Usa movimientos súper eficaces para cerrar.",
       "variant": []
     },
     {
-      "detail": "Absol ➜ Gengar, Otra Vez, +2 +2 + Precisión X 🔔 usar movimientos súper eficaces🔔",
+      "detail": "Si sale Absol, entra con Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Usa movimientos súper eficaces para cerrar.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/sixto/mandibuzz.json
+++ b/src/data/hoenn/sixto/mandibuzz.json
@@ -2,6 +2,21 @@
   "id": "mandibuzz",
   "name": "Mandibuzz",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 Frente a Mienshao; Gengar debilita con bola sombra frente a Mandibuzz / Spiritomb; Volcarona +2 (Gigadrenado a Absol)",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Mienshao.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar y debilita a Mienshao con Bola Sombra.",
+          "variant": [
+            {
+              "detail": "Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2. Usa Gigadrenado contra Absol.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/sixto/metagross.json
+++ b/src/data/hoenn/sixto/metagross.json
@@ -2,6 +2,16 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa rocas 🪨 Frente a Absol; Gengar +2 (Bola Sombra a todo)",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Absol.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Maquinación hasta +2 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/sixto/mienshao.json
+++ b/src/data/hoenn/sixto/mienshao.json
@@ -2,11 +2,20 @@
   "id": "mienshao",
   "name": "Mienshao",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Gengar y matalo con bola sombra ",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Frente a Mandibuzz/spiritomb ➜ cambia a Chansey y usa Trampa Rocas ➜ frente a Absol entra con  Volcarona x2 Danza aleteo (Gigadrenado a Absol)",
+      "detail": "Debilita a Mienshao con Bola Sombra.",
       "variant": []
+    },
+    {
+      "detail": "Frente a Mandibuzz o Spiritomb, cambia a Chansey y usa 🪨 Trampa Rocas 🪨.",
+      "variant": [
+        {
+          "detail": "Frente a Absol, entra con Volcarona y usa Danza Aleteo x2. Usa Gigadrenado contra Absol.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/mightyena.json
+++ b/src/data/hoenn/sixto/mightyena.json
@@ -2,11 +2,16 @@
   "id": "mightyena",
   "name": "Mightyena",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 USA TRAMPA ROCAS 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Frente a Absol ➜ Gengar Otra vez +4 (Bola Sombra a todo)",
-      "variant": []
+      "detail": "Frente a Absol.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Otra Vez, Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/sableye.json
+++ b/src/data/hoenn/sixto/sableye.json
@@ -2,38 +2,38 @@
   "id": "sableye",
   "name": "Sableye",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Absol ➜ Cambiar a Gengar y usar Otra Vez 🔔ver objeto🔔",
+      "detail": "Si sale Absol, cambia a Gengar y usa Otra Vez. Revisa el objeto de Absol.",
       "variant": []
     },
     {
-      "detail": "Si gengar es mas rapido que Absol usa Esta ruta 🔔 mira abajo 🔔",
+      "detail": "Si Gengar es más rápido que Absol, elige una ruta.",
       "variant": [
         {
-          "detail": "Rápido ➜ Gengar +2 +2 + Precisión X",
+          "detail": "Ruta rápida: Gengar usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Ahorrar dinero ➜ Gengar +6 +2 Bola Sombra a todo",
+          "detail": "Ruta de ahorro: Gengar usa Maquinación hasta +6, Velocidad X para +2 Velocidad y barre con Bola Sombra.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Absol Usa primero A bocajarro ➜ Gengar +4 (No usar Otra Vez - absol pañuelo elegido)",
+      "detail": "Si Absol usa A Bocajarro primero, Gengar usa Maquinación hasta +4. No uses Otra Vez. Absol tiene Pañuelo Elegido.",
       "variant": []
     },
     {
-      "detail": "Aggron ➜ Sacrifica a Politoed ➜ Poliwrath Puño drenaje",
+      "detail": "Si sale Aggron, entra Politoed como pivote. Luego entra con Poliwrath 🐸🥊 y usa Puño Drenaje.",
       "variant": [
         {
-          "detail": "Shiftry ➜ Volcarona x2 danza aleteo ➜ lanzallamas a Shiftry y el resto de plantas usar Psíquico",
+          "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas.",
           "variant": []
         },
         {
-          "detail": "Hariyama ➜ Poliwrath  Ataque X  completar con Cascada contra Hariyama",
+          "detail": "Si sale Hariyama, Poliwrath 🐸🥊 usa Ataque X y completa la ruta con Cascada contra Hariyama.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/sixto/salamence.json
+++ b/src/data/hoenn/sixto/salamence.json
@@ -2,30 +2,34 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Mira Qué Habilidad Tiene 💡",
+  "initialMove": "💡 Revisa la habilidad 💡",
   "tricks": [
     {
-      "detail": "Intimidación ➜ 🥚Amortiguador🥚",
+      "detail": "Si tiene Intimidación, usa 🥚 Amortiguador 🥚.",
       "variant": [
         {
-          "detail": "Absol ➜ Gengar +4 + Precisión (No usar Otra Vez)",
+          "detail": "Si sale Absol, entra con Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
           "variant": []
         },
         {
-          "detail": "Scizor ➜ Volcarona x2 Danza aleteo + Especial X 💡gigadrenado a Luxray💡",
+          "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Sin Intimidación ➜ Trampa Rocas y sacrifica a Politoed y con Poliwrath puño hielo para matarlo",
+      "detail": "Si no tiene Intimidación, usa 🪨 Trampa Rocas 🪨.",
       "variant": [
         {
-          "detail": "Shiftry ➜ Volcarona x2 Danza aleteo y usa lanzallamas  contra Shiftry y el resto de plantas usar Psíquico (Mantener HP por encima del 23%)",
+          "detail": "Luego entra Politoed como pivote. Entra con Poliwrath 🐸🥊 y usa Puño Hielo para derrotar a Salamence.",
           "variant": []
         },
         {
-          "detail": "Hariyama ➜ Con  Poliwrath usa Ataque X 💡con Cascada contra Hariyama💡",
+          "detail": "Si sale Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas. Mantén los PS por encima del 23%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Hariyama, Poliwrath 🐸🥊 usa Ataque X y completa la ruta con Cascada contra Hariyama.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/sixto/scizor.json
+++ b/src/data/hoenn/sixto/scizor.json
@@ -2,6 +2,16 @@
   "id": "scizor",
   "name": "Scizor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Volcarona x2 Danza eleteo + Especial X (gigadrenado a Luxray Si solo haces x1 danza aleteo absol te gana en velocidad con pañuelo elegido)💡",
-  "tricks": []
+  "initialMove": "Cambia a Volcarona.",
+  "tricks": [
+    {
+      "detail": "Usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
+      "variant": [
+        {
+          "detail": "Si solo usas Danza Aleteo x1, Absol con Pañuelo Elegido supera en Velocidad a Volcarona.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/sixto/scolipede.json
+++ b/src/data/hoenn/sixto/scolipede.json
@@ -2,15 +2,29 @@
   "id": "scolipede",
   "name": "Scolipede",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 si no cambia usa 🥚 Amortiguador 🥚",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Absol ➜ Gengar Otra Vez +2 + Precisión X 🔔para ahorrar dinero: Gengar +6 Absol no tiene banda focus🔔",
+      "detail": "Si Scolipede no cambia, usa 🥚 Amortiguador 🥚.",
       "variant": []
     },
     {
-      "detail": "Luxray ➜ Amortiguador ➜ esperar a Absol / Crawdaunt ➜ Gengar Otra Vez  +2 + Precisión X🔔para ahorrar dinero: Gengar +6🔔",
-      "variant": []
+      "detail": "Si sale Absol, entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Absol no tiene Banda Focus.",
+      "variant": [
+        {
+          "detail": "Ruta de ahorro: Gengar usa Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Luxray, usa Amortiguador y espera a Absol o Crawdaunt. Luego entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X.",
+      "variant": [
+        {
+          "detail": "Ruta de ahorro: Gengar usa Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/scrafty.json
+++ b/src/data/hoenn/sixto/scrafty.json
@@ -5,11 +5,11 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Absol --> Gengar +4 + Precisión (No usar Otra Vez)",
+      "detail": "Si sale Absol, entra con Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
       "variant": []
     },
     {
-      "detail": "Scizor --> Volcarona +2 + Ataque Especial X (Gigadrenado a Luxray)",
+      "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/sixto/sharpedo.json
+++ b/src/data/hoenn/sixto/sharpedo.json
@@ -2,15 +2,20 @@
   "id": "sharpedo",
   "name": "Sharpedo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas ,frente a Absol 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Rápido --> Gengar, Otra Vez, +2 +2 + Precisión",
-      "variant": []
-    },
-    {
-      "detail": "Ahorrar dinero --> Gengar, Otra Vez, +6 +2; Bola Sombra a todos / Mantener Otra Vez hasta terminar de boostearte",
-      "variant": []
+      "detail": "Frente a Absol.",
+      "variant": [
+        {
+          "detail": "Ruta rápida: entra con Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta de ahorro: entra con Gengar, usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad. Barre con Bola Sombra y mantén Otra Vez hasta terminar de boostearte.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/shiftry.json
+++ b/src/data/hoenn/sixto/shiftry.json
@@ -2,20 +2,20 @@
   "id": "shiftry",
   "name": "Shiftry",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampas Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si entra Absol ➜ Cambia a Gengar +4 (No usar Otra Vez); Bola Sombra a todo",
+      "detail": "Si entra Absol, cambia a Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
       "variant": []
     },
     {
-      "detail": "Si entra Aggron ➜ Sacrifica a Politoed y con Poliwrath mata a aggron",
+      "detail": "Si entra Aggron, entra Politoed como pivote. Luego entra con Poliwrath 🐸🥊 para derrotar a Aggron.",
       "variant": [
         {
-          "detail": "Si entra Shiftry ➜ Volcarona x2 Danza aleteo 🔔 lanzallamas en Shiftry y el resto de plantas usar Psíquico (Mantener HP por encima del 23%)🔔",
+          "detail": "Si entra Shiftry, entra con Volcarona y usa Danza Aleteo x2. Usa Lanzallamas contra Shiftry y Psíquico contra el resto de plantas. Mantén los PS por encima del 23%.",
           "variant": [
             {
-              "detail": " Si entra Hariyama ➜ Usa Ataque X con poliwrath y ataca 🔔 Cascada contra Hariyama🔔",
+              "detail": "Si entra Hariyama, Poliwrath 🐸🥊 usa Ataque X y ataca con Cascada contra Hariyama.",
               "variant": []
             }
           ]

--- a/src/data/hoenn/sixto/spiritomb.json
+++ b/src/data/hoenn/sixto/spiritomb.json
@@ -2,15 +2,20 @@
   "id": "spiritomb",
   "name": "Spiritomb",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Absol --> Gengar +4",
+      "detail": "Si sale Absol, entra con Gengar y usa Maquinación hasta +4.",
       "variant": []
     },
     {
-      "detail": "Mienshao --> Gengar debilita con bola sombra y frente a Mandibuzz / Spiritomb; Volcarona +2",
-      "variant": []
+      "detail": "Si sale Mienshao, entra con Gengar y debilítalo con Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Frente a Mandibuzz o Spiritomb, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/sixto/tentacruel.json
+++ b/src/data/hoenn/sixto/tentacruel.json
@@ -5,11 +5,11 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Absol --> Gengar +4 + Precisión (No usar Otra Vez)",
+      "detail": "Si sale Absol, entra con Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
       "variant": []
     },
     {
-      "detail": "Scizor --> Volcarona +2 + Ataque Especial X; 🔔 Gigadrenado a Luxray 🔔",
+      "detail": "Si sale Scizor, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Usa Gigadrenado contra Luxray.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/sixto/toxicroak.json
+++ b/src/data/hoenn/sixto/toxicroak.json
@@ -2,6 +2,11 @@
   "id": "toxicroak",
   "name": "Toxicroak",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻 Gengar +4 y luego usa otra vez porque tiene banda focus 🔔 Bola Sombra a todo 🔔",
-  "tricks": []
+  "initialMove": "Cambia a Gengar 👻.",
+  "tricks": [
+    {
+      "detail": "Usa Maquinación hasta +4. Luego usa Otra Vez, porque Toxicroak tiene Banda Focus. Barre con Bola Sombra.",
+      "variant": []
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Releases the Hoenn Spanish strategy structure preview from `develop` to `main`.
- Publishes Sixto cleanup and the first Fatima files.
- Keeps `initialMove` as the opening action only.
- Keeps follow-up route logic in `tricks.detail` and `variant`.

## Scope
- Release PR from `develop` to `main`.
- Hoenn Spanish strategy JSON files only.
- No English translation changes.
- No asset changes.
- No frontend layout changes.

## Notes
- Intended to update GitHub Pages so the Hoenn structure preview can be reviewed live.