### PR TITLE
Clean Hoenn Fatima Spanish strategy structure

### DIFF
--- a/src/data/hoenn/fatima/chandelure.json
+++ b/src/data/hoenn/fatima/chandelure.json
@@ -2,6 +2,21 @@
   "id": "chandelure",
   "name": "Chandelure",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa rocas 🪨 Frente a Lucario ➜ Gengar +2 + Precisión X (No usar Otra Vez) 🔔 para ahorrar dinero: Gengar +6 🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Ruta de ahorro: Gengar usa Maquinación hasta +6.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/fatima/dusknoir.json
+++ b/src/data/hoenn/fatima/dusknoir.json
@@ -2,65 +2,82 @@
   "id": "dusknoir",
   "name": "Dusknoir",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡(Observa si tiene Presión)💡",
+  "initialMove": "💡 Revisa si tiene Presión 💡",
   "tricks": [
     {
-      "detail": "Con Presión ➜ Trampa Rocas 🔔(Si se queda usa Amortiguador)🔔",
+      "detail": "Si tiene Presión, usa 🪨 Trampa Rocas 🪨.",
       "variant": [
         {
-          "detail": "Mawile ➜ Cambiar a Slowbro y usar Bostezo, sacrificar a Politoed, Poliwrath +6 🔔(Puño Hielo a Froslass)🔔 🚨(Si el Puño trueno te paraliza usa una Curacion Total)🚨",
+          "detail": "Si Dusknoir se queda, usa Amortiguador.",
           "variant": []
         },
         {
-          "detail": "Lucario ➜ Cambiar a Gengar para ver movimiento",
+          "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo.",
           "variant": [
             {
-              "detail": "A Bocajarro ➜ Gengar +2 + Precisión X (No usar Otra Vez) 💰(Si quieres Ahorrar: Gengar +6)💰",
-              "variant": []
-            }, 
-            { 
-              "detail": "Patada Salto Alta ➜ Gengar +2, suicidate frente a Houndoom, sacrificar a Politoed, Poliwrath +6 🚨(Si hay quemadura, usar Restaurar Todo)🚨",
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza a Poliwrath, usa Cura Total.",
               "variant": []
             }
-          ] 
-        },
-        { 
-          "detail": "Honchkrow ➜ Sacrificar a Politoed, Poliwrath Barre hasta llegar a Hydreigon, usar un Ataque X y seguir Barrriendo",
-          "variant": []
+          ]
         },
         {
-          "detail": "Arcanine ➜ Cambiar a Slowbro y usar Bostezo frente a Raichu, sacrificar a Politoed, Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Hydreigon ➜ Teletransporte",
+          "detail": "Si sale Lucario, cambia a Gengar para revisar el movimiento.",
           "variant": [
             {
-              "detail": "Si se queda ➜ Enviar a Slowbro y usar Bostezo, sacrificar a Politoed, Poliwrath +6 🔔(Puño Hielo a Froslass)🔔",
+              "detail": "Si usa A Bocajarro, Gengar usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Ruta de ahorro: Gengar usa Maquinación hasta +6.",
               "variant": []
             },
             {
-              "detail": "Mawile ➜ Enviar a Slowbro y usar Bostezo, sacrificar a Politoed, Poliwrath +6 🔔(Puño Hielo a Froslass)🔔 🚨(Si el Puño trueno te paraliza usa una Curacion Total)🚨",
+              "detail": "Si usa Patada Salto Alta, Gengar usa Maquinación hasta +2. Luego deja caer a Gengar frente a Houndoom, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Si hay quemadura, usa Restaurar Todo.",
               "variant": []
-            } 
-          ]  
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Honchkrow, entra Politoed como pivote y entra con Poliwrath 🐸🥊. Barre hasta llegar a Hydreigon, usa Ataque X y sigue barriendo.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo frente a Raichu.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Hydreigon, usa Teletransporte.",
+          "variant": [
+            {
+              "detail": "Si Hydreigon se queda, envía a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Mawile, envía a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza a Poliwrath, usa Cura Total.",
+              "variant": []
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Sin Presión (Zoroark) ➜ Trampa Rocas frente a Lucario 🔔(Revisar posición de Lucario en el Equipo)🔔",
+      "detail": "Si no tiene Presión, es Zoroark. Usa 🪨 Trampa Rocas 🪨 frente a Lucario y revisa la posición de Lucario en el equipo.",
       "variant": [
         {
-          "detail": "Posición 2 (A Bocajarro) ➜ Gengar Otra Vez 4+2 🔔(Barre con Bola Sombra)🔔",
+          "detail": "Si Lucario está en posición 2 y usa A Bocajarro, Gengar usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
           "variant": []
-        },    
+        },
         {
-          "detail": "Posición 3 (Patada Salto Alta) ➜ Cambiar a Slowbro y usar Bostezo frente al Dusknoir falso, usar Protección y Bostezo si sale Hydreigon, sacrifica a Politoed, Poliwrath +6 🥊",
-          "variant": []
+          "detail": "Si Lucario está en posición 3 y usa Patada Salto Alta, cambia a Slowbro y usa Bostezo frente al Dusknoir falso.",
+          "variant": [
+            {
+              "detail": "Usa Protección y Bostezo si sale Hydreigon. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
     }
   ]
 }
-  
-

--- a/src/data/hoenn/fatima/dusknoir.json
+++ b/src/data/hoenn/fatima/dusknoir.json
@@ -28,7 +28,7 @@
               "variant": []
             },
             {
-              "detail": "Si usa Patada Salto Alta, Gengar usa Maquinación hasta +2. Luego deja caer a Gengar frente a Houndoom, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Si hay quemadura, usa Restaurar Todo.",
+              "detail": "Si usa Patada Salto Alta, Gengar usa Maquinación hasta +2. Luego deja que Houndoom debilite a Gengar, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Si hay quemadura, usa Restaurar Todo.",
               "variant": []
             }
           ]

--- a/src/data/hoenn/fatima/froslass.json
+++ b/src/data/hoenn/fatima/froslass.json
@@ -2,21 +2,30 @@
   "id": "froslass",
   "name": "Froslass",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Trampa Rocas ➜ si Froslass se queda, usa Amortiguador 💡",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Mawile ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrificar a Politoed; Poliwrath +6 🐸🥊 💡Puño Hielo a Froslass💡",
+      "detail": "Si Froslass se queda, usa Amortiguador.",
       "variant": []
     },
     {
-      "detail": "Hydreigon ➜ Teletransporte",
+      "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Si permanece ➜ slowbro y usar Bostezo ➜ sacrificar a Politoed ➜ Poliwrath +6 🐸🥊 💡Puño Hielo a Froslass💡",
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Hydreigon, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Si Hydreigon permanece, envía a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
           "variant": []
         },
         {
-          "detail": "Mawile ➜ slowbro y usar Bostezo ➜ sacrificar a Politoed ➜ Poliwrath +6 🐸🥊 💡Puño Hielo a Froslass; si el Puño Trueno paraliza, usar Cura Total💡",
+          "detail": "Si sale Mawile, envía a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza a Poliwrath, usa Cura Total.",
           "variant": []
         }
       ]

--- a/src/data/hoenn/fatima/honchkrow.json
+++ b/src/data/hoenn/fatima/honchkrow.json
@@ -2,15 +2,25 @@
   "id": "honchkrow",
   "name": "Honchkrow",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔 Cambiar a Slowbro y usar Bostezo 🔔",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Si permanece / Hydreigon / Lucario ➜ Sacrificar a Politoed ➜ Poliwrath +6 🔔 Puño Drenaje  para mantener la línea de salud 🔔",
-      "variant": []
+      "detail": "Usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Honchkrow permanece, o si sale Hydreigon o Lucario, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje para mantener la línea de salud.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Banette ➜ Cambiar a Chansey y usar Trampa Rocas frente a Honchkrow ➜ sacrificar a Politoed  ➜ Poliwrath Puño H ➜ Cuando entra Hydreigon usa Ataque X  🔔 Puño Hielo para Honchkrow 🔔",
-      "variant": []
+      "detail": "Si sale Banette, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 frente a Honchkrow.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊. Usa Puño Hielo contra Honchkrow. Cuando entre Hydreigon, usa Ataque X y completa la ruta.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/houndoom.json
+++ b/src/data/hoenn/fatima/houndoom.json
@@ -2,15 +2,25 @@
   "id": "houndoom",
   "name": "Houndoom",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Honchkrow ➜ Sacrificar a Politoed ➜ Poliwrath Puño H y cuando entre Hydreigon  usa Ataque X y completar  🔔puño Hielo para eliminar a Honchkrow🔔",
-      "variant": []
+      "detail": "Si sale Honchkrow, entra Politoed como pivote y entra con Poliwrath 🐸🥊.",
+      "variant": [
+        {
+          "detail": "Usa Puño Hielo contra Honchkrow. Cuando entre Hydreigon, usa Ataque X y completa la ruta.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Lucario ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrificar a Politoed ➜ Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Lucario, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/hydreigon.json
+++ b/src/data/hoenn/fatima/hydreigon.json
@@ -2,31 +2,47 @@
   "id": "hydreigon",
   "name": "Hydreigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Onda Certera ➜ Teletransporte",
+      "detail": "Si usa Onda Certera, usa Teletransporte.",
       "variant": []
     },
     {
-      "detail": "Si permanece ➜ Slowbro y usar Bostezo  sacrificar a Politoed; Poliwrath +6 🐸🥊 🔔Puño Hielo a Froslass🔔",
-      "variant": []
+      "detail": "Si Hydreigon permanece, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Mawile ➜ Slowbro y usar Bostezo ➜ sacrificar a Politoed ➜ Poliwrath +6 🔔Puño Hielo a Froslass (Si el Puño Trueno paraliza, usar Cura Total)🔔",
-      "variant": []
+      "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza a Poliwrath, usa Cura Total.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Lucario ➜ Gengar +2 + Precisión X (No usar Otra Vez)  🔔para ahorrar dinero Gengar +6🔔",
-      "variant": []
+      "detail": "Si sale Lucario, entra con Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+      "variant": [
+        {
+          "detail": "Ruta de ahorro: Gengar usa Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Honchkrow ➜ Sacrificar a Politoed ➜ Poliwrath Puño H si entra hydreigon usa Ataque X y completar  🔔puño Hielo para eliminar a Honchkrow🔔",
-      "variant": []
-    },
-    {
-      "detail": "Mawile ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrificar a Politoed ➜ Poliwrath +6; 🔔Puño Hielo a Froslass (Si el Puño Trueno paraliza, usar Cura Total)🔔",
-      "variant": []
+      "detail": "Si sale Honchkrow, entra Politoed como pivote y entra con Poliwrath 🐸🥊.",
+      "variant": [
+        {
+          "detail": "Usa Puño Hielo contra Honchkrow. Si entra Hydreigon, usa Ataque X y completa la ruta.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/lucario.json
+++ b/src/data/hoenn/fatima/lucario.json
@@ -2,32 +2,52 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Cambiar a Slowbro 💡",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "A Bocajarro ➜ Cambiar a Chansey y usar Trampa Rocas frente a Lucario, Gengar +2 + Precisión X (No usar Otra Vez) 💰(Si quieres Ahorrar: Gengar +6)💰",
-      "variant": []
-    },
-    {
-      "detail": "Patada Salto Alta ➜ Bostezo, sacrificar a Politoed, Poliwrath +6 🔔(Eliminar quemadura primero)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Honchkrow ➜ Bostezo",
+      "detail": "Si Lucario usa A Bocajarro, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 frente a Lucario.",
       "variant": [
         {
-          "detail": "Si permanece / Hydreigon / Lucario, Sacrificar a Politoed, Poliwrath +6 🔔(Puño Drenaje para mantener la línea de salud)🔔",
+          "detail": "Luego entra con Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez. Ruta de ahorro: Gengar usa Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si Lucario usa Patada Salto Alta, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Elimina la quemadura primero si corresponde.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Honchkrow, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Honchkrow permanece, o si sale Hydreigon o Lucario, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje para mantener la línea de salud.",
           "variant": []
         },
         {
-          "detail": "Banette ➜ Cambiar a Chansey y usar Trampa Rocas frente a Honchkrow, sacrificar a Politoed, 💊entra Poliwrath y pushea hasta Hydreigon luego usa Ataque X💊 🔔(Puño Hielo para Honchkrow)🔔",
-          "variant": []
-        }  
-      ]  
+          "detail": "Si sale Banette, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 frente a Honchkrow.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊. Empuja hasta Hydreigon, usa Ataque X y completa la ruta. Usa Puño Hielo contra Honchkrow.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Arcanine ➜ Slowbro, bostezo frente a Raichu, sacrificar a Politoed, Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Arcanine, cambia a Slowbro y usa Bostezo frente a Raichu.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/luxray.json
+++ b/src/data/hoenn/fatima/luxray.json
@@ -2,6 +2,16 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 Gengar +4 + Defensa X 🔔Si usa Fuerza Bruta y sale críto  usar primero max pocion  y luego Bola Sombra a todo🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Entra con Gengar, usa Maquinación hasta +4 y Defensa X.",
+      "variant": [
+        {
+          "detail": "Si Luxray usa Fuerza Bruta y sale crítico, usa primero Max Poción. Luego barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/fatima/mandibuzz.json
+++ b/src/data/hoenn/fatima/mandibuzz.json
@@ -2,6 +2,16 @@
   "id": "mandibuzz",
   "name": "Mandibuzz",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Cambia a Slowbro frente  Arcanine Usar Bostezo ➜ frente a Raichu ➜ sacrificar a Politoed ➜ Poliwrath +6 🐸🥊💡",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Frente a Arcanine, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Cuando salga Raichu, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/fatima/mawile.json
+++ b/src/data/hoenn/fatima/mawile.json
@@ -2,6 +2,16 @@
   "id": "mawile",
   "name": "Mawile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 🪨 Trampa Rocas 🪨 cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6 💡 Puño Hielo a Froslass",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/fatima/meganium.json
+++ b/src/data/hoenn/fatima/meganium.json
@@ -2,15 +2,25 @@
   "id": "meganium",
   "name": "Meganium",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Arcanine --> Cambiar a Slowbro; Slowbro Bostezo frente a Raichu; sacrificar a Politoed; Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Arcanine, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo frente a Raichu. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Lucario --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Lucario, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/mismagius.json
+++ b/src/data/hoenn/fatima/mismagius.json
@@ -2,6 +2,16 @@
   "id": "mismagius",
   "name": "Mismagius",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa rocas 🪨 frente a Lucario; cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/fatima/ninetales.json
+++ b/src/data/hoenn/fatima/ninetales.json
@@ -2,6 +2,16 @@
   "id": "ninetales",
   "name": "Ninetales",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Amortiguador frente a Lucario; Gengar +4 +2 💡 Bola Sombra a todo",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/fatima/raichu.json
+++ b/src/data/hoenn/fatima/raichu.json
@@ -2,6 +2,16 @@
   "id": "raichu",
   "name": "Raichu",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Cambiar a Slowbro ➜ ante Arcanine ➜ Slowbro Bostezo frente a Raichu ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊💡",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Frente a Arcanine, usa Bostezo frente a Raichu.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/fatima/regice.json
+++ b/src/data/hoenn/fatima/regice.json
@@ -2,6 +2,21 @@
   "id": "regice",
   "name": "Regice",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 frente a Lucario; Gengar +2 + Precisión (No usar Otra Vez); 🔔 para ahorrar dinero: Gengar +6 🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Ruta de ahorro: Gengar usa Maquinación hasta +6.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/fatima/rotom_agua.json
+++ b/src/data/hoenn/fatima/rotom_agua.json
@@ -2,23 +2,33 @@
   "id": "rotom_agua",
   "name": "Rotom Agua",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 si no cambia, usa Amortiguador",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Mawile ➜ Slowbro usa Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔 Puño Hielo a Froslass; si el Puño Trueno paraliza, usar Cura Total 🔔",
+      "detail": "Si Rotom Agua no cambia, usa Amortiguador.",
       "variant": []
     },
     {
-      "detail": "Hydreigon ➜ Teletransporte",
-      "variant": []
+      "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza a Poliwrath, usa Cura Total.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Si permanece ➜ Enviar a Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔 Puño Hielo a Froslass 🔔",
-      "variant": []
-    },
-    {
-      "detail": "Mawile ➜ Enviar a Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔 Puño Hielo a Froslass; si el Puño Trueno paraliza, usar Cura Total 🔔",
-      "variant": []
+      "detail": "Si sale Hydreigon, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Si Hydreigon permanece, envía a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mawile, envía a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza a Poliwrath, usa Cura Total.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/fatima/sableye.json
+++ b/src/data/hoenn/fatima/sableye.json
@@ -2,7 +2,21 @@
   "id": "sableye",
   "name": "Sableye",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 frente a Lucario; Gengar +2 + Precisión (No usar Otra Vez); 🔔 para ahorrar dinero: Gengar +6 🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Ruta de ahorro: Gengar usa Maquinación hasta +6.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
-    

--- a/src/data/hoenn/fatima/umbreon.json
+++ b/src/data/hoenn/fatima/umbreon.json
@@ -2,23 +2,33 @@
   "id": "umbreon",
   "name": "Umbreon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Trampa Rocas si no cambia usa Amortiguador 💡",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Mawile --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6; 🔔 Puño Hielo a Froslass; si el Puño Trueno paraliza, usar Cura Total 🔔",
+      "detail": "Si Umbreon no cambia, usa Amortiguador.",
       "variant": []
     },
     {
-      "detail": "Hydreigon --> Teletransporte",
-      "variant": []
+      "detail": "Si sale Mawile, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza a Poliwrath, usa Cura Total.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Si permanece --> Enviar a Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6; 🔔 Puño Hielo a Froslass 🔔",
-      "variant": []
-    },
-    {
-      "detail": "Mawile --> Enviar a Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6; 🔔 Puño Hielo a Froslass; si el Puño Trueno paraliza, usar Cura Total 🔔",
-      "variant": []
+      "detail": "Si sale Hydreigon, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Si Hydreigon permanece, envía a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Mawile, envía a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass. Si Puño Trueno paraliza a Poliwrath, usa Cura Total.",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Completes the Hoenn Fatima Spanish strategy structure cleanup.
- Keeps `initialMove` as the opening action only.
- Moves route follow-up steps into `tricks.detail` and nested `variant` entries.
- Replaces old Politoed sacrifice wording with pivot wording.
- Expands shorthand setup text such as Gengar boosts and Poliwrath setup into clear Spanish.

## Scope
- Hoenn Fatima strategy JSON files only.
- No English translation changes.
- No asset changes.
- No frontend layout changes.

## Notes
- English translations are intentionally left for the final global translation pass.