### PR TITLE
Clean Hoenn Nivea Spanish strategy structure

### DIFF
--- a/src/data/hoenn/nivea/abomasnow.json
+++ b/src/data/hoenn/nivea/abomasnow.json
@@ -2,37 +2,47 @@
   "id": "abomasnow",
   "name": "Abomasnow",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "⬇️Mira las Opciones para Resolver⬇️",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "🍀SUERTE🍀 ➜ Sacrificar a Politoed, saca a Poliwrath y usa Puño Drenaje, 💊frente a Empoleon usa un Ataque X y luego Barre💊",
-      "variant": []
-    },  
-    {
-      "detail": "✅RAPIDO✅ ➜ Cambia a Gengar 🔔(Mira si el Cuerpo Maldito se Activa)🔔",
+      "detail": "Ruta con suerte: entra Politoed como pivote y luego entra con Poliwrath 🐸🥊.",
       "variant": [
         {
-          "detail": "Si se Activa ➜ Sacrificar a Politoed y entra Poliwrath +6",
+          "detail": "Usa Puño Drenaje. Frente a Empoleon, usa Ataque X y barre.",
           "variant": []
-        },  
-        {  
-          "detail": "No se Activa ➜ Gengar Otra Vez 🔔(Mira tu Situacion)🔔",
-          "variant": [
-            {  
-              "detail": "☠️Gengar Muere☠️ ➜ Volcarona +2",
-              "variant": [] 
-            },  
-            {    
-              "detail": "👻Gengar no Muere👻 ➜ Sacrificar a Politoed y entra Poliwrath +6",
-              "variant": [] 
-            }  
-          ]  
-        }  
-      ]    
-    },  
+        }
+      ]
+    },
     {
-      "detail": "💰AHORRAR💰 ➜ 💕Encanto tres veces💕; Teletransporte; Volcarona +2 🚨(PS por encima del 70%)🚨",
-      "variant": []
+      "detail": "Ruta rápida: cambia a Gengar y revisa si se activa Cuerpo Maldito.",
+      "variant": [
+        {
+          "detail": "Si se activa, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si no se activa, Gengar usa Otra Vez y revisa la situación.",
+          "variant": [
+            {
+              "detail": "Si Gengar cae, entra con Volcarona y usa Danza Aleteo x2.",
+              "variant": []
+            },
+            {
+              "detail": "Si Gengar no cae, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Ruta de ahorro: usa Encanto tres veces. Luego usa Teletransporte hacia Volcarona y usa Danza Aleteo x2.",
+      "variant": [
+        {
+          "detail": "Mantén los PS de Volcarona por encima del 70%.",
+          "variant": []
+        }
+      ]
     }
-  ]  
-}  
+  ]
+}

--- a/src/data/hoenn/nivea/altaria.json
+++ b/src/data/hoenn/nivea/altaria.json
@@ -2,6 +2,16 @@
   "id": "altaria",
   "name": "Altaria",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Mienshao ➜ Gengar +2 🔔(Barrer con Bola Sombra)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Mienshao.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Maquinación hasta +2 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/nivea/beartic.json
+++ b/src/data/hoenn/nivea/beartic.json
@@ -2,6 +2,11 @@
   "id": "beartic",
   "name": "Beartic",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Gengar Otra Vez +6👻 🔔(Barrer con Bola Sombra)🔔",
