### PR TITLE
Release Sinnoh Alecran Spanish structure cleanup

### DIFF
--- a/src/data/sinnoh/alecran/crustle.json
+++ b/src/data/sinnoh/alecran/crustle.json
@@ -2,6 +2,31 @@
   "id": "crustle",
   "name": "Crustle",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 al enfrentar a Skuntank ➜ sacrifica a Politoed ➜ cambiar a Volcarona luego a Gengar ➜ frente a Durant cambia a Slowbro y usa Bostezo luego Teletransporte ➜ entrar con Poliwrath +6 y usa Puño Drenaje ➜ 💊frente Crustle usar Velocidad X luego termina de Barrer💊",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Skuntank, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Cambia a Volcarona y luego a Gengar.",
+          "variant": [
+            {
+              "detail": "Frente a Durant, cambia a Slowbro y usa Bostezo. Luego usa Teletransporte.",
+              "variant": [
+                {
+                  "detail": "Entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y usa Puño Drenaje.",
+                  "variant": [
+                    {
+                      "detail": "Frente a Crustle, usa Velocidad X y termina de barrer.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/alecran/dustox.json
+++ b/src/data/sinnoh/alecran/dustox.json
@@ -8,11 +8,16 @@
       "detail": "Al enfrentar a Flygon, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-          "variant": []
+          "detail": "Si Flygon no cambia, usa Amortiguador.",
+          "variant": [
+            {
+              "detail": "Después continúa la ruta: entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Si Flygon no cambia, usa Amortiguador.",
+          "detail": "Si la ruta continúa normalmente, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/sinnoh/alecran/dustox.json
+++ b/src/data/sinnoh/alecran/dustox.json
@@ -2,6 +2,20 @@
   "id": "dustox",
   "name": "Dustox",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 al enfrentar a Flygon ➜ cambiar a Slowbro y usar Bostezo ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊 🔔(Si no Cambia usa Amortiguador)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Flygon, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Flygon no cambia, usa Amortiguador.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/alecran/heracross.json
+++ b/src/data/sinnoh/alecran/heracross.json
@@ -2,11 +2,21 @@
   "id": "heracross",
   "name": "Heracross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar Otra vez +2 y Bola Sombra 💡",
+  "initialMove": "Gengar usa Otra Vez.",
   "tricks": [
     {
-      "detail": "Drapion ➜ Cambia a Chansey usa Trampa Rocas al enfrentar a Durant ➜ entra con Gengar +4 (No usar Otra Vez) 🔔(Barrer con Bola Sombra)🔔",
-      "variant": []
+      "detail": "Luego Gengar usa Maquinación hasta +2 y Bola Sombra. 💡",
+      "variant": [
+        {
+          "detail": "Si sale Drapion, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 al enfrentar a Durant.",
+          "variant": [
+            {
+              "detail": "Después entra con Gengar y usa Maquinación hasta +4. No uses Otra Vez. Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/kabutops.json
+++ b/src/data/sinnoh/alecran/kabutops.json
@@ -2,49 +2,69 @@
   "id": "kabutops",
   "name": "Kabutops",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda ➜ Cambiar a Slowbro y usar Bostezo",
+      "detail": "Si Kabutops se queda, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Yanmega ➜ Sacrifica a Politoed y entrar con Poliwrath +6 🐸🥊",
+          "detail": "Si sale Yanmega, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Drapion ➜ Sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
+          "detail": "Si sale Drapion, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Ferrothorn ➜ Volcarona +2 🦋🔥 ",
+          "detail": "Si sale Ferrothorn, entra con Volcarona y usa Danza Aleteo x2. 🦋🔥",
           "variant": []
         },
         {
-          "detail": "Scizor ➜ Sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-          "variant": []  
-        }
-      ]
-    },
-    {
-      "detail": "Flygon ➜ Usar Teletransporte ➜ enviar a Slowbro  🔔(Revisar daño de Terremoto)🔔",
-      "variant": [
-        {
-          "detail": "29.4 - 34.5% (Crítico 43.7 - 51.7%) --> Usar Relajo para recibir Cometa Draco ➜ usa Bostezo al enfrentar a Yanmega ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-          "variant": []
-        },
-        {
-          "detail": "36.5 - 44% (Crítico 54 - 65%) ➜ Usa Bostezo hasta enfrentar a Drapion/Scizor ➜ sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
+          "detail": "Si sale Scizor, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Durant ➜ Entra con Gengar +4 (No usar Otra Vez) 🔔(Barrer con Bola Sombra)🔔",
-      "variant": []
+      "detail": "Si sale Flygon, usa Teletransporte y envía a Slowbro. Revisa el daño de Terremoto.",
+      "variant": [
+        {
+          "detail": "Si Terremoto hace 29.4 - 34.5%, o 43.7 - 51.7% con crítico, usa Relajo para recibir Cometa Draco.",
+          "variant": [
+            {
+              "detail": "Luego usa Bostezo al enfrentar a Yanmega. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si Terremoto hace 36.5 - 44%, o 54 - 65% con crítico, usa Bostezo hasta enfrentar a Drapion o Scizor.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Scizor ➜ Chansey usa Amortiguador esperando a Flygon ➜ cambia a Slowbro y usar Bostezo al enfrentar a Drapion ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Durant, entra con Gengar y usa Maquinación hasta +4. No uses Otra Vez.",
+      "variant": [
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Scizor, Chansey usa Amortiguador esperando a Flygon.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo al enfrentar a Drapion. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/omastar.json
+++ b/src/data/sinnoh/alecran/omastar.json
@@ -2,15 +2,25 @@
   "id": "omastar",
   "name": "Omastar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Escavalier ➜ Sacrificar a Politoed ➜ Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Escavalier, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Kingler ➜ Cambiar a Slowbro usa Bostezo ➜ frente a Sceptile entra con Volcarona +1 🦋🔥",
-      "variant": []
+      "detail": "Si sale Kingler, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Sceptile, entra con Volcarona y usa Danza Aleteo x1. 🦋🔥",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Releases the completed Sinnoh Alecrán Spanish strategy structure cleanup from `develop` to `main`.
- Publishes concise `initialMove` entries and nested route details.
- Includes the Codex feedback fix for the Dustox no-switch route.
- Keeps English translations untouched for the final global translation pass.

## Scope
- Release PR from `develop` to `main`.
- Sinnoh Alecrán strategy JSON files only.
- No asset changes.
- No frontend layout changes.

## Notes
- This publishes Alecrán to GitHub Pages for deploy review.