### PR TITLE
Clean Hoenn Dracon Spanish strategy structure

### DIFF
--- a/src/data/hoenn/dracon/aggron.json
+++ b/src/data/hoenn/dracon/aggron.json
@@ -2,6 +2,16 @@
   "id": "aggron",
   "name": "Aggron",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Encanto; Amortiguador y Frente a Gallade(banda focus) Gengar Otra vez +4 (Bola Sombra a todo) 💡",
-  "tricks": []
+  "initialMove": "Usa Encanto.",
+  "tricks": [
+    {
+      "detail": "Usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Frente a Gallade con Banda Focus, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/dracon/altaria.json
+++ b/src/data/hoenn/dracon/altaria.json
@@ -2,6 +2,16 @@
   "id": "altaria",
   "name": "Altaria",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 frente a Lucario ➜ Gengar +4 ⚫ Bola Sombra a todo ⚫",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Lucario.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/dracon/ampharos.json
+++ b/src/data/hoenn/dracon/ampharos.json
@@ -2,46 +2,56 @@
   "id": "ampharos",
   "name": "Ampharos",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Haxorus ➜ Gengar Otra vez +2 ataca hasta que aparesca Lucario, sacrifica a Politoed, Poliwrath +6 🔔(Puño Drenaje a Ampharos)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ Cambiar a Gengar para ver el movimiento",
+      "detail": "Si sale Haxorus, entra con Gengar, usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Patada Salto Alta ➜ ⬇️Opción para resolver⬇️",
+          "detail": "Ataca hasta que aparezca Lucario. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lucario, cambia a Gengar para revisar el movimiento.",
+      "variant": [
+        {
+          "detail": "Si usa Patada Salto Alta, elige una ruta para resolver.",
           "variant": [
             {
-              "detail": "🚨Arriesgar🚨 ➜ Maquinación y barrer directamente ",
+              "detail": "Ruta arriesgada: usa Maquinación y barre directamente.",
               "variant": []
             },
             {
-              "detail": "✅Seguro✅ ➜ Cambiar a Slowbro, luego a Chansey y volver a Gengar",
+              "detail": "Ruta segura: cambia a Slowbro, luego a Chansey y vuelve a Gengar.",
               "variant": [
                 {
-                  "detail": "Haxorus ➜ Gengar +2 ataca hasta que aparesca Lucario, sacrifica a Politoed, Poliwrath +6 🔔(Puño Drenaje a Ampharos)🔔",
+                  "detail": "Si sale Haxorus, Gengar usa Maquinación hasta +2 y ataca hasta que aparezca Lucario. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
                   "variant": []
                 },
                 {
-                  "detail": "Lucario ➜ Sacrificar a Politoed; Poliwrath +6 🔔(Puño Drenaje a Ampharos)🔔",
+                  "detail": "Si sale Lucario, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
                   "variant": []
-                }  
-              ]  
-            } 
-          ]  
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "A Bocajarro ➜ Gengar +4 🔔(Bola Sombra a todo)🔔",
+          "detail": "Si usa A Bocajarro, Gengar usa Maquinación hasta +4 y barre con Bola Sombra.",
           "variant": []
-        }  
-      ] 
+        }
+      ]
     },
     {
-      "detail": "Feraligatr ➜ Cambiar a Slowbro y usar Bostezo frente a Sceptile, Volcarona +3 🔔(Mantener PS por encima del 75%)🔔",
-      "variant": []
+      "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/eelektross.json
+++ b/src/data/hoenn/dracon/eelektross.json
@@ -5,12 +5,17 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Puño Drenaje ➜ Gengar +4 +2 🔔Bola Sombra a todo🔔",
+      "detail": "Si usa Puño Drenaje, entra con Gengar, usa Maquinación hasta +4, Velocidad X para +2 Velocidad y barre con Bola Sombra.",
       "variant": []
     },
     {
-      "detail": "Fuerza Bruta ➜ Amortiguador y esperar a Gallade ➜ Gengar +4 + Otra Vez",
-      "variant": []
+      "detail": "Si usa Fuerza Bruta, usa Amortiguador y espera a Gallade.",
+      "variant": [
+        {
+          "detail": "Luego entra con Gengar, usa Otra Vez, Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/empoleon.json
+++ b/src/data/hoenn/dracon/empoleon.json
@@ -2,6 +2,16 @@
   "id": "empoleon",
   "name": "Empoleon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 frente a Gallade; cambiar a Slowbro y usar Bostezo frente a Empoleon ➜ sacrifica a Politoed ➜ Poliwrath +6",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Gallade.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo frente a Empoleon. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/dracon/feraligatr.json
+++ b/src/data/hoenn/dracon/feraligatr.json
@@ -2,24 +2,29 @@
   "id": "feraligatr",
   "name": "Feraligatr",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Cascada ➜ Teletransporte para sacar a Slowbro y usar Bostezo",
+      "detail": "Si usa Cascada, usa Teletransporte hacia Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Triturar ➜ Sacrificar a Politoed; Poliwrath +6",
+          "detail": "Si usa Triturar, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Sceptile ➜ Volcarona +3 🔔(Mantener PS por encima del 75%)🔔",
+          "detail": "Si sale Sceptile, entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
           "variant": []
-        }  
-      ]  
+        }
+      ]
     },
     {
-      "detail": "Gallade/Roserade ➜ Sacrificar a Politoed; Slowbro mantiene Bostezo frente a Salamence ➜ Teletransporte para sacar a Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Gallade o Roserade, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Slowbro mantiene Bostezo frente a Salamence. Luego usa Teletransporte para entrar con Poliwrath 🐸🥊 y usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/floatzel.json
+++ b/src/data/hoenn/dracon/floatzel.json
@@ -2,15 +2,25 @@
   "id": "floatzel",
   "name": "Floatzel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Gallade --> Cambiar a Slowbro y usar Bostezo frente a Empoleon; sacrificar a Politoed; Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Gallade, cambia a Slowbro y usa Bostezo frente a Empoleon.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Feraligatr --> Cambiar a Slowbro y usar Bostezo frente a Sceptile; Volcarona +3 🔔(mantener PS por encima del 75%)🔔",
-      "variant": []
+      "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/flygon.json
+++ b/src/data/hoenn/dracon/flygon.json
@@ -2,6 +2,16 @@
   "id": "flygon",
   "name": "Flygon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 frente a Metagross; cambiar a Slowbro y usar Bostezo frente a Lapras; sacrificar a Politoed; Poliwrath +6",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Metagross.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo frente a Lapras. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/dracon/gallade.json
+++ b/src/data/hoenn/dracon/gallade.json
@@ -2,19 +2,34 @@
   "id": "gallade",
   "name": "Gallade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚 AMORTIGUADOR 🥚",
+  "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Espada Santa ➜ Gengar, Otra Vez, +4 +2 + Precisión + Otra Vez (🔔Tiene Banda Focus🔔)",
-      "variant": []
+      "detail": "Si usa Espada Santa, cambia a Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Usa Maquinación hasta +4, Velocidad X para +2 Velocidad, Precisión X y Otra Vez. Gallade tiene Banda Focus.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Lucario ➜ Gengar usa Maquinación y va entrar Haxorus cambiar a Chansey y luego volver a Gengar, Otra Vez, +4 + Otra Vez 🔔haxorus banda focus🔔",
-      "variant": []
+      "detail": "Si sale Lucario, Gengar usa Maquinación.",
+      "variant": [
+        {
+          "detail": "Cuando entre Haxorus, cambia a Chansey y luego vuelve a Gengar. Usa Otra Vez, Maquinación hasta +4 y Otra Vez. Haxorus tiene Banda Focus.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Haxorus ➜ Gengar, Otra Vez, +4 +2 + Otra Vez (🔔haxorus banda focus🔔)",
-      "variant": []
+      "detail": "Si sale Haxorus, cambia a Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Usa Maquinación hasta +4, Velocidad X para +2 Velocidad y Otra Vez. Haxorus tiene Banda Focus.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/haxorus.json
+++ b/src/data/hoenn/dracon/haxorus.json
@@ -2,6 +2,11 @@
   "id": "haxorus",
   "name": "Haxorus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻 Gengar +4 +2 Bola Sombra a todos 👻",
-  "tricks": []
+  "initialMove": "Cambia a Gengar 👻.",
+  "tricks": [
+    {
+      "detail": "Usa Maquinación hasta +4, Velocidad X para +2 Velocidad y barre con Bola Sombra.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/hoenn/dracon/kingdra.json
+++ b/src/data/hoenn/dracon/kingdra.json
@@ -2,7 +2,16 @@
   "id": "kingdra",
   "name": "Kingdra",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Amortiguador frente a Gallade ➜ Gengar otra vez +4 ⚠️Gallade banda focus⚠️ (Bola Sombra a todo)💡",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Frente a Gallade.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Otra Vez, Maquinación hasta +4 y barre con Bola Sombra. Gallade tiene Banda Focus.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }
- 

--- a/src/data/hoenn/dracon/krookodile.json
+++ b/src/data/hoenn/dracon/krookodile.json
@@ -2,6 +2,16 @@
   "id": "krookodile",
   "name": "Krookodile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 Gengar +4 +2 + Precisión X (No usar Otra Vez) usar ataques supereficaces 🐊 ",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Entra con Gengar, usa Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. No uses Otra Vez.",
+      "variant": [
+        {
+          "detail": "Usa ataques súper eficaces para cerrar la ruta.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/dracon/lapras.json
+++ b/src/data/hoenn/dracon/lapras.json
@@ -26,7 +26,7 @@
               "detail": "Ruta segura: cambia a Slowbro, luego a Chansey y vuelve a Gengar.",
               "variant": [
                 {
-                  "detail": "Si sale Haxorus, Gengar usa Otra Vez y Maquinación hasta +2. Ataca hasta Lucario, luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "detail": "Si sale Haxorus, Gengar usa Otra Vez y Maquinación hasta +2. Ataca hasta que aparezca Lucario, luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
                   "variant": []
                 },
                 {
@@ -40,7 +40,7 @@
       ]
     },
     {
-      "detail": "Si sale Haxorus, Gengar usa Maquinación hasta +2 y ataca hasta Lucario.",
+      "detail": "Si sale Haxorus, Gengar usa Maquinación hasta +2 y ataca hasta que aparezca Lucario.",
       "variant": [
         {
           "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",

--- a/src/data/hoenn/dracon/lapras.json
+++ b/src/data/hoenn/dracon/lapras.json
@@ -2,51 +2,69 @@
   "id": "lapras",
   "name": "Lapras",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 (Si Lapras se queda, usa Amortiguador)",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Lucario ➜ Cambiar a Gengar para ver el movimiento",
+      "detail": "Si Lapras se queda, usa Amortiguador.",
       "variant": []
     },
     {
-      "detail": "A Bocajarro ➜ Gengar +4  Bola Sombra a todo",
+      "detail": "Si sale Lucario, cambia a Gengar para revisar el movimiento.",
       "variant": [
-        
+        {
+          "detail": "Si usa A Bocajarro, Gengar usa Maquinación hasta +4 y barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Patada Salto Alta, elige una ruta para resolver.",
+          "variant": [
+            {
+              "detail": "Ruta arriesgada: usa Maquinación y barre directamente. La situación contra Lapras queda aleatoria.",
+              "variant": []
+            },
+            {
+              "detail": "Ruta segura: cambia a Slowbro, luego a Chansey y vuelve a Gengar.",
+              "variant": [
+                {
+                  "detail": "Si sale Haxorus, Gengar usa Otra Vez y Maquinación hasta +2. Ataca hasta Lucario, luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si sale Lucario, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
       ]
     },
     {
-      "detail": "Patada Salto Alta ➜ Opción para resolver",
-      "variant": []
-    },
-    {
-      "detail": "Arriesgar ➜ Maquinación y barrer directamente ➜ aleatorio contra Lapras",
-      "variant": []
-    },
-    {
-      "detail": "Seguro ➜ Cambiar a Slowbro, luego a Chansey y volver a Gengar",
-      "variant": []
-    },
-    {
-      "detail": "Haxorus ➜ Gengar otra vez +2 ➜ atacar hasta Lucario ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 ",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 Pueño drenaje a Ampharos",
+      "detail": "Si sale Haxorus, Gengar usa Maquinación hasta +2 y ataca hasta Lucario.",
       "variant": [
-        
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
       ]
     },
     {
-      "detail": "Haxorus ➜ Gengar +2 ➜ atacar  hasta Lucario ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Metagross, Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Metagross ➜ Slowbro usa Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-      "variant": []
-    },
-    {
-      "detail": "Eelektross / Regice ➜ Slowbro usa Bostezo frente a Nidoking ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Eelektross o Regice, Slowbro usa Bostezo frente a Nidoking.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/lucario.json
+++ b/src/data/hoenn/dracon/lucario.json
@@ -14,7 +14,7 @@
       ]
     },
     {
-      "detail": "Si usa Patada Salto Alta, Gengar usa Maquinación y Lucario cae.",
+      "detail": "Si usa Patada Salto Alta, Gengar usa Maquinación y debilita a Lucario.",
       "variant": [
         {
           "detail": "Frente a Haxorus, cambia a Chansey y luego vuelve a Gengar. Usa Otra Vez y Maquinación hasta +4. Haxorus tiene Banda Focus.",

--- a/src/data/hoenn/dracon/lucario.json
+++ b/src/data/hoenn/dracon/lucario.json
@@ -2,19 +2,34 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻 Cambiar a Gengar 👻",
+  "initialMove": "Cambia a Gengar 👻.",
   "tricks": [
     {
-      "detail": "A Bocajarro ➜ Otra Vez ➜ cambiar a Slowbro y usar Bostezo frente a Lapras ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si usa A Bocajarro, usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo frente a Lapras. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Patada Salto Alta ➜ Gengar Maquinación y lucario se muere ➜ frente a Haxorus ➜ cambiar a Chansey y luego  Gengar Otra vez +4 (Haxorus banda focus)",
-      "variant": []
+      "detail": "Si usa Patada Salto Alta, Gengar usa Maquinación y Lucario cae.",
+      "variant": [
+        {
+          "detail": "Frente a Haxorus, cambia a Chansey y luego vuelve a Gengar. Usa Otra Vez y Maquinación hasta +4. Haxorus tiene Banda Focus.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Metagross ➜ Cambiar a Slowbro, luego a Chansey frente a Lapras ➜ Trampa Rocas frente a Metagross ➜ cambiar a Slowbro y usar Bostezo ➜ sacrifica a Politoed; Poliwrath +6🐸🥊",
-      "variant": []
+      "detail": "Si sale Metagross, cambia a Slowbro y luego a Chansey frente a Lapras.",
+      "variant": [
+        {
+          "detail": "Usa 🪨 Trampa Rocas 🪨 frente a Metagross. Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
-}  
+}

--- a/src/data/hoenn/dracon/metagross.json
+++ b/src/data/hoenn/dracon/metagross.json
@@ -2,24 +2,28 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Metagross se queda ➜ Ver situación",
+      "detail": "Si Metagross se queda, revisa la situación.",
       "variant": []
     },
     {
-      "detail": "Si tiene Vidasfera y sube su ataque ➜ Chansey usa Teletransporte y cambia a Volcarona lanzallamas ➜ frente a Flygon ➜ Slowbro usa Bostezo ➜ sacrifica a Politoed; Poliwrath +6",
+      "detail": "Si tiene Vidasfera y sube su Ataque, Chansey usa Teletransporte hacia Volcarona.",
       "variant": [
         {
-          "detail": "Otras situaciones ➜ Slowbro usa Bostezo",
+          "detail": "Volcarona usa Lanzallamas. Frente a Flygon, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "En otras situaciones, Slowbro usa Bostezo.",
           "variant": [
             {
-              "detail": "Lapras / Nidoking ➜ Sacrifica a Politoed ➜ Poliwrath +6",
+              "detail": "Si sale Lapras o Nidoking, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             },
             {
-              "detail": "Salamence ➜ Protección y Bostezo frente a Nidoking ➜ sacrifica a Politoed ➜ Poliwrath +6",
+              "detail": "Si sale Salamence, usa Protección y Bostezo frente a Nidoking. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
@@ -27,25 +31,30 @@
       ]
     },
     {
-      "detail": "Eelektross / Regice ➜ Cambiar a Slowbro y usar Bostezo",
+      "detail": "Si sale Eelektross o Regice, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Nidoking ➜ Sacrifica a Politoed ➜ Poliwrath +6",
+          "detail": "Si sale Nidoking, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Salamence ➜ Protección y Bostezo frente a Nidoking ➜ sacrifica a Politoed ➜ Poliwrath +6",
+          "detail": "Si sale Salamence, usa Protección y Bostezo frente a Nidoking. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Lucario ➜ Gengar +4 🔔 Bola Sombra a todo🔔 ",
+      "detail": "Si sale Lucario, entra con Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
       "variant": []
     },
     {
-      "detail": "Feraligatr ➜ Cambiar a Slowbro y usar Bostezo frente a Sceptile ➜ Volcarona +3 🔔 (mantener PS por encima del 75%)🔔 ",
-      "variant": []
+      "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 75%.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/nidoking.json
+++ b/src/data/hoenn/dracon/nidoking.json
@@ -2,6 +2,16 @@
   "id": "nidoking",
   "name": "Nidoking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Amortiguador frente a Eelektross; Gengar, Otra Vez, +4 +2 (Bola Sombra a todo)👻",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Frente a Eelektross.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/dracon/regirock.json
+++ b/src/data/hoenn/dracon/regirock.json
@@ -2,15 +2,20 @@
   "id": "regirock",
   "name": "Regirock",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻 Cambiar a Gengar 👻",
+  "initialMove": "Cambia a Gengar 👻.",
   "tricks": [
     {
-      "detail": "Puño Drenaje --> Gengar +4 +2; 🔔Bola Sombra a todo🔔",
+      "detail": "Si usa Puño Drenaje, usa Maquinación hasta +4, Velocidad X para +2 Velocidad y barre con Bola Sombra.",
       "variant": []
     },
     {
-      "detail": "Eelektross --> Cambiar a Chansey y luego a Gengar +4 +2; 🔔Bola Sombra a todo🔔",
-      "variant": []
+      "detail": "Si sale Eelektross, cambia a Chansey y luego vuelve a Gengar.",
+      "variant": [
+        {
+          "detail": "Usa Maquinación hasta +4, Velocidad X para +2 Velocidad y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/salamence.json
+++ b/src/data/hoenn/dracon/salamence.json
@@ -2,68 +2,83 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔(Ver si tiene Intimidación)🔔",
+  "initialMove": "💡 Revisa si tiene Intimidación 💡",
   "tricks": [
     {
-      "detail": "Tiene Intimidación --> Amortiguador",
+      "detail": "Si tiene Intimidación, usa Amortiguador.",
       "variant": [
         {
-          "detail": "Feraligatr ➜ cambiar a Slowbro y usar Bostezo frente a Sceptile ➜ Volcarona +3 🔔(Puedes usar un Especial X)🔔 🚨(PS por encima del 75%)🚨",
+          "detail": "Si sale Feraligatr, cambia a Slowbro y usa Bostezo frente a Sceptile.",
+          "variant": [
+            {
+              "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Puedes usar Ataque Especial X. Mantén los PS por encima del 75%.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Gallade, entra con Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Gallade tiene Banda Focus.",
           "variant": []
         },
         {
-          "detail": "Gallade ➜  Gengar Otra Vez 4+2 + Precisión X 🔔gallade Tiene Banda focus🔔 ",
-          "variant": []
-        },
-        {
-          "detail": "Eelektross/Regice ➜ Gengar Otra Vez 4+2 🔔(Barre con Bola Sombra)🔔",
+          "detail": "Si sale Eelektross o Regice, entra con Gengar, usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y barre con Bola Sombra.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Sin Intimidación ➜ Trampa Rocas",
+      "detail": "Si no tiene Intimidación, usa 🪨 Trampa Rocas 🪨.",
       "variant": [
         {
-          "detail": "Lucario ➜ Cambiar a Gengar 🔔(Ver movimiento)🔔",
+          "detail": "Si sale Lucario, cambia a Gengar para revisar el movimiento.",
           "variant": [
             {
-              "detail": "A Bocajarro ➜ Gengar +4 🔔(Barre con Bola Sombra)🔔",
+              "detail": "Si usa A Bocajarro, Gengar usa Maquinación hasta +4 y barre con Bola Sombra.",
               "variant": []
             },
             {
-              "detail": "Patada Salto Alta ➜ ⬇️Opciónes para Resolver⬇️",
+              "detail": "Si usa Patada Salto Alta, elige una ruta para resolver.",
               "variant": [
                 {
-                  "detail": "🚨Arriesgar🚨 ➜ Maquinación y barrer directamente 🔔(Aleatorio contra Lapras)🔔",
+                  "detail": "Ruta arriesgada: usa Maquinación y barre directamente. La situación contra Lapras queda aleatoria.",
                   "variant": []
                 },
                 {
-                  "detail": "✅ Ruta Segura✅ ➜ Cambiar a Slowbro, luego a Chansey y volver a Gengar",
+                  "detail": "Ruta segura: cambia a Slowbro, luego a Chansey y vuelve a Gengar.",
                   "variant": [
                     {
-                      "detail": "Haxorus ➜ Gengar otra vez +2 y ataca hasta tener en frente a Lucario ➜ sacrifica a Politoed ➜ Poliwrath +6 🔔(Puño drenaje a Ampharos,Lucario Pañuelo elegido)🔔",
+                      "detail": "Si sale Haxorus, Gengar usa Otra Vez y Maquinación hasta +2. Ataca hasta tener a Lucario enfrente. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos. Lucario tiene Pañuelo Elegido.",
                       "variant": []
                     },
                     {
-                      "detail": "Lucario ➜ Sacrifica a Politoed ➜ Poliwrath +6 🔔(Puño drenaje a Ampharos)🔔",
+                      "detail": "Si sale Lucario, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos.",
                       "variant": []
                     }
                   ]
-                } 
-              ] 
-            } 
-          ]   
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Metagross ➜ Cambiar a Slowbro y usar Bostezo ➜ frente a Lapras ➜ sacrifica a Politoed ➜ Poliwrath +6 🔔(Si Metagross se queda, sigue con Bostezo)🔔",
-          "variant": []
+          "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo frente a Lapras.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Si Metagross se queda, sigue usando Bostezo.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Haxorus ➜ Gengar Otra vez +2 Ataca Hasta Tener en frente a Lucario ➜ sacrifica a Politoed ➜ Poliwrath +6 🔔(Puño drenaje a Ampharos, Lucario Pañuelo elegido)🔔",
-          "variant": []
-        } 
-      ]  
+          "detail": "Si sale Haxorus, Gengar usa Otra Vez y Maquinación hasta +2. Ataca hasta tener a Lucario enfrente.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Ampharos. Lucario tiene Pañuelo Elegido.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/sceptile.json
+++ b/src/data/hoenn/dracon/sceptile.json
@@ -2,6 +2,16 @@
   "id": "sceptile",
   "name": "Sceptile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Cambiar a Slowbro frente a Feraligatr; Bostezo frente a Sceptile; Volcarona +2 +x especial 💡 PS por encima del 75%",
-  "tricks": []
-}   
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Frente a Feraligatr, usa Bostezo frente a Sceptile.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Mantén los PS por encima del 75%.",
+          "variant": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/hoenn/dracon/seviper.json
+++ b/src/data/hoenn/dracon/seviper.json
@@ -2,15 +2,25 @@
   "id": "seviper",
   "name": "Seviper",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Metagross --> Cambiar a Slowbro y usar Bostezo frente a Lapras; sacrificar a Politoed; Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Metagross, cambia a Slowbro y usa Bostezo frente a Lapras.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Gallade--> Cambiar a Slowbro y usar Bostezo frente a Empoleon; sacrificar a Politoed; Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Gallade, cambia a Slowbro y usa Bostezo frente a Empoleon.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/dracon/torkoal.json
+++ b/src/data/hoenn/dracon/torkoal.json
@@ -2,14 +2,23 @@
   "id": "torkoal",
   "name": "Torkoal",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Encanto 💡 ❗ Arriesgar sacrificar a Politoed; Poliwrath +6❗",
+  "initialMove": "Usa Encanto.",
   "tricks": [
     {
-      "detail": "Fuerza Bruta --> Amortiguador; esperar a Gallade/Roserade; Gengar +2 +2 + Precisión (No usar Otra Vez)",
+      "detail": "Ruta arriesgada: entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Gallade --> Gengar +2 +2 + Precisión (No usar Otra Vez)",
+      "detail": "Si usa Fuerza Bruta, usa Amortiguador y espera a Gallade o Roserade.",
+      "variant": [
+        {
+          "detail": "Luego entra con Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Gallade, entra con Gengar, usa Maquinación hasta +4 y Precisión X. No uses Otra Vez.",
       "variant": []
     }
   ]


### PR DESCRIPTION
## Summary
- Completes the Hoenn Dracon Spanish strategy structure cleanup.
- Keeps `initialMove` as the opening action only.
- Moves route follow-up steps into `tricks.detail` and nested `variant` entries.
- Replaces old Politoed sacrifice wording with pivot wording.
- Expands shorthand setup text such as Gengar boosts, Volcarona setup, and Poliwrath setup into clear Spanish.
- Fixes long flat routes in Ampharos, Lapras, Metagross, and Salamence into nested readable routes.

## Scope
- Hoenn Dracon strategy JSON files only.
- No English translation changes.
- No asset changes.
- No frontend layout changes.

## Notes
- English translations are intentionally left for the final global translation pass.