-  "tricks": []
+  "initialMove": "Cambia a Gengar 👻.",
+  "tricks": [
+    {
+      "detail": "Usa Otra Vez. Luego usa Maquinación hasta +6 y barre con Bola Sombra.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/hoenn/nivea/blissey.json
+++ b/src/data/hoenn/nivea/blissey.json
@@ -2,15 +2,34 @@
   "id": "blissey",
   "name": "Blissey",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Mienshao; cambiar a Gengar y usar bola sombra a mienshao",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Skarmory --> Cambiar a Slowbro; Bostezo frente a Mismagius; sacrificar a Politoed; Poliwrath +6 🔔(Cascada a Skarmory)🔔",
-      "variant": []
+      "detail": "Frente a Mienshao.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar y usa Bola Sombra contra Mienshao.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Walrein o Dewgong --> Sacrificar a Politoed; Poliwrath +6 🔔(Cascada a Skarmory)🔔",
-      "variant": []
+      "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Walrein o Dewgong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": [
+        {
+          "detail": "Usa Cascada contra Skarmory.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/froslass.json
+++ b/src/data/hoenn/nivea/froslass.json
@@ -2,6 +2,16 @@
   "id": "froslass",
   "name": "Froslass",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Hariyama; Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6 🔔(Puño Hielo a Froslass)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Hariyama.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/nivea/gallade.json
+++ b/src/data/hoenn/nivea/gallade.json
@@ -2,6 +2,16 @@
   "id": "gallade",
   "name": "Gallade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Cambia a Gengar +6👻 🔔(Barrer con Bola Sombra)🔔 🚨(Si Skarmory hace Critico usa Max Pocion)🚨",
-  "tricks": []
+  "initialMove": "Cambia a Gengar 👻.",
+  "tricks": [
+    {
+      "detail": "Usa Maquinación hasta +6 y barre con Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Si Skarmory hace golpe crítico, usa Max Poción.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/nivea/glalie.json
+++ b/src/data/hoenn/nivea/glalie.json
@@ -2,10 +2,10 @@
   "id": "glalie",
   "name": "Glalie",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Mienshao ➜ Entra Gengar +2 🔔(Barrer con Bola Sombra)🔔",
+      "detail": "Si sale Mienshao, entra con Gengar, usa Maquinación hasta +2 y barre con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/nivea/hariyama.json
+++ b/src/data/hoenn/nivea/hariyama.json
@@ -2,15 +2,25 @@
   "id": "hariyama",
   "name": "Hariyama",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🐸Opciones para Resolver🐸",
+  "initialMove": "💡 Varias opciones 💡",
   "tricks": [
     {
-      "detail": "Rápido --> Trampa Rocas; Gengar 4+2 + Precisión X; 🔔(Barrer con Bola Sombra; si se bloquea, usar Onda Certera)🔔",
-      "variant": []
+      "detail": "Ruta rápida: usa 🪨 Trampa Rocas 🪨.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Barre con Bola Sombra; si se bloquea, usa Onda Certera.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Ahorrar Dinero --> Cambiar a Slowbro, luego a Chansey y usar Trampa Rocas; Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6 🔔(Cascada a Froslass)🔔",
-      "variant": []
+      "detail": "Ruta de ahorro: cambia a Slowbro, luego a Chansey y usa 🪨 Trampa Rocas 🪨.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Froslass.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/lanturn.json
+++ b/src/data/hoenn/nivea/lanturn.json
@@ -2,33 +2,45 @@
   "id": "lanturn",
   "name": "Lanturn",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Hariyama ➜ Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño Hielo a Froslass)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Metagross ➜ Cambiar a Slowbro, luego de Volcarona frente a Serperior ➜ Volcarona +2",
-      "variant": []
-    },
-    {
-      "detail": "Mienshao ➜ Cambiar a Gengar y atacar con Bola Sombra",
+      "detail": "Si sale Hariyama, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Skarmory ➜ Cambiar a Slowbro y usar Bostezo ➜ frente a Mismagius ➜ sacrifica a Politoed ➜ Poliwrath +6 🔔(Cascada a Skarmory)🔔"
-        },
-        {
-          "detail": "Walrein o Dewgong ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Cascada a Skarmory)🔔"
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
         }
       ]
     },
     {
-      "detail": "Gallade ➜ Gengar +4 (No usar Otra Vez) 🔔(Barrer con Bola Sombra)🔔",
+      "detail": "Si sale Metagross, cambia a Slowbro. Luego entra con Volcarona frente a Serperior y usa Danza Aleteo x2.",
       "variant": []
     },
     {
-      "detail": "Beartic ➜ Gengar Otra Vez +4 🔔(Barrer con Bola Sombra)🔔",
+      "detail": "Si sale Mienshao, cambia a Gengar y usa Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Walrein o Dewgong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Gallade, entra con Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Beartic, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y barre con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/nivea/metagross.json
+++ b/src/data/hoenn/nivea/metagross.json
@@ -2,24 +2,36 @@
   "id": "metagross_4",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Machada ➜ Cambiar a Slowbro, luego de Volcarona a Serperior ➜ Volcarona +2 🦋🔥",
-      "variant": []
-    },
-    {
-      "detail": "Puño Meteoro ➜ Teletransporte, Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Puño Hielo a Froslass)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Mamoswine ➜ Encanto cambiar a Slowbro y usar Bostezo frente a Mismagius 🔔(Revisar la Salud del Slowbro)🔔",
+      "detail": "Si usa Machada, cambia a Slowbro.",
       "variant": [
         {
-          "detail": "Slowbro tiene menos del 79% de vida ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Cascada a Metagross)🔔"
+          "detail": "Luego entra con Volcarona frente a Serperior y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si usa Puño Meteoro, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Mamoswine, usa Encanto. Luego cambia a Slowbro y usa Bostezo frente a Mismagius.",
+      "variant": [
+        {
+          "detail": "Si Slowbro tiene menos del 79% de PS, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Metagross.",
+          "variant": []
         },
         {
-          "detail": "Slowbro tiene mas del 79% de vida ➜ Volcarona +1 🦋🔥"
+          "detail": "Si Slowbro tiene más del 79% de PS, entra con Volcarona y usa Danza Aleteo x1.",
+          "variant": []
         }
       ]
     }

--- a/src/data/hoenn/nivea/mienshao.json
+++ b/src/data/hoenn/nivea/mienshao.json
@@ -2,59 +2,78 @@
   "id": "mienshao",
   "name": "Mienshao",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambiar a Gengar, luego a Slowbro para recibir Roca Afilada💡 🔔(Verificar Objeto + Precisión)🔔",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Vidasfera ➜ Cambiar a Chansey para recibir Ida y Vuelta ➜ usar Trampa Rocas frente a Mienshao ➜ cambiar a Gengar y esperar a que se debilite solo",
+      "detail": "Luego cambia a Slowbro para recibir Roca Afilada. Verifica el objeto y la precisión.",
+      "variant": []
+    },
+    {
+      "detail": "Si tiene Vidasfera, cambia a Chansey para recibir Ida y Vuelta.",
       "variant": [
         {
-          "detail": "Skarmory ➜ Cambiar a Slowbro y usar Bostezo frente a Mismagius ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Cascada a Skarmory)🔔",
-          "variant": []
-        },
+          "detail": "Usa 🪨 Trampa Rocas 🪨 frente a Mienshao. Luego cambia a Gengar y espera a que Mienshao se debilite solo.",
+          "variant": [
+            {
+              "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Walrein o Dewgong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si no tiene Vidasfera, Slowbro usa Bostezo frente a Nidoking.",
+      "variant": [
         {
-          "detail": "Walrein o Dewgong ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Cascada a Skarmory)🔔",
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Sin Vidasfera ➜ Slowbro usar Bostezo frente a Nidoking ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-      "variant": []
-    },
-    {
-      "detail": "Sin Precisión ➜ Cambiar a Chansey 🔔(Mira el Objeto)🔔",
+      "detail": "Si no tienes precisión, cambia a Chansey y revisa el objeto.",
       "variant": [
         {
-          "detail": "Vidasfera + Ida y Vuelta ➜ Trampa Rocas frente a Mienshao ➜ cambiar a Gengar y esperar a que se debilite solo",
+          "detail": "Si tiene Vidasfera y usa Ida y Vuelta, usa 🪨 Trampa Rocas 🪨 frente a Mienshao. Luego cambia a Gengar y espera a que se debilite solo.",
           "variant": [
             {
-              "detail": "Skarmory ➜ Cambiar a Slowbro y usar Bostezo frente a Mismagius ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Cascada a Skarmory)🔔",
+              "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
               "variant": []
             },
             {
-              "detail": "Walrein o Dewgong ➜ Sacrificar a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Cascada a Skarmory)🔔",
+              "detail": "Si sale Walrein o Dewgong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
               "variant": []
-            }  
-          ]  
+            }
+          ]
         },
         {
-          "detail": "Cambio a Nidoking ➜ Trampa Rocas frente a Mienshao ➜ cambiar a Gengar y usar Maquinación para Barrer 🔔(Si no hay crítico no debilita)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Cambio a Mismagius ➜ Trampa Rocas frente a Mienshao ➜ cambiar a Gengar y esperar a que se debilite solo",
+          "detail": "Si cambia a Nidoking, usa 🪨 Trampa Rocas 🪨 frente a Mienshao. Luego cambia a Gengar y usa Maquinación para barrer.",
           "variant": [
             {
-              "detail": "Skarmory ➜ Cambiar a Slowbro y usar Bostezo frente a Mismagius ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Cascada a Skarmory)🔔",
+              "detail": "Si no hay golpe crítico, Gengar no debilita al rival.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si cambia a Mismagius, usa 🪨 Trampa Rocas 🪨 frente a Mienshao. Luego cambia a Gengar y espera a que se debilite solo.",
+          "variant": [
+            {
+              "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
               "variant": []
             },
             {
-              "detail": "Walrein o Dewgong ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Cascada a Skarmory)🔔",
+              "detail": "Si sale Walrein o Dewgong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
               "variant": []
             }
           ]
         }
-      ] 
+      ]
     }
-  ]  
-}  
+  ]
+}

--- a/src/data/hoenn/nivea/mismagius.json
+++ b/src/data/hoenn/nivea/mismagius.json
@@ -2,15 +2,34 @@
   "id": "mismagius",
   "name": "Mismagius",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Mienshao, cambia a Gengar Bola Sombra",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Skarmory ➜ Cambiar a Slowbro y usar Bostezo frente a Mismagius ➜ sacrificar a Politoed ➜ Poliwrath +6 🐸🥊🔔(Cascada a Skarmory)🔔",
-      "variant": []
+      "detail": "Frente a Mienshao.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar y usa Bola Sombra.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Walrein o Dewgong ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊🔔(Cascada a Skarmory)🔔",
-      "variant": []
+      "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Walrein o Dewgong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": [
+        {
+          "detail": "Usa Cascada contra Skarmory.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/nidoqueen.json
+++ b/src/data/hoenn/nivea/nidoqueen.json
@@ -2,22 +2,27 @@
   "id": "nidoqueen",
   "name": "Nidoqueen",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Metagross ➜ Cambiar a Slowbro, luego a Volcarona frente a Serperior ➜ Volcarona +2 🦋🔥",
+      "detail": "Si sale Metagross, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona frente a Serperior y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Mienshao, entra con Gengar, usa Otra Vez, Maquinación hasta +2 y barre con Bola Sombra.",
       "variant": []
     },
     {
-      "detail": "Mienshao ➜ Gengar Otra Vez +2 🔔(Barrer con Bola Sombra)🔔",
+      "detail": "Si sale Gallade, entra con Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
       "variant": []
     },
     {
-      "detail": "Gallade ➜ Gengar +4 (No usar Otra Vez) 🔔(Barrer con Bola Sombra)🔔",
-      "variant": []
-    },
-    {
-      "detail": "beartic ➜ Gengar Otra Vez +4 🔔(Barrer con Bola Sombra)🔔",
+      "detail": "Si sale Beartic, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y barre con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/nivea/serperior.json
+++ b/src/data/hoenn/nivea/serperior.json
@@ -2,6 +2,16 @@
   "id": "serperior",
   "name": "Serperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 frente a Metagross ➜ cambiar a Slowbro y luego a Volcarona ➜ entra Serperior ➜ Volcarona x2 danza aleteo (serperior no te mata)",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Metagross.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y luego entra con Volcarona. Frente a Serperior, usa Danza Aleteo x2. Serperior no debilita a Volcarona.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/nivea/skarmory.json
+++ b/src/data/hoenn/nivea/skarmory.json
@@ -2,29 +2,45 @@
   "id": "skarmory",
   "name": "Skarmory",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 🔔(Si no cambia usa Amortiguador)",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Mienshao ➜ Cambiar a Gengar y atacar con Bola sombra",
+      "detail": "Si Skarmory no cambia, usa Amortiguador.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Mienshao, cambia a Gengar y usa Bola Sombra.",
       "variant": [
         {
-          "detail": "Skarmory ➜ Cambiar a Slowbro usar Bostezo frente a Mismagius ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊🔔(Cascada a Skarmory)🔔"
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Walrein o Dewgong ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Cascada a Skarmory)🔔"
+          "detail": "Si sale Walrein o Dewgong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+          "variant": []
         }
       ]
     },
     {
-      "detail": "Hariyama ➜ Slowbro usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño Hielo a Froslass)🔔",
+      "detail": "Si sale Hariyama, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Gallade, entra con Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
       "variant": []
     },
     {
-      "detail": "Gallade ➜ Gengar +4 (No usar Otra Vez) 🔔(Barrer con Bola Sombra)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Beartic ➜ Gengar Otra Vez +4 🔔(Barrer con Bola Sombra)🔔",
+      "detail": "Si sale Beartic, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y barre con Bola Sombra.",
       "variant": []
     }
   ]

--- a/src/data/hoenn/nivea/togekiss.json
+++ b/src/data/hoenn/nivea/togekiss.json
@@ -2,6 +2,16 @@
   "id": "togekiss",
   "name": "Togekiss",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Metagross ➜ cambiar a Slowbro, luego a Volcarona frente a Serperior ➜ Volcarona +2 🔔(Serperior no mata a Volcarona)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Metagross.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro. Luego entra con Volcarona frente a Serperior y usa Danza Aleteo x2. Serperior no debilita a Volcarona.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/nivea/vanilluxe.json
+++ b/src/data/hoenn/nivea/vanilluxe.json
@@ -2,11 +2,16 @@
   "id": "vanilluxe",
   "name": "Vanilluxe",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Gallade ➜ Gengar Otra Vez 2+2 + Precisión X (no tiene banda focus) 🔔(Onda Certera a Empoleon/Walrein o Dewgong)🔔",
-      "variant": []
+      "detail": "Si sale Gallade, entra con Gengar, usa Otra Vez, Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Gallade no tiene Banda Focus.",
+      "variant": [
+        {
+          "detail": "Usa Onda Certera contra Empoleon, Walrein o Dewgong.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/nivea/walrein.json
+++ b/src/data/hoenn/nivea/walrein.json
@@ -32,7 +32,7 @@
               "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
               "variant": [
                 {
-                  "detail": "Testeo: si entra Lanturn, probablemente usa Voltiocambio. Usa Bostezo otra vez.",
+                  "detail": "Nota: si entra Lanturn, probablemente usa Voltiocambio. Usa Bostezo otra vez.",
                   "variant": []
                 }
               ]
@@ -41,7 +41,7 @@
               "detail": "Si sale Walrein o Dewgong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
               "variant": [
                 {
-                  "detail": "Testeo: si entra Lanturn, probablemente usa Voltiocambio. Usa Bostezo otra vez.",
+                  "detail": "Nota: si entra Lanturn, probablemente usa Voltiocambio. Usa Bostezo otra vez.",
                   "variant": []
                 }
               ]

--- a/src/data/hoenn/nivea/walrein.json
+++ b/src/data/hoenn/nivea/walrein.json
@@ -2,58 +2,82 @@
   "id": "walrein",
   "name": "Walrein",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Superdiente ➜ Amortiguador frente a Hariyama ➜ Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño Hielo a Froslass)🔔",
+      "detail": "Si usa Superdiente, usa Amortiguador frente a Hariyama.",
       "variant": [
         {
-          "detail": "Mantiene Superdiente ➜ Cambiar a Gengar Otra Vez 4+2 + Precisión X 🔔(Si te Bloquean Bola Sombra, Barre con Onda Certera)🔔",
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass.",
           "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Mienshao ➜ Cambiar a Gengar otra vez +2",
-      "variant": [
+        },
         {
-          "detail": "Mismagius ➜ Bola Sombra para Debilitar",
+          "detail": "Si mantiene Superdiente, cambia a Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X.",
           "variant": [
-             {
-               "detail": "Sale Skarmory ➜ Cambiar a Slowbro usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Cascada a Skarmory // 👾(TESTEO)👾 Si entra Lanturn va usar Voltiocambio, usar Bostezo otra vez)🔔",
-               "variant": []
-             },
-             {
-               "detail": " Walrein o Dewgong ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Cascada a Skarmory // 👾(TESTEO)👾 Si entra Lanturn va usar Voltiocambio, usar Bostezo otra vez)🔔",
-               "variant": []  
-            }  
-          ] 
-        },  
+            {
+              "detail": "Si te bloquean Bola Sombra, barre con Onda Certera.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Mienshao, cambia a Gengar, usa Otra Vez y Maquinación hasta +2.",
+      "variant": [
         {
-          "detail": " Walrein o Dewgong ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Cascada a Skarmory)🔔",
+          "detail": "Si sale Mismagius, usa Bola Sombra para debilitarlo.",
+          "variant": [
+            {
+              "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+              "variant": [
+                {
+                  "detail": "Testeo: si entra Lanturn, probablemente usa Voltiocambio. Usa Bostezo otra vez.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Walrein o Dewgong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
+              "variant": [
+                {
+                  "detail": "Testeo: si entra Lanturn, probablemente usa Voltiocambio. Usa Bostezo otra vez.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Walrein o Dewgong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Skarmory.",
           "variant": []
         },
         {
-          "detail": "Skarmory ➜ Cambiar a Slowbro y usar Bostezo frente a Mismagius ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊",
+          "detail": "Si sale Skarmory, cambia a Slowbro y usa Bostezo frente a Mismagius. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Glalie/altaria ➜ Barrer con Bola Sombra",
+          "detail": "Si sale Glalie o Altaria, barre con Bola Sombra.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Gallade ➜ Gengar +4 (No usar Otra Vez) 🔔(Barrer con Bola Sombra)🔔",
+      "detail": "Si sale Gallade, entra con Gengar, usa Maquinación hasta +4 y barre con Bola Sombra. No uses Otra Vez.",
       "variant": []
     },
     {
-      "detail": "Beactric ➜ Gengar Otra Vez +4 🔔(Barrer con Bola Sombra)🔔",
+      "detail": "Si sale Beartic, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y barre con Bola Sombra.",
       "variant": []
     },
     {
-      "detail": "Metagross  ➜ Cambiar a Slowbro ➜ entra Serperior cambia a Volcarona +2 🦋🔥",
-      "variant": []
+      "detail": "Si sale Metagross, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Cuando entre Serperior, cambia a Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Completes the Hoenn Nivea Spanish strategy structure cleanup.
- Keeps `initialMove` as the opening action only.
- Moves route follow-up steps into `tricks.detail` and nested `variant` entries.
- Replaces old Politoed sacrifice wording with pivot wording.
- Expands shorthand setup text such as Gengar boosts, Volcarona setup, and Poliwrath setup into clear Spanish.
- Fixes incomplete nested variant entries in long routes such as Lanturn, Mienshao, Skarmory, and Walrein.

## Scope
- Hoenn Nivea strategy JSON files only.
- No English translation changes.
- No asset changes.
- No frontend layout changes.

## Notes
- English translations are intentionally left for the final global translation pass.