### PR TITLE
Fix Sinnoh Alecran initial move structure

### DIFF
--- a/src/data/sinnoh/alecran/beautifly.json
+++ b/src/data/sinnoh/alecran/beautifly.json
@@ -2,14 +2,19 @@
   "id": "beautifly",
   "name": "Beautifly",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro y usa Bostezo.",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Luego entra Politoed como pivote.",
+      "detail": "Usa Bostezo.",
       "variant": [
         {
-          "detail": "Entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
-          "variant": []
+          "detail": "Luego entra Politoed como pivote.",
+          "variant": [
+            {
+              "detail": "Entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
     },

--- a/src/data/sinnoh/alecran/durant.json
+++ b/src/data/sinnoh/alecran/durant.json
@@ -2,20 +2,25 @@
   "id": "durant",
   "name": "Durant",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Gengar y usa Maquinación.",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Barre hasta que salga Drapion.",
+      "detail": "Gengar usa Maquinación.",
       "variant": [
         {
-          "detail": "Entra Chansey y usa 🪨 Trampa Rocas 🪨.",
+          "detail": "Barre hasta que salga Drapion.",
           "variant": [
             {
-              "detail": "Frente a Heracross, cambia a Gengar, usa Otra Vez y Maquinación hasta +4.",
+              "detail": "Entra Chansey y usa 🪨 Trampa Rocas 🪨.",
               "variant": [
                 {
-                  "detail": "Barre con Bola Sombra.",
-                  "variant": []
+                  "detail": "Frente a Heracross, cambia a Gengar, usa Otra Vez y Maquinación hasta +4.",
+                  "variant": [
+                    {
+                      "detail": "Barre con Bola Sombra.",
+                      "variant": []
+                    }
+                  ]
                 }
               ]
             }

--- a/src/data/sinnoh/alecran/heracross.json
+++ b/src/data/sinnoh/alecran/heracross.json
@@ -2,17 +2,27 @@
   "id": "heracross",
   "name": "Heracross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Gengar usa Otra Vez.",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Luego Gengar usa Maquinación hasta +2 y Bola Sombra. 💡",
+      "detail": "Usa Otra Vez.",
       "variant": [
         {
-          "detail": "Si sale Drapion, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 al enfrentar a Durant.",
+          "detail": "Gengar usa Maquinación hasta +2 y Bola Sombra. 💡",
           "variant": [
             {
-              "detail": "Después entra con Gengar y usa Maquinación hasta +4. No uses Otra Vez. Barre con Bola Sombra.",
-              "variant": []
+              "detail": "Si sale Drapion, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 al enfrentar a Durant.",
+              "variant": [
+                {
+                  "detail": "Después entra con Gengar y usa Maquinación hasta +4. No uses Otra Vez.",
+                  "variant": [
+                    {
+                      "detail": "Barre con Bola Sombra.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
## Summary
- Fixes `initialMove` in three Sinnoh Alecrán files so it only contains the opening switch/action.
- Moves follow-up actions into `tricks` and nested `variant` entries.
- Keeps the scope limited to Alecrán strategy JSON files.

## Files
- `src/data/sinnoh/alecran/beautifly.json`
- `src/data/sinnoh/alecran/durant.json`
- `src/data/sinnoh/alecran/heracross.json`

## Notes
- Opening mentions of another Pokémon now use the switch as the initial move, e.g. `Cambia a Gengar.`
- No English, asset, or frontend changes.