### PR TITLE
Fix remaining Sinnoh Alecran Spanish strategy structure

### DIFF
--- a/src/data/sinnoh/alecran/beautifly.json
+++ b/src/data/sinnoh/alecran/beautifly.json
@@ -2,11 +2,25 @@
   "id": "beautifly",
   "name": "Beautifly",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Slowbro y usa Bostezo ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊💡",
+  "initialMove": "Cambia a Slowbro y usa Bostezo.",
   "tricks": [
     {
-      "detail": "🔔Frente a Flygon ➜ usar Protección y Bostezo🔔",
-      "variant": []
+      "detail": "Luego entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Frente a Flygon, usa Protección y Bostezo.",
+      "variant": [
+        {
+          "detail": "Después continúa con la ruta de Poliwrath 🐸🥊 si corresponde.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/crawdaunt.json
+++ b/src/data/sinnoh/alecran/crawdaunt.json
@@ -2,6 +2,21 @@
   "id": "crawdaunt",
   "name": "Crawdaunt",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Usar Amortiguador luego usar 🪨Trampa Rocas🪨 frente a Durant entrar con Gengar +4 (No usar Otra Vez) 🔔(Barrer con Bola Sombra)🔔",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Luego usa 🪨 Trampa Rocas 🪨.",
+      "variant": [
+        {
+          "detail": "Frente a Durant, entra con Gengar y usa Maquinación hasta +4. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/alecran/drapion.json
+++ b/src/data/sinnoh/alecran/drapion.json
@@ -2,96 +2,190 @@
   "id": "drapion",
   "name": "Drapion",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda ➜ Identificar movimiento",
+      "detail": "Si Drapion se queda, identifica su movimiento.",
       "variant": [
         {
-          "detail": "Triturar ➜ Revisar daño",
+          "detail": "Si usa Triturar, revisa el daño.",
           "variant": [
             {
-              "detail": "15 - 18% (Crítico 33 - 40%) ➜ Usar Teletransporte",
+              "detail": "Si hace 15 - 18%, o 33 - 40% con crítico, usa Teletransporte.",
               "variant": [
                 {
-                  "detail": "Si se queda ➜ Enviar a Politoed y espera que lo debiliten ➜ entra con Poliwrath +6 🐸🥊",
-                  "variant": []
+                  "detail": "Si Drapion se queda, envía a Politoed como pivote y espera que lo debiliten.",
+                  "variant": [
+                    {
+                      "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": []
+                    }
+                  ]
                 },
                 {
-                  "detail": "Flygon ➜ Slowbro usa Relajo para recibir Cometa Draco ➜ usar Bostezo al enfrentar a Yanmega ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-                  "variant": []
+                  "detail": "Si sale Flygon, Slowbro usa Relajo para recibir Cometa Draco.",
+                  "variant": [
+                    {
+                      "detail": "Luego usa Bostezo al enfrentar a Yanmega. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": []
+                    }
+                  ]
                 },
                 {
-                  "detail": "Kabutops ➜ Slowbro usa Bostezo al enfrentar a Flygon ➜ usar Protección y Bostezo al enfrentar a Yanmega ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-                  "variant": []
+                  "detail": "Si sale Kabutops, Slowbro usa Bostezo al enfrentar a Flygon.",
+                  "variant": [
+                    {
+                      "detail": "Luego usa Protección y Bostezo al enfrentar a Yanmega. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": []
+                    }
+                  ]
                 }
               ]
             },
             {
-              "detail": "19 - 23% (Crítico 43 - 51%) ➜ Chansey usa Encanto y Amortiguador esperando a Tyranitar ➜ sacrificar a Politoed ➜ entrar con Poliwrath y usa un Ataque X para Barrer 🔔(Cascada a Drapion y Puño Drenaje a Volcarona)🔔",
+              "detail": "Si hace 19 - 23%, o 43 - 51% con crítico, Chansey usa Encanto y Amortiguador esperando a Tyranitar.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote. Después entra con Poliwrath 🐸🥊, usa Ataque X y barre.",
+                  "variant": [
+                    {
+                      "detail": "Usa Cascada contra Drapion y Puño Drenaje contra Volcarona.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Puya Nociva, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Puya Nociva ➜ Cambiar a Slowbro y usa Bostezo ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-          "variant": []
-        },
-        {
-          "detail": "Terremoto ➜ Cambiar a Slowbro y usar Bostezo al enfrentar a Scizor ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-          "variant": []
+          "detail": "Si usa Terremoto, cambia a Slowbro y usa Bostezo al enfrentar a Scizor.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Kingler ➜ Slowbro usa Bostezo al enfrentar a Sceptile ➜ Volcarona +1",
-      "variant": []
-    },
-    {
-      "detail": "Durant ➜ Entrar con Gengar +4 (No usar Otra Vez) 🔔(Barre con Bola Sombra)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Escavalier ➜ Sacrifica a Politoed ➜ entra con Poliwrath +6 🐸🥊 fijo hasta llegar a Gastrodon",
-      "variant": []
-    },
-    {
-      "detail": "Scyther ➜ Chansey usa Encanto y Amortiguador esperando a Escavalier ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊 fijo hasta llegar a Gastrodon",
-      "variant": []
-    },
-    {
-      "detail": "Scizor ➜ Usar Amortiguador para identificar movimiento",
+      "detail": "Si sale Kingler, Slowbro usa Bostezo al enfrentar a Sceptile.",
       "variant": [
         {
-          "detail": "Fuerza Bruta ➜ Slowbro usa Bostezo; sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊 🔔(Si el Bostezo le cae a Flygon usa Protección y Bostezo)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Acrobata ➜ Usar Teletransporte ➜ enviar a Slowbro para usar Bostezo ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
+          "detail": "Después entra con Volcarona y usa Danza Aleteo x1. 🦋🔥",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Flygon ➜ Usar Teletransporte ➜ enviar a Slowbro y revisar daño",
+      "detail": "Si sale Durant, entra con Gengar y usa Maquinación hasta +4. No uses Otra Vez.",
       "variant": [
         {
-          "detail": "29.4 - 34.5% (Crítico 43.7 - 51.7%) ➜ Usar Relajo para recibir Cometa Draco ➜ usar Bostezo al enfrentar a Yanmega ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-          "variant": []
-        },
-        {
-          "detail": "36.5 - 44% (Crítico 54 - 65%) ➜ Usar Bostezo al enfrentar a Drapion ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
+          "detail": "Barre con Bola Sombra.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Skuntank ➜ Sacrifica a Politoed ➜ cambiar a Volcarona luego a Gengar ➜ frente a Durant cambia a Slowbro y usa Bostezo luego Teletransporte ➜ entrar con Poliwrath +6 y usa Puño Drenaje ➜ 💊frente Crustle usar Velocidad X luego termina de Barrer💊",
-      "variant": []
+      "detail": "Si sale Escavalier, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y continúa fijo hasta llegar a Gastrodon.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Tyranitar ➜ Poliwrath usa Puño Drenaje contra tyranitar ➜ al enfrentar a Ferrothorn cambia a Volcarona +1 🦋🔥 ",
-      "variant": []
+      "detail": "Si sale Scyther, Chansey usa Encanto y Amortiguador esperando a Escavalier.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Continúa fijo hasta llegar a Gastrodon.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Scizor, usa Amortiguador para identificar movimiento.",
+      "variant": [
+        {
+          "detail": "Si usa Fuerza Bruta, Slowbro usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si Bostezo le cae a Flygon, usa Protección y Bostezo.",
+              "variant": []
+            },
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Acróbata, usa Teletransporte y envía a Slowbro para usar Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Flygon, usa Teletransporte, envía a Slowbro y revisa el daño.",
+      "variant": [
+        {
+          "detail": "Si Terremoto hace 29.4 - 34.5%, o 43.7 - 51.7% con crítico, usa Relajo para recibir Cometa Draco.",
+          "variant": [
+            {
+              "detail": "Luego usa Bostezo al enfrentar a Yanmega. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si Terremoto hace 36.5 - 44%, o 54 - 65% con crítico, usa Bostezo al enfrentar a Drapion.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Skuntank, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Cambia a Volcarona y luego a Gengar. Frente a Durant, cambia a Slowbro y usa Bostezo. Luego usa Teletransporte.",
+          "variant": [
+            {
+              "detail": "Entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y usa Puño Drenaje. Frente a Crustle, usa Velocidad X y termina de barrer.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Tyranitar, Poliwrath usa Puño Drenaje contra Tyranitar.",
+      "variant": [
+        {
+          "detail": "Al enfrentar a Ferrothorn, cambia a Volcarona y usa Danza Aleteo x1. 🦋🔥",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/durant.json
+++ b/src/data/sinnoh/alecran/durant.json
@@ -2,11 +2,35 @@
   "id": "durant",
   "name": "Durant",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Gengar y usa Maquinación luego Barre hasta que salga Drapion, entra Chansey y usa 🪨Trampa Rocas🪨, frente a Heracross cambia a Gengar Otra Vez +4 🔔(Barre con Bola sombra)🔔",
+  "initialMove": "Cambia a Gengar y usa Maquinación.",
   "tricks": [
     {
-      "detail": "Gengar +2 y entra Gliscor --> Matalo con bolsa sombra luego cambiar a Chansey para atraer a otro pokemon",
-      "variant": []
+      "detail": "Barre hasta que salga Drapion.",
+      "variant": [
+        {
+          "detail": "Entra Chansey y usa 🪨 Trampa Rocas 🪨.",
+          "variant": [
+            {
+              "detail": "Frente a Heracross, cambia a Gengar, usa Otra Vez y Maquinación hasta +4.",
+              "variant": [
+                {
+                  "detail": "Barre con Bola Sombra.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si Gengar está en +2 y entra Gliscor, derrótalo con Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Chansey para atraer a otro Pokémon.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/escavalier.json
+++ b/src/data/sinnoh/alecran/escavalier.json
@@ -2,6 +2,16 @@
   "id": "escavalier",
   "name": "Escavalier",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Usar 🪨Trampa Rocas🪨 ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊💡",
-  "tricks": []
-}    
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Luego entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/sinnoh/alecran/ferrothorn.json
+++ b/src/data/sinnoh/alecran/ferrothorn.json
@@ -2,61 +2,86 @@
   "id": "ferrothorn",
   "name": "Ferrothorn",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda ➜ Identificar movimiento",
+      "detail": "Si Ferrothorn se queda, identifica su movimiento.",
       "variant": [
         {
-          "detail": "Latigazo / Giro Rápido ➜ Chansey usa Encanto y Amortiguador al enfrentar a Tyranitar luego cambia a Poliwrath y usa Puño Drenaje",
+          "detail": "Si usa Latigazo o Giro Rápido, Chansey usa Encanto y Amortiguador al enfrentar a Tyranitar.",
           "variant": [
             {
-              "detail": "Ferrothorn ➜ Volcarona +1 🦋🔥",
-              "variant": []
-            },
-            {
-              "detail": "Gastrodon ➜ Slowbro usa Bostezo, sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
-              "variant": []
+              "detail": "Luego cambia a Poliwrath y usa Puño Drenaje.",
+              "variant": [
+                {
+                  "detail": "Si sale Ferrothorn, entra con Volcarona y usa Danza Aleteo x1. 🦋🔥",
+                  "variant": []
+                },
+                {
+                  "detail": "Si sale Gastrodon, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             }
           ]
         },
         {
-          "detail": " 🌱 Drenadoras 🌱 ➜ Cambiar a Slowbro",
+          "detail": "Si usa Drenadoras, cambia a Slowbro. 🌱",
           "variant": [
             {
-              "detail": "Flygon ➜ Usar Relajo para recibir Cometa Draco ➜ usar Bostezo al enfrentar a Yanmega ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-              "variant": []
-            },
-            {
-              "detail": "Kabutops ➜ Usar Bostezo",
+              "detail": "Si sale Flygon, usa Relajo para recibir Cometa Draco y luego usa Bostezo al enfrentar a Yanmega.",
               "variant": [
                 {
-                  "detail": "Yanmega ➜ Sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Kabutops, usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Si sale Yanmega, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
                   "variant": []
                 },
                 {
-                  "detail": "Ferrothorn ➜ Volcarona +2 🦋🔥",
+                  "detail": "Si sale Ferrothorn, entra con Volcarona y usa Danza Aleteo x2. 🦋🔥",
                   "variant": []
                 }
-              ]  
+              ]
             }
           ]
         }
       ]
     },
     {
-      "detail": "Flygon ➜ Usar Teletransporte ➜ enviar a Slowbro y usar Relajo para recibir Cometa Draco ➜ usar Bostezo al enfrentar a Yanmega ➜ sacrifica a Politoed y entra con Poliwrath +6🐸🥊",
-      "variant": []
-    },
-    {
-      "detail": "Kabutops ➜ Cambiar a Slowbro y usar Bostezo",
+      "detail": "Si sale Flygon, usa Teletransporte para enviar a Slowbro.",
       "variant": [
         {
-          "detail": "Yanmega ➜ Usar Protección y Bostezo al enfrentar a Octillery ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-          "variant": []
+          "detail": "Usa Relajo para recibir Cometa Draco y luego usa Bostezo al enfrentar a Yanmega.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Kabutops, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Yanmega, usa Protección y Bostezo al enfrentar a Octillery.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Ferrothorn ➜ Volcarona +2 🦋🔥",
+          "detail": "Si sale Ferrothorn, entra con Volcarona y usa Danza Aleteo x2. 🦋🔥",
           "variant": []
         }
       ]

--- a/src/data/sinnoh/alecran/flygon.json
+++ b/src/data/sinnoh/alecran/flygon.json
@@ -2,32 +2,66 @@
   "id": "flygon",
   "name": "Flygon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda ➜ Usar Teletransporte ➜ enviar a Slowbro y revisar daño",
+      "detail": "Si Flygon se queda, usa Teletransporte, envía a Slowbro y revisa el daño.",
       "variant": [
         {
-          "detail": "29.4 - 34.5% (Crítico 43.7 - 51.7%) ➜ Usar Relajo para aguantar Cometa Draco ➜ usar Bostezo para que entre Yanmega ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
+          "detail": "Si Terremoto hace 29.4 - 34.5%, o 43.7 - 51.7% con crítico, usa Relajo para recibir Cometa Draco.",
+          "variant": [
+            {
+              "detail": "Luego usa Bostezo al enfrentar a Yanmega. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si Terremoto hace 36.5 - 44%, o 54 - 65% con crítico, usa Bostezo al enfrentar a Drapion o Scizor.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Skuntank, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Cambia a Volcarona y luego a Gengar. Frente a Durant, cambia a Slowbro y usa Bostezo. Luego usa Teletransporte.",
+          "variant": [
+            {
+              "detail": "Entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y usa Puño Drenaje. Frente a Crustle, usa Velocidad X y termina de barrer.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Scizor, Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Bostezo le cae a Flygon, usa Protección y Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "36.5 - 44% (Crítico 54 - 65%) ➜ Usar Bostezo al enfrentar a Drapion/Scizor ➜ sacrifica a Politoed  ➜ Poliwrath +6 🐸🥊",
+          "detail": "Si la ruta continúa normal, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Skuntank ➜ Sacrifica a Politoed ➜ cambiar a Volcarona luego a Gengar ➜ frente a Durant cambia a Slowbro y usa Bostezo luego Teletransporte ➜ entrar con Poliwrath +6 y usa Puño Drenaje ➜ 💊frente Crustle usar Velocidad X luego termina de Barrer💊",
-      "variant": []
-    },
-    {
-      "detail": "Scizor ➜ Slowbro usa Bostezo ➜ sacrifica a Politoed y entra con Poliwrath +6🐸🥊 🔔(Si el Bostezo le cae a Flygon usa Protección y Bostezo)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Escavalier ➜ Sacrifica a Politoed ➜ entra con Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Escavalier, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/forretress.json
+++ b/src/data/sinnoh/alecran/forretress.json
@@ -2,6 +2,26 @@
   "id": "forretress",
   "name": "Forretress",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡🪨Trampa Rocas🪨 al enfrentar a Skuntank ➜ sacrifica a Politoed ➜ cambiar de Volcarona a Gengar para que Skuntank use Autodestrucción al enfrentar a Durant ➜ Slowbro usa Bostezo y Teletransporte ➜ entra con Poliwrath +6 absorbiendo el golpe de Crustle y usar Velocidad X para presionar💡",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Skuntank, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Cambia de Volcarona a Gengar para que Skuntank use Autodestrucción.",
+          "variant": [
+            {
+              "detail": "Al enfrentar a Durant, Slowbro usa Bostezo y Teletransporte.",
+              "variant": [
+                {
+                  "detail": "Entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque, absorbe el golpe de Crustle y usa Velocidad X para presionar.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/alecran/gastrodon.json
+++ b/src/data/sinnoh/alecran/gastrodon.json
@@ -2,23 +2,43 @@
   "id": "gastrodon",
   "name": "Gastrodon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Terremoto ➜ Cambiar a Slowbro y usa Bostezo al enfrentar a Volcarona ➜ sacrifica a Politoed y entra con Poliwrath +6🐸🥊",
-      "variant": []
+      "detail": "Si Gastrodon usa Terremoto, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo al enfrentar a Volcarona. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Escavalier ➜ Sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Escavalier, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Scizor ➜ Chansey usa Amortiguador para recibir Aróbata ➜ cambiar a Slowbro al enfrentar a Flygon y usar Bostezo ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Scizor, Chansey usa Amortiguador para recibir Acróbata.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro al enfrentar a Flygon y usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Flygon ➜ Cambiar a Slowbro y usa Bostezo ➜ sacrifica a Politoed  y entra con Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Flygon, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/gliscor.json
+++ b/src/data/sinnoh/alecran/gliscor.json
@@ -2,15 +2,30 @@
   "id": "gliscor",
   "name": "Gliscor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Terremoto ➜ Cambiar a Slowbro y usar Bostezo al enfrentar a Volcarona ➜ sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si Gliscor usa Terremoto, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo al enfrentar a Volcarona.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Durant ➜ Entrar con Gengar +4 (No usar Otra Vez) 🔔(Barrer con Bola Sombra)🔔",
-      "variant": []
+      "detail": "Si sale Durant, entra con Gengar y usa Maquinación hasta +4. No uses Otra Vez.",
+      "variant": [
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/kingler.json
+++ b/src/data/sinnoh/alecran/kingler.json
@@ -2,15 +2,34 @@
   "id": "kingler",
   "name": "Kingler",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Cambiar a Slowbro🔔",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Martillazo ➜ Usar Bostezo ➜ sacrifica a Politoed y entra con Poliwrath +6 🐸🥊 🔔(Si el Bostezo le cae a Flygon usa Protección y Bostezo)🔔",
-      "variant": []
+      "detail": "Si Kingler usa Martillazo, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Bostezo le cae a Flygon, usa Protección y Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Fuerza Bruta ➜ Cambiar a Chansey al enfrentar a Sceptile ➜ usar Trampa Rocas y usar Amortiguador esperando el cambio ➜ Slowbro usa Bostezo al enfrentar a Sceptile ➜ entra con Volcarona +1 🦋🔥",
-      "variant": []
+      "detail": "Si Kingler usa Fuerza Bruta, cambia a Chansey al enfrentar a Sceptile.",
+      "variant": [
+        {
+          "detail": "Usa 🪨 Trampa Rocas 🪨 y Amortiguador esperando el cambio.",
+          "variant": [
+            {
+              "detail": "Slowbro usa Bostezo al enfrentar a Sceptile. Después entra con Volcarona y usa Danza Aleteo x1. 🦋🔥",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/octillery.json
+++ b/src/data/sinnoh/alecran/octillery.json
@@ -2,42 +2,62 @@
   "id": "octillery",
   "name": "Octillery",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda ➜ Revisar si Chansey tiene un estado alterado",
+      "detail": "Si Octillery se queda, revisa si Chansey tiene un estado alterado.",
       "variant": [
         {
-          "detail": "Sin estado alterado ➜ Usar Teletransporte enviar a Slowbro y usar Bostezo ➜ sacrificar Politoed ➜ entra con Poliwrath +6 🐸🥊",
-          "variant": []
-        },
-        {
-          "detail": "Con estado alterado ➜ Cambia a Slowbro",
+          "detail": "Si Chansey no tiene estado alterado, usa Teletransporte, envía a Slowbro y usa Bostezo.",
           "variant": [
             {
-              "detail": "Kabutops ➜ Usa Bostezo 🥱",
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si Chansey tiene estado alterado, cambia a Slowbro.",
+          "variant": [
+            {
+              "detail": "Si sale Kabutops, usa Bostezo. 🥱",
               "variant": [
                 {
-                  "detail": "Yanmega ➜ Sacrificar a Politoed y entra con Poliwrath +6 🐸🥊",
+                  "detail": "Si sale Yanmega, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
                   "variant": []
                 },
                 {
-                  "detail": "Ferrothorn ➜ Volcarona +2 🦋🔥 ",
+                  "detail": "Si sale Ferrothorn, entra con Volcarona y usa Danza Aleteo x2. 🦋🔥",
                   "variant": []
-                }   
-              ]   
+                }
+              ]
             },
             {
-              "detail": "Flygon ➜ Usar Relajo para recibir Cometa Draco ➜ usa Bostezo al enfrentar a Yanmega ➜ sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
-              "variant": []
+              "detail": "Si sale Flygon, usa Relajo para recibir Cometa Draco y luego usa Bostezo al enfrentar a Yanmega.",
+              "variant": [
+                {
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             }
           ]
         }
       ]
     },
     {
-      "detail": "Skuntank --> Sacrifica a Politoed ➜ cambiar a Volcarona luego a Gengar ➜ frente a Durant cambia a Slowbro y usa Bostezo luego Teletransporte ➜ entrar con Poliwrath +6 y usa Puño Drenaje ➜ 💊frente Crustle usar Velocidad X luego termina de Barrer💊",
-      "variant": []
+      "detail": "Si sale Skuntank, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Cambia a Volcarona y luego a Gengar. Frente a Durant, cambia a Slowbro y usa Bostezo. Luego usa Teletransporte.",
+          "variant": [
+            {
+              "detail": "Entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y usa Puño Drenaje. Frente a Crustle, usa Velocidad X y termina de barrer.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/sceptile.json
+++ b/src/data/sinnoh/alecran/sceptile.json
@@ -2,7 +2,21 @@
   "id": "sceptile",
   "name": "Sceptile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 luego usar Amortiguador al enfrentar a Kingler ➜ Slowbro usa Bostezo  al enfrentar a Sceptile ➜ entrar con Volcarona +1 🦋🔥",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Luego usa Amortiguador al enfrentar a Kingler.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo al enfrentar a Sceptile.",
+          "variant": [
+            {
+              "detail": "Después entra con Volcarona y usa Danza Aleteo x1. 🦋🔥",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
-  

--- a/src/data/sinnoh/alecran/scizor.json
+++ b/src/data/sinnoh/alecran/scizor.json
@@ -2,15 +2,29 @@
   "id": "scizor",
   "name": "Scizor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚",
+  "initialMove": "Usa Amortiguador. 🥚",
   "tricks": [
     {
-      "detail": "Fuerza Bruta ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrificar a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Si el Bostezo le cae a Flygon usa Protección y Bostezo)🔔",
-      "variant": []
+      "detail": "Si Scizor usa Fuerza Bruta, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Bostezo le cae a Flygon, usa Protección y Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Acróbata ➜ Usar 🪨Trampa Rocas🪨 al enfrentar a Flygon ➜ Slowbro usa Bostezo al enfrentar a Scizor ➜ sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si Scizor usa Acróbata, usa 🪨 Trampa Rocas 🪨 al enfrentar a Flygon.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo al enfrentar a Scizor. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/scyther.json
+++ b/src/data/sinnoh/alecran/scyther.json
@@ -2,6 +2,16 @@
   "id": "scyther",
   "name": "Scyther",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Usar Encanto y 🪨Trampa Rocas🪨 al enfrentar a Escavalier ➜ sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊💡",
-  "tricks": []
+  "initialMove": "Usa Encanto.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Escavalier, usa 🪨 Trampa Rocas 🪨.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/alecran/skuntank.json
+++ b/src/data/sinnoh/alecran/skuntank.json
@@ -2,24 +2,39 @@
   "id": "skuntank",
   "name": "Skuntank",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡🪨Trampa Rocas🪨 y cambiar a Gengar💡",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Puya Nociva ➜ Gengar usa Otra Vez al movimiento Veneno ➜ cambiar a Slowbro y usar Bostezo",
+      "detail": "Luego cambia a Gengar.",
       "variant": [
         {
-          "detail": "Si se queda ➜ Usar Protección y Bostezo ➜ sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
-          "variant": []
-        },
-        {
-          "detail": "Octillery ➜ Sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
-          "variant": []
-        }  
-      ]  
+          "detail": "Si Skuntank usa Puya Nociva, Gengar usa Otra Vez al movimiento de tipo Veneno.",
+          "variant": [
+            {
+              "detail": "Después cambia a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Si Skuntank se queda, usa Protección y Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si sale Octillery, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Autodestrucción y entra Durant ➜ Slowbro usa Bostezo ➜ sacrificar a Politoed y entrar con Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si usa Autodestrucción y entra Durant, Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/steelix.json
+++ b/src/data/sinnoh/alecran/steelix.json
@@ -2,6 +2,16 @@
   "id": "steelix",
   "name": "Steelix",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Kingler ➜ cambiar a Slowbro y usa Bostezo ➜ frente a Sceptile  entra con Volcarona +1 🦋🔥",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Kingler, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Sceptile, entra con Volcarona y usa Danza Aleteo x1. 🦋🔥",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/alecran/tyranitar.json
+++ b/src/data/sinnoh/alecran/tyranitar.json
@@ -2,32 +2,60 @@
   "id": "tyranitar",
   "name": "Tyranitar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda ➜ Cambiar a Poliwrath y usa Puño Drenaje 🚨(Metodo Arriesgado: Directamente sacrifica a Politoed para entrar con Poliwrath +6)🚨",
+      "detail": "Si Tyranitar se queda, cambia a Poliwrath y usa Puño Drenaje.",
       "variant": [
         {
-          "detail": "Ferrothorn ➜ Volcarona +1",
+          "detail": "Ruta arriesgada: entra Politoed como pivote para dar entrada segura a Poliwrath 🐸🥊 y usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Gastrodon ➜ Sacrificar a Politoed ➜ entrar con Poliwrath y usar Ataque X para Barrer 🔔(Puño Drenaje a Volcarona)🔔",
+          "detail": "Si sale Ferrothorn, entra con Volcarona y usa Danza Aleteo x1. 🦋🔥",
           "variant": []
         },
         {
-          "detail": "Drapion ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño Drenaje a Volcarona)🔔",
-          "variant": []
+          "detail": "Si sale Gastrodon, entra Politoed como pivote.",
+          "variant": [
+            {
+              "detail": "Luego entra con Poliwrath 🐸🥊 y usa Ataque X para barrer. Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Gliscor ➜ Puño Hielo y deja que muera ➜ entra Volcarona +1",
-          "variant": []  
-        }   
-      ]  
+          "detail": "Si sale Drapion, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Gliscor, usa Puño Hielo y deja que Poliwrath quede debilitado si corresponde.",
+          "variant": [
+            {
+              "detail": "Luego entra con Volcarona y usa Danza Aleteo x1. 🦋🔥",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Scizor ➜ Slowbro usa Bostezo ➜ sacrificar a Politoed y entrar con Poliwrath +6 🔔(Si el Bostezo le cae a Flygon usa Protección y Bostezo)🔔",
-      "variant": []
+      "detail": "Si sale Scizor, Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Bostezo le cae a Flygon, usa Protección y Bostezo.",
+          "variant": []
+        },
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/alecran/vespiquen.json
+++ b/src/data/sinnoh/alecran/vespiquen.json
@@ -2,6 +2,21 @@
   "id": "vespiquen",
   "name": "Vespiquen",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 🪨Trampa Rocas🪨 al enfrentar a Kingler ➜ cambiar a Slowbro y usar Bostezo al enfrentar a Sceptile ➜ entrar con Volcarona  +1💡",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Kingler, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo al enfrentar a Sceptile.",
+          "variant": [
+            {
+              "detail": "Después entra con Volcarona y usa Danza Aleteo x1. 🦋🔥",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/alecran/volcarona.json
+++ b/src/data/sinnoh/alecran/volcarona.json
@@ -2,6 +2,16 @@
   "id": "volcarona",
   "name": "Volcarona",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Sacrificar a Politoed ➜ entrar con Poliwrath +6 🐸🥊 (Puño Drenaje a Volcarona)💡",
-  "tricks": []
+  "initialMove": "Entra Politoed como pivote.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": [
+        {
+          "detail": "Usa Puño Drenaje contra Volcarona.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/alecran/yanmega.json
+++ b/src/data/sinnoh/alecran/yanmega.json
@@ -2,24 +2,39 @@
   "id": "yanmega",
   "name": "Yanmega",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Usar Defensa Especial X y 🪨Trampa Rocas🪨💡",
+  "initialMove": "Usa Defensa Especial X.",
   "tricks": [
     {
-      "detail": "Kabutops ➜ Cambiar a Slowbro y usar Bostezo ",
+      "detail": "Luego usa 🪨 Trampa Rocas 🪨.",
       "variant": [
         {
-          "detail": "Yanmega ➜ Sacrificar a Politoed  y entrar con Poliwrath  +6",
-          "variant": []
+          "detail": "Si sale Kabutops, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Yanmega, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Ferrothorn, entra con Volcarona y usa Danza Aleteo x2.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Ferrothorn ➜ Volcarona  +2",
-          "variant": []
-        }  
-      ]  
-    },
-    {
-      "detail": "Flygon ➜ Usar Teletransporte  para enviar a Slowbro ➜ usar Relajo para recibir Cometa Draco ➜ usar Bostezo al enfrentar a Yanmega ➜ sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
+          "detail": "Si sale Flygon, usa Teletransporte para enviar a Slowbro.",
+          "variant": [
+            {
+              "detail": "Usa Relajo para recibir Cometa Draco y luego usa Bostezo al enfrentar a Yanmega.",
+              "variant": [
+                {
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Completes the remaining Sinnoh Alecrán Spanish strategy structure cleanup.
- Fixes the 21 Alecrán JSON files that were missed in the first Alecrán pass.
- Keeps `initialMove` as the opening action only.
- Moves route follow-up steps into `tricks.detail` and nested `variant` entries.
- Replaces old Politoed sacrifice wording with pivot wording.
- Expands shorthand setup text such as Gengar boosts, Volcarona setup, and Poliwrath setup into clear Spanish.

## Context
- The first Alecrán release covered 5 files.
- Alecrán has 26 files total.
- This PR covers the remaining 21 files, so the full trainer folder is now included.

## Scope
- Sinnoh Alecrán strategy JSON files only.
- No English translation changes.
- No asset changes.
- No frontend layout changes.

## Files
- `src/data/sinnoh/alecran/beautifly.json`
- `src/data/sinnoh/alecran/crawdaunt.json`
- `src/data/sinnoh/alecran/drapion.json`
- `src/data/sinnoh/alecran/durant.json`
- `src/data/sinnoh/alecran/escavalier.json`
- `src/data/sinnoh/alecran/ferrothorn.json`
- `src/data/sinnoh/alecran/flygon.json`
- `src/data/sinnoh/alecran/forretress.json`
- `src/data/sinnoh/alecran/gastrodon.json`
- `src/data/sinnoh/alecran/gliscor.json`
- `src/data/sinnoh/alecran/kingler.json`
- `src/data/sinnoh/alecran/octillery.json`
- `src/data/sinnoh/alecran/sceptile.json`
- `src/data/sinnoh/alecran/scizor.json`
- `src/data/sinnoh/alecran/scyther.json`
- `src/data/sinnoh/alecran/skuntank.json`
- `src/data/sinnoh/alecran/steelix.json`
- `src/data/sinnoh/alecran/tyranitar.json`
- `src/data/sinnoh/alecran/vespiquen.json`
- `src/data/sinnoh/alecran/volcarona.json`
- `src/data/sinnoh/alecran/yanmega.json`

## Review checklist
- This PR touches exactly 21 files.
- All files are under `src/data/sinnoh/alecran`.
- No English translation changes.
- No frontend or asset changes.
- No `Ataque Especial X` wording was introduced.
- Old route arrows and raw boost shorthand were removed from the touched files.