### PR TITLE
Clean Hoenn Plubio Spanish strategy structure

### DIFF
--- a/src/data/hoenn/plubio/altaria.json
+++ b/src/data/hoenn/plubio/altaria.json
@@ -2,6 +2,21 @@
   "id": "altaria",
   "name": "Altaria",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚 Amortiguador frente a Eelektross; Gengar usa Otra Vez; cambiar a Slowbro y usar Bostezo frente a Altaria; cambiar a Chansey y esperar a Eelektross; Teletransporte; Slowbro usa Bostezo; sacrificar a Politoed; Poliwrath +6 🥚",
-  "tricks": []
-}   
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Frente a Eelektross, entra con Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo frente a Altaria. Luego cambia a Chansey para atraer a Eelektross, usa Teletransporte hacia Slowbro y vuelve a usar Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/hoenn/plubio/dragonite.json
+++ b/src/data/hoenn/plubio/dragonite.json
@@ -2,6 +2,11 @@
   "id": "dragonite",
   "name": "Dragonite",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💕🐸 Encanto; sacrificar a Politoed; Poliwrath +6 🐸💕",
-  "tricks": []
+  "initialMove": "Usa Encanto.",
+  "tricks": [
+    {
+      "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/eelektross.json
+++ b/src/data/hoenn/plubio/eelektross.json
@@ -2,79 +2,113 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 TRAMPA ROCAS 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": " Fuerza Bruta ➜ Gengar Otra Vez luego cambia a Slowbro",
+      "detail": "Si usa Fuerza Bruta, entra con Gengar y usa Otra Vez. Luego cambia a Slowbro.",
       "variant": [
-         {
-           "detail": "🍎 Milotic con Restos 🍎 ➜ Bostezo",
-           "variant": [
-              {
-                "detail": "Serperior ➜ Usa Proteccion, y vuelve a usar Bostezo → sacrifica al sapito y entra Poliwrath +6 🥊",
-                "variant": []
-              },
-              {
-                "detail": "Otro➜ Sacrifica al sapito despues entra Poliwrath +6 🥊",
-                "variant": []
-              }
-           ] 
-         },
-         {
-           "detail": " Milotic sin Restos ➜ Usa Bostezo 🔔(Si usa Escaldar sigue usando Bostezo)🔔",
-           "variant": [
-              {
-                "detail": "Poder Oculto Electrico ➜ Sacrifica al sapito y entra Poliwrath +6 🥊",
-                "variant": []
-              },
-              {
-                "detail": "Serperior➜ Usa Proteccion luego Bostezo frente a Eelektross despues sacrifica al sapito y entra Poliwrath +6 🥊",
-                "variant": []
-              },
-              {
-                "detail": "Eelektros ➜ Sacrifica al sapito despues entra Poliwrath +6 🥊",
-                "variant": []
-              },
-              {
-                "detail": " Altaria ➜ Usa Proteccion y Bostezo ",
-                "variant": [
-                  {
-                    "detail": "Eelektross ➜ Sacrifica al sapito y entra Poliwrath +6 🥊",
-                    "variant": []
-                  },  
-                  {
-                    "detail": "Gyarados ➜ 💊 Volcarona +1 y un Ataque Especial X 💊",
-                    "variant": []
-                  }   
-                ]   
-              } 
-           ]
-         },
-         {
-           "detail": "Swampert ➜ Bostezo frente a Altaria, Cambia a Chansey para atraer a Eelektross luego usa Teletransporte y saca a Slowbro, usa Bostezo despues sacrifica al sapito y entra Poliwrath +6 🥊",
-           "variant": []
-         },
-         {
-           "detail": "Gardevoir ➜ Bostezo luego sacrifica al sapito y entra Poliwrath +6 🥊",
-           "variant": []
-         },
-         {
-           "detail": "Mienshao ➜ Cambia a Gengar y usa Otra Vez, frente a Milotic sacrifica al sapito y entra Poliwrath +6 🥊",
-           "variant": []
-         },
-         { 
-           "detail": "Gengar atrapa a Eelektros en un ataque electrico ➜ 💊Cambia a Chansey y tomate una pocion max💊, cambia a Slowbro y usa Bostezo frente a Altaria, cambia a Chansey para atraer a Eelektross y luego usa Teletransporte, entra Slowbro y usa Bostezo despues sacrifica al sapito y entra Poliwrath +6 🥊",
-           "variant": []
-         } 
-      ]  
+        {
+          "detail": "Si sale Milotic con Restos, usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Serperior, usa Protección y vuelve a usar Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale otro Pokémon, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Milotic sin Restos, usa Bostezo. Si usa Escaldar, sigue usando Bostezo.",
+          "variant": [
+            {
+              "detail": "Si usa Poder Oculto Eléctrico, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Serperior, usa Protección y luego Bostezo frente a Eelektross. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Eelektross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Altaria, usa Protección y Bostezo.",
+              "variant": [
+                {
+                  "detail": "Si sale Eelektross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si sale Gyarados, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Swampert, usa Bostezo frente a Altaria. Cambia a Chansey para atraer a Eelektross, usa Teletransporte hacia Slowbro y vuelve a usar Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Gardevoir, usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Mienshao, cambia a Gengar y usa Otra Vez.",
+          "variant": [
+            {
+              "detail": "Frente a Milotic, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si Gengar encierra a Eelektross en un ataque eléctrico, cambia a Chansey y usa Max Poción.",
+          "variant": [
+            {
+              "detail": "Cambia a Slowbro y usa Bostezo frente a Altaria. Luego cambia a Chansey para atraer a Eelektross, usa Teletransporte hacia Slowbro y vuelve a usar Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Mienshao ➜ Cambia a Slowbro y usa Bostezo contra Serperior despues Teletransporte y saca a Volcarona +2 🔥",
-      "variant": []
+      "detail": "Si sale Mienshao, cambia a Slowbro y usa Bostezo contra Serperior.",
+      "variant": [
+        {
+          "detail": "Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Metagross ➜ Sacrifica al sapito y entra Poliwrath +6 🥊  🔔(Jugada Estable: Saca a Slowbro y usa Bostezo)🔔",
-      "variant": []
+      "detail": "Si sale Metagross, elige una ruta.",
+      "variant": [
+        {
+          "detail": "Ruta rápida: entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta estable: cambia a Slowbro y usa Bostezo.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/empoleon.json
+++ b/src/data/hoenn/plubio/empoleon.json
@@ -2,47 +2,72 @@
   "id": "empoleon",
   "name": "Empoleon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Terremoto --> Cambiar a Slowbro y usar Bostezo frente a Roserade; Volcarona +3 🔔(Antes de barrer mantener PS por encima del 70%)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Cascada --> Cambiar a Slowbro y usar Bostezo frente a Roserade; Teletransporte; Volcarona +1; presionar hasta Milotic, luego usar Danza Aleteo una vez y presionar dos veces a Milotic 🔔(Milotic Crítico o primero curar al máximo)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Escaldar --> Cambiar a Slowbro",
+      "detail": "Si usa Terremoto, cambia a Slowbro y usa Bostezo frente a Roserade.",
       "variant": [
         {
-          "detail": "Si se queda --> Bostezo frente a Roserade; Volcarona +4 🔔(Puedes tomar un Atk. Especial X)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Milotic --> Bostezo; sacrificar a Politoed; Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Roserade --> Volcarona +4 🔔(Puedes tomar un Atk. Especial X)🔔",
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Antes de barrer, mantén los PS por encima del 70%.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Milotic --> Cambiar a Slowbro y usar Bostezo frente a Roserade; Volcarona +4",
-      "variant": []
-    },
-    {
-      "detail": "Roserade --> Teletransporte",
+      "detail": "Si usa Cascada, cambia a Slowbro y usa Bostezo frente a Roserade.",
       "variant": [
         {
-          "detail": "Movimiento Planta --> Volcarona +4 🔔(Puedes tomar un Atk. Especial X)🔔",
+          "detail": "Usa Teletransporte hacia Volcarona y usa Danza Aleteo x1. Presiona hasta Milotic, luego usa Danza Aleteo una vez más y presiona dos veces a Milotic. Si Milotic hace crítico, primero cura al máximo.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si usa Escaldar, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Si Empoleon se queda, usa Bostezo frente a Roserade. Luego entra con Volcarona y usa Danza Aleteo x4. Puedes usar Ataque Especial X.",
           "variant": []
         },
         {
-          "detail": "Movimiento Veneno --> Slowbro usa Bostezo; sacrificar a Politoed; Poliwrath +6",
+          "detail": "Si sale Milotic, usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Roserade, entra con Volcarona y usa Danza Aleteo x4. Puedes usar Ataque Especial X.",
           "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Milotic, cambia a Slowbro y usa Bostezo frente a Roserade.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x4.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Roserade, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Si usa un movimiento de Planta, entra con Volcarona y usa Danza Aleteo x4. Puedes usar Ataque Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa un movimiento de Veneno, Slowbro usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/hoenn/plubio/gardevoir.json
+++ b/src/data/hoenn/plubio/gardevoir.json
@@ -2,41 +2,61 @@
   "id": "gardevoir",
   "name": "Gardevoir",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Vidasfera + Psicocarga --> Teletransporte; enviar a Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Sin Vidasfera + Psicocarga --> Teletransporte; Gengar usa un movimiento para caer debilitado",
+      "detail": "Si tiene Vidasfera y usa Psicocarga, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Whiscash --> Opción para resolver",
+          "detail": "Envía a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si no tiene Vidasfera y usa Psicocarga, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Gengar usa un movimiento para quedar debilitado.",
           "variant": [
             {
-              "detail": "✅Seguro✅ --> Slowbro usa Bostezo frente a Roserade; sacrificar a Politoed; Poliwrath +6",
+              "detail": "Si sale Whiscash, elige una ruta para resolver.",
+              "variant": [
+                {
+                  "detail": "Ruta segura: Slowbro usa Bostezo frente a Roserade. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                },
+                {
+                  "detail": "Ruta arriesgada: entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Milotic, Slowbro usa Bostezo frente a Roserade. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             },
             {
-              "detail": "🚨Arriesgar🚨 --> Sacrificar a Politoed; Poliwrath +6",
-              "variant": []
-            } 
-          ]  
-       },
-       {
-         "detail": "Milotic --> Slowbro usa Bostezo frente a Roserade; sacrificar a Politoed; Poliwrath +6",
-         "variant": []
-       },
-       {
-         "detail": "Togekiss --> Onda Certera y sacrificar; 💊Slowbro toma defensa especial X💊 y usa Bostezo frente a Roserade; sacrificar a Politoed; Poliwrath +6",
-         "variant": []
-       }  
-      ]   
+              "detail": "Si sale Togekiss, usa Onda Certera y deja que Gengar quede debilitado.",
+              "variant": [
+                {
+                  "detail": "Slowbro usa Defensa Especial X y Bostezo frente a Roserade. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Eelektross --> Gengar usa Otra Vez; cambiar a Slowbro; usar Bostezo; sacrificar a Politoed; Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/gyarados.json
+++ b/src/data/hoenn/plubio/gyarados.json
@@ -2,6 +2,21 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Amortiguador frente a Eelektross; Gengar usa Otra Vez; cambiar a Slowbro y usar Bostezo frente a Altaria; cambiar a Chansey y esperar a Eelektross; Teletransporte; Slowbro usa Bostezo; sacrificar a Politoed; Poliwrath +6 💡",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Frente a Eelektross, entra con Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo frente a Altaria. Luego cambia a Chansey para atraer a Eelektross, usa Teletransporte hacia Slowbro y vuelve a usar Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/lanturn.json
+++ b/src/data/hoenn/plubio/lanturn.json
@@ -5,64 +5,89 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Si se queda --> Aguantar con boosts de SpDef + Amortiguador dos veces",
+      "detail": "Si Lanturn se queda, aguanta con Defensa Especial X y Amortiguador dos veces.",
       "variant": [
         {
-          "detail": "Si se queda --> Teletransporte; Gengar usa Bola Sombra; ver daño",
+          "detail": "Si sigue en campo, usa Teletransporte hacia Gengar y usa Bola Sombra para revisar el daño.",
           "variant": [
             {
-              "detail": "Más del 40% (Crítico 60%) --> Sacrificar a Politoed; Slowbro usa Bostezo; Teletransporte; Poliwrath +6",
+              "detail": "Si hace más del 40% de daño, o 60% con crítico, entra Politoed como pivote. Luego Slowbro usa Bostezo, usa Teletransporte y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             },
             {
-              "detail": "Menos del 35% (Crítico 52%) --> Maquinación",
+              "detail": "Si hace menos del 35% de daño, o 52% con crítico, usa Maquinación.",
               "variant": [
                 {
-                  "detail": "Gengar no muere → derrota con Bola Sombra, sale Togekiss / Roserade → Chansey, vuelta a empezar",
+                  "detail": "Si Gengar no cae, derrota con Bola Sombra. Si sale Togekiss o Roserade, cambia a Chansey y reinicia la ruta.",
                   "variant": []
                 },
                 {
-                  "detail": "Gengar muere → Volcarona +3 (antes de empezar a barrer, PS por encima del 75%)",
+                  "detail": "Si Gengar cae, entra con Volcarona y usa Danza Aleteo x3. Antes de empezar a barrer, mantén los PS por encima del 75%.",
                   "variant": []
                 }
               ]
             },
             {
-              "detail": "Giros inesperados → guiarse con las opciones inferiores",
+              "detail": "Si aparece un giro inesperado, guíate por las opciones inferiores.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Dragonite --> Encanto; sacrificar a Politoed; Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Regice / Registeel --> Sacrificar a Politoed; Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Milotic --> Teletransporte; enviar a Slowbro; Bostezo frente a Roserade; Volcarona +4",
-          "variant": []
-        },
-        {
-          "detail": "Empoleon --> Cambiar a Slowbro y usar Bostezo frente a Roserade; Volcarona +3; 🔔 PS por encima del 70% 🔔",
-          "variant": []
-        },
-        {
-          "detail": "Gardevoir --> Teletransporte; enviar a Slowbro; Bostezo; sacrificar a Politoed; Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Roserade --> Teletransporte para ver movimiento",
+          "detail": "Si sale Dragonite, usa Encanto.",
           "variant": [
             {
-              "detail": "Movimiento Planta --> Volcarona +4",
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Regice o Registeel, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Milotic, usa Teletransporte hacia Slowbro y usa Bostezo frente a Roserade.",
+          "variant": [
+            {
+              "detail": "Luego entra con Volcarona y usa Danza Aleteo x4.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Empoleon, cambia a Slowbro y usa Bostezo frente a Roserade.",
+          "variant": [
+            {
+              "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Mantén los PS por encima del 70%.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Gardevoir, usa Teletransporte hacia Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Roserade, usa Teletransporte para revisar el movimiento.",
+          "variant": [
+            {
+              "detail": "Si usa un movimiento de Planta, entra con Volcarona y usa Danza Aleteo x4.",
               "variant": []
             },
             {
-              "detail": "Movimiento Veneno --> Slowbro usa Bostezo; sacrificar a Politoed; Poliwrath +6",
-              "variant": []
+              "detail": "Si usa un movimiento de Veneno, Slowbro usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             }
           ]
         }

--- a/src/data/hoenn/plubio/ludicolo.json
+++ b/src/data/hoenn/plubio/ludicolo.json
@@ -2,6 +2,16 @@
   "id": "ludicolo",
   "name": "Ludicolo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Teletransporte; enviar a Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6 💡",
-  "tricks": []
+  "initialMove": "Usa Teletransporte.",
+  "tricks": [
+    {
+      "detail": "Envía a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/metagross.json
+++ b/src/data/hoenn/plubio/metagross.json
@@ -2,6 +2,16 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔 sacrificar a Politoed; Poliwrath +6 🔔 Si Poliwrath muere, Gengar +4 +2 🔔",
-  "tricks": []
+  "initialMove": "Entra Politoed como pivote.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": [
+        {
+          "detail": "Si Poliwrath cae, entra con Gengar, usa Maquinación hasta +4, Velocidad X para +2 Velocidad y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/mienshao.json
+++ b/src/data/hoenn/plubio/mienshao.json
@@ -2,6 +2,16 @@
   "id": "mienshao",
   "name": "Mienshao",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔🐸Cambiar a Slowbro y usar Bostezo frente a Serperior; Teletransporte; Volcarona +2🐸🔔",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo frente a Serperior.",
+      "variant": [
+        {
+          "detail": "Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/milotic.json
+++ b/src/data/hoenn/plubio/milotic.json
@@ -5,47 +5,47 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Si se queda --> Ver movimiento",
+      "detail": "Si Milotic se queda, revisa el movimiento.",
       "variant": [
         {
-          "detail": "Surf / Hidrobomba ➜ Teletransporte ➜ Slowbro y usar Bostezo",
+          "detail": "Si usa Surf o Hidrobomba, usa Teletransporte hacia Slowbro y usa Bostezo.",
           "variant": [
             {
-              "detail": "Roserade ➜ Volcarona +4 🦋🔥",
+              "detail": "Si sale Roserade, entra con Volcarona y usa Danza Aleteo x4.",
               "variant": []
             },
             {
-              "detail": "Ludicolo ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
+              "detail": "Si sale Ludicolo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Rayo Hielo ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
+          "detail": "Si usa Rayo Hielo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Escaldar ➜ Teletransporte ➜ sacar a Slowbro y usar Bostezo (si no cambia usa Bostezo)",
+          "detail": "Si usa Escaldar, usa Teletransporte hacia Slowbro y usa Bostezo. Si Milotic no cambia, sigue usando Bostezo.",
           "variant": [
             {
-              "detail": "Serperior ➜ Usar Protección y Bostezo hasta que salga Lanturn ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
+              "detail": "Si sale Serperior, usa Protección y Bostezo hasta que salga Lanturn. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             },
             {
-              "detail": "Roserade ➜ Usar Teletransporte y revisar el objeto del rival:",
+              "detail": "Si sale Roserade, usa Teletransporte y revisa el objeto del rival.",
               "variant": [
                 {
-                  "detail": "Si lleva Vidasfera ➜ Entrar con Volcarona +1 + Especial X 🦋🔥",
+                  "detail": "Si lleva Vidasfera, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
                   "variant": []
                 },
                 {
-                  "detail": "Sin Vidasfera ➜ Entrar con Volcarona +2 + Especial X 🔔 que tu vida no baje del 70% 🔔",
+                  "detail": "Si no lleva Vidasfera, entra con Volcarona, usa Danza Aleteo x2 y Ataque Especial X. Mantén los PS por encima del 70%.",
                   "variant": []
                 }
               ]
             },
             {
-              "detail": "Gardevoir ➜ Sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
+              "detail": "Si sale Gardevoir, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
@@ -53,75 +53,105 @@
       ]
     },
     {
-      "detail": "Empoleon ➜ Poner Trampa Rocas para ver su movimiento:",
+      "detail": "Si sale Empoleon, usa 🪨 Trampa Rocas 🪨 para revisar su movimiento.",
       "variant": [
         {
-          "detail": "Cascada ➜ Cambiar a Slowbro y usar Bostezo frente a Roserade ➜ usar Teletransporte y entrar con Volcarona +1 para presionar hasta que salga Milotic ➜ entonces usa Danza Aleteo una vez y terminar de barrer",
+          "detail": "Si usa Cascada, cambia a Slowbro y usa Bostezo frente a Roserade. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1. Presiona hasta Milotic, usa Danza Aleteo una vez más y termina de barrer.",
           "variant": []
         },
         {
-          "detail": "Terremoto ➜ Cambiar a Slowbro y usar Bostezo hasta que salga Roserade ➜ usar Teletransporte y entrar con Volcarona +3 🦋🔥",
+          "detail": "Si usa Terremoto, cambia a Slowbro y usa Bostezo hasta que salga Roserade. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x3.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Eelektross ➜ Poner Trampas ➜ Gengar usa Otra Vez y cambiar a Slowbro frente a Milotic/Swampert ➜ usar Bostezo (si continúa usando Escaldar sigue con Bostezo hasta que cambie)",
+      "detail": "Si sale Eelektross, coloca 🪨 Trampa Rocas 🪨, Gengar usa Otra Vez y cambia a Slowbro frente a Milotic o Swampert.",
       "variant": [
         {
-          "detail": "Poder Oculto Eléctrico ➜ Sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
-          "variant": []
-        },
+          "detail": "Usa Bostezo. Si sigue usando Escaldar, mantén Bostezo hasta que cambie.",
+          "variant": [
+            {
+              "detail": "Si usa Poder Oculto Eléctrico, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Serperior, usa Protección y Bostezo hasta que salga Eelektross. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Altaria, usa Chansey para atraer a Eelektross, usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Eelektross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Gardevoir, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Metagross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": [
         {
-          "detail": "Serperior ➜ Usar Protección y Bostezo hasta que salga Eelektross ➜ luego sacrifica a Politoed y entrar con Poliwrath +6 🐸🥊",
-          "variant": []
-        },
-        {
-          "detail": "Altaria ➜ Usar a Chansey para atraer a Eelektross, usar Teletransporte ➜ Slowbro Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-          "variant": []
-        },
-        {
-          "detail": "Eelektross ➜ Sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
-          "variant": []
-        },
-        {
-          "detail": "Gardevoir ➜ Sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
+          "detail": "Si Poliwrath cae por crítico, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Metagross ➜ Sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
+      "detail": "Si sale Mienshao, cambia a Slowbro y usa Bostezo frente a Serperior.",
       "variant": [
         {
-          "detail": "Si Poliwrath muere por crítico ➜ Gengar Otra vez +4 +2",
+          "detail": "Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Mienshao ➜ Cambiar a Slowbro y usar Bostezo frente a Serperior ➜ Teletransporte ➜ Volcarona +2 🦋🔥",
+      "detail": "Si sale Regice o Registeel, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Regice / Registeel ➜ Sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Dragonite, usa Encanto.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Dragonite ➜ Encanto ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Gardevoir, usa Teletransporte hacia Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Gardevoir ➜ Teletransporte ➜ Slowbro Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Whiscash, usa Encanto.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Raíz Grande y Velocidad X.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Whiscash ➜ Encanto ➜ sacrifica a Politoed ➜ Poliwrath +6 + Raíz Grande + Velocidad X",
-      "variant": []
-    },
-    {
-      "detail": "Roserade ➜ Teletransporte ➜ Slowbro usa Bostezo ➜ Teletransporte ➜ Volcarona +1 + Especial X",
-      "variant": []
+      "detail": "Si sale Roserade, usa Teletransporte hacia Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1 y Ataque Especial X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/registeel.json
+++ b/src/data/hoenn/plubio/registeel.json
@@ -2,40 +2,50 @@
   "id": "registeel",
   "name": "Registeel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 TRAMPA ROCAS 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda ➜ Sacrifica al sapito y luego entra Poliwrath +6 🥊",
+      "detail": "Si Registeel se queda, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     },
     {
-      "detail": "Eelektross ➜ Gengar Otra Vez despues cambia a Slowbro, frente a Milotic/Swampert usa Bostezo 😴 (Si se queda haciendo Escaldar sigue usando Bostezo)",
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez y luego cambia a Slowbro.",
       "variant": [
-         {
-           "detail": "Poder Oculto Electrico ➜ Sacrifica al sapito y luego entra Poliwrath +6 🥊",
-           "variant": []
-         },
-         {    
-            "detail": "Altaria ➜ Cambia a Chansey para atraer a Eelektross, usa Teletransporte y entra Slowbro usa Bostezo luego sacrifica al sapito y entra Poliwrath +6 🥊",
-            "variant": []
-         },
-         {  
-            "detail": "Serperior ➜ Usa Proteccion y Bostezo, despues sacrifica al sapito y entra Poliwrath +6 🥊",
-            "variant": []
-         },
-         {  
-            "detail": "Eelektross ➜ Sacrifica al sapito y entra Poliwrath +6 🥊",
-            "variant": []
-         },
-         {       
-            "detail": "Gardevoir ➜ Sacrifica al sapito y entra Poliwrath +6 🥊",
-            "variant": []
-         } 
-      ]  
+        {
+          "detail": "Frente a Milotic o Swampert, usa Bostezo. Si se queda usando Escaldar, sigue usando Bostezo.",
+          "variant": [
+            {
+              "detail": "Si usa Poder Oculto Eléctrico, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Altaria, cambia a Chansey para atraer a Eelektross. Usa Teletransporte hacia Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Serperior, usa Protección y Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Eelektross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Gardevoir, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Mienshao ➜ Cambia a Slowbro y usa Bostezo contra Serperior, despues usa Teletransporte y entra Volcarona +1 🔥",
-      "variant": []
+      "detail": "Si sale Mienshao, cambia a Slowbro y usa Bostezo contra Serperior.",
+      "variant": [
+        {
+          "detail": "Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/roserade.json
+++ b/src/data/hoenn/plubio/roserade.json
@@ -5,60 +5,65 @@
   "initialMove": "🥚 Amortiguador 🥚",
   "tricks": [
     {
-      "detail": "Vidasfera + Lluevehojas / Bomba Lodo --> Teletransporte; Slowbro usa Bostezo; Teletransporte; 💊Volcarona +1 + Especial X💊",
-      "variant": []
-    },
-    {
-      "detail": "Sin Vidasfera + Lluevehojas --> Teletransporte",
+      "detail": "Si tiene Vidasfera y usa Lluevehojas o Bomba Lodo, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Si se queda --> Volcarona +4 🔔(Mantener PS por encima del 70%)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Gardevoir --> Slowbro usa Bostezo; sacrificar a Politoed; Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Milotic --> Slowbro usa Bostezo; sacrificar a Politoed; Poliwrath +6",
+          "detail": "Slowbro usa Bostezo. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1 y Ataque Especial X.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Sin Vidasfera + Bomba Lodo (Testeo) --> Teletransporte; Volcarona debilita 🔔(Ver quién sale)🔔",
+      "detail": "Si no tiene Vidasfera y usa Lluevehojas, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Milotic --> Cambiar a Chansey para ver movimiento",
+          "detail": "Si Roserade se queda, entra con Volcarona y usa Danza Aleteo x4. Mantén los PS por encima del 70%.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gardevoir, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Milotic, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si no tiene Vidasfera y usa Bomba Lodo, usa Teletransporte y entra con Volcarona para debilitar a Roserade.",
+      "variant": [
+        {
+          "detail": "Si sale Milotic, cambia a Chansey para revisar el movimiento.",
           "variant": [
             {
-              "detail": "Hidrobomba / Surf --> Teletransporte; Slowbro usa Bostezo frente a Ludicolo; sacrificar a Politoed; Poliwrath +6",
+              "detail": "Si usa Hidrobomba o Surf, usa Teletransporte hacia Slowbro y usa Bostezo frente a Ludicolo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             },
             {
-              "detail": "Escaldar --> Cambiar a Slowbro y usar Bostezo frente a Gardevoir; sacrificar a Politoed; Poliwrath +6",
+              "detail": "Si usa Escaldar, cambia a Slowbro y usa Bostezo frente a Gardevoir. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
-            }  
-          ]  
+            }
+          ]
         },
         {
-          "detail": "Togekiss --> Sacrificar a Volcarona; Slowbro aguanta + X SpDef y usa Bostezo; sacrificar a Politoed; Poliwrath +6",
+          "detail": "Si sale Togekiss, deja que Volcarona quede debilitada. Slowbro aguanta con Defensa Especial X y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Gardevoir --> Sacrificar a Volcarona; Slowbro usa Bostezo; sacrificar a Politoed; Poliwrath +6",
+          "detail": "Si sale Gardevoir, deja que Volcarona quede debilitada. Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Metagross --> Sacrificar a Politoed; Poliwrath +6",
+      "detail": "Si sale Metagross, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": [
         {
-          "detail": "☠️Si Poliwrath cae☠️ --> Gengar 4+2 🔔(Bola Sombra a Seaking)🔔",
+          "detail": "Si Poliwrath cae, entra con Gengar, usa Maquinación hasta +4, Velocidad X para +2 Velocidad y usa Bola Sombra contra Seaking.",
           "variant": []
         }
-      ]  
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/seaking.json
+++ b/src/data/hoenn/plubio/seaking.json
@@ -2,6 +2,21 @@
   "id": "seaking",
   "name": "Seaking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🐸 CAMBIA AL SAPITO LUEGO ENTRA METAGROSS Y DEJA QUE LO MATE DESPUES ENTRA POLIWRATH +6 🐸 🚨(SI MUERE POR CRITICO ENTRA GENGAR 4+2)🚨",
-  "tricks": []
+  "initialMove": "Cambia a Politoed.",
+  "tricks": [
+    {
+      "detail": "Luego entra Metagross y deja que lo debilite.",
+      "variant": [
+        {
+          "detail": "Después entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Si Poliwrath cae por crítico, entra con Gengar, usa Maquinación hasta +4, Velocidad X para +2 Velocidad y barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/serperior.json
+++ b/src/data/hoenn/plubio/serperior.json
@@ -2,28 +2,38 @@
   "id": "serperior",
   "name": "Serperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Lluevehojas --> Teletransporte 🔔(Ver cuánto aumenta su Ataque)🔔",
+      "detail": "Si usa Lluevehojas, usa Teletransporte y revisa cuánto aumenta su Ataque Especial.",
       "variant": [
         {
-          "detail": "+4 --> Enviar a Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6",
+          "detail": "Si llega a +4, envía a Slowbro y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "+2 --> 💊Volcarona +1 + Especial X💊",
+          "detail": "Si queda en +2, entra con Volcarona, usa Danza Aleteo x1 y Ataque Especial X.",
           "variant": []
-        }  
-      ]  
+        }
+      ]
     },
     {
-      "detail": "Mienshao --> Cambiar a Slowbro y usar Bostezo frente a Serperior; Teletransporte; Volcarona +2",
-      "variant": []
+      "detail": "Si sale Mienshao, cambia a Slowbro y usa Bostezo frente a Serperior.",
+      "variant": [
+        {
+          "detail": "Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Eelektross --> Gengar usa Otra Vez; cambiar a Slowbro frente a Milotic; usar Bostezo; sacrificar a Politoed; Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez y cambia a Slowbro frente a Milotic.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/starmie.json
+++ b/src/data/hoenn/plubio/starmie.json
@@ -2,6 +2,16 @@
   "id": "starmie",
   "name": "Starmie",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro y usa Bostezo contra Serperior, despues usa Teletransporte y saca a Volcarona +2 🔥",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo contra Serperior.",
+      "variant": [
+        {
+          "detail": "Después usa Teletransporte y entra con Volcarona para usar Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/swampert.json
+++ b/src/data/hoenn/plubio/swampert.json
@@ -2,6 +2,21 @@
   "id": "swampert",
   "name": "Swampert",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador frente a Eelektross ➜ Gengar usa Otra Vez ➜ cambiar a Slowbro usar  Bostezo frente a Altaria ➜ cambiar a Chansey y esperar a Eelektross ➜ Teletransporte ➜ Slowbro usa Bostezo ➜ sacrificar a Politoed ➜ 🐸🥊 Poliwrath +6🥚",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Frente a Eelektross, entra con Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo frente a Altaria. Luego cambia a Chansey para esperar a Eelektross, usa Teletransporte hacia Slowbro y vuelve a usar Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/tentacruel.json
+++ b/src/data/hoenn/plubio/tentacruel.json
@@ -2,11 +2,16 @@
   "id": "tentacruel",
   "name": "Tentacruel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 TRAMPA ROCAS 🪨,",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Eelektross ➜ Gengar Otra Vez despues cambia a Slowbro y usa Bostezo Frete Milotic ➜ sacrifica a Politoed ➜ Poliwrath +6 🥊",
-      "variant": []
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez y después cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo frente a Milotic. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/togekiss.json
+++ b/src/data/hoenn/plubio/togekiss.json
@@ -2,42 +2,57 @@
   "id": "togekiss",
   "name": "Togekiss",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Teletransporte 💡",
+  "initialMove": "Usa Teletransporte.",
   "tricks": [
     {
-      "detail": "Fallo al cambiar --> Ver daño; 🔔(Si no hay golpe, ver Roserade con Vidasfera para confirmar equipo)🔔",
+      "detail": "Si falla al cambiar, revisa el daño. Si no hay golpe, revisa si Roserade tiene Vidasfera para confirmar el equipo.",
       "variant": [
         {
-          "detail": "Golpe a Chansey (menos del 15%) --> Enviar a Slowbro; aguantar con + X SpDef; Bostezo frente a Roserade; Teletransporte; Volcarona +4 🔔(Mantener PS por encima del 70%)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Golpe a Chansey (más del 15%) --> Enviar a Slowbro; aguantar con + X SpDef; Bostezo frente a Roserade; Teletransporte; 💊Volcarona +1 + Especial X💊",
-          "variant": []
-        }  
-      ]  
-    },
-    {
-      "detail": "Poder Oculto --> Ver daño",
-      "variant": [
-        {
-          "detail": "Golpe a Chansey (menos del 20%) --> Gengar usa Otra Vez; cambiar a Slowbro frente a Milotic; usar Bostezo",
+          "detail": "Si el golpe a Chansey hace menos del 15%, envía a Slowbro y aguanta con Defensa Especial X.",
           "variant": [
             {
-              "detail": "Poder Oculto Eléctrico --> Sacrificar a Politoed; Poliwrath +6",
+              "detail": "Usa Bostezo frente a Roserade. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x4. Mantén los PS por encima del 70%.",
               "variant": []
-            },
-            { 
-              "detail": "Roserade --> Volcarona +4 🔔(Antes de barrer mantener PS por encima del 70%)🔔",
-              "variant": []
-            }  
-          ]   
+            }
+          ]
         },
         {
-          "detail": "Golpe a Chansey (más del 20%) --> Enviar a Slowbro; usar Bostezo frente a Roserade; Teletransporte; 💊Volcarona +1 + Especial X💊",
-          "variant": []
-        }  
-      ]  
+          "detail": "Si el golpe a Chansey hace más del 15%, envía a Slowbro y aguanta con Defensa Especial X.",
+          "variant": [
+            {
+              "detail": "Usa Bostezo frente a Roserade. Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1 y Ataque Especial X.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si usa Poder Oculto, revisa el daño.",
+      "variant": [
+        {
+          "detail": "Si el golpe a Chansey hace menos del 20%, Gengar usa Otra Vez y cambia a Slowbro frente a Milotic.",
+          "variant": [
+            {
+              "detail": "Usa Bostezo. Si usa Poder Oculto Eléctrico, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Roserade, entra con Volcarona y usa Danza Aleteo x4. Antes de barrer, mantén los PS por encima del 70%.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si el golpe a Chansey hace más del 20%, envía a Slowbro y usa Bostezo frente a Roserade.",
+          "variant": [
+            {
+              "detail": "Luego usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1 y Ataque Especial X.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/hoenn/plubio/wailord.json
+++ b/src/data/hoenn/plubio/wailord.json
@@ -2,6 +2,11 @@
   "id": "wailord",
   "name": "Wailord",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🐸 SACRIFICA AL SAPITO Y ENTRA POLIWRATH +6 🐸",
-  "tricks": []
+  "initialMove": "Entra Politoed como pivote.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/walrein.json
+++ b/src/data/hoenn/plubio/walrein.json
@@ -2,6 +2,21 @@
   "id": "walrein",
   "name": "Walrein",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🐸 CAMBIA AL SAPITO LUEGO ENTRA METAGROSS Y DEJA QUE LO MATE DESPUES ENTRA POLIWRATH +6 🐸 🚨(SI MUERE POR CRITICO ENTRA GENGAR 4+2)🚨",
-  "tricks": []
+  "initialMove": "Cambia a Politoed.",
+  "tricks": [
+    {
+      "detail": "Luego entra Metagross y deja que Walrein lo debilite.",
+      "variant": [
+        {
+          "detail": "Después entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Si Poliwrath cae por crítico, entra con Gengar, usa Maquinación hasta +4, Velocidad X para +2 Velocidad y barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/hoenn/plubio/whiscash.json
+++ b/src/data/hoenn/plubio/whiscash.json
@@ -2,6 +2,16 @@
   "id": "whiscash",
   "name": "Whiscash",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Encanto; sacrificar a Politoed; Poliwrath +6 + Raíz Grande +2 💡",
-  "tricks": []
+  "initialMove": "Usa Encanto.",
+  "tricks": [
+    {
+      "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": [
+        {
+          "detail": "Usa Raíz Grande y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Completes the Hoenn Plubio Spanish strategy structure cleanup.
- Keeps `initialMove` as the opening action only.
- Moves route follow-up steps into `tricks.detail` and nested `variant` entries.
- Replaces old Politoed sacrifice wording with pivot wording.
- Expands shorthand setup text such as Gengar boosts, Volcarona setup, and Poliwrath setup into clear Spanish.
- Fixes long flat routes in Eelektross, Empoleon, Gardevoir, Lanturn, Milotic, Registeel, Roserade, and Togekiss into nested readable routes.

## Scope
- Hoenn Plubio strategy JSON files only.
- No English translation changes.
- No asset changes.
- No frontend layout changes.

## Notes
- English translations are intentionally left for the final global translation pass.