### PR TITLE
Clean Sinnoh Gaia Spanish strategy structure

### DIFF
--- a/src/data/sinnoh/gaia/absol.json
+++ b/src/data/sinnoh/gaia/absol.json
@@ -2,6 +2,21 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambiar a Slowbro y luego a Chansey usar 🪨Trampa Rocas🪨 al enfrentar a Absol; cambiar a Slowbro y usar Bostezo ; entrar con Volcarona +1💡",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Luego cambia a Chansey y usa 🪨 Trampa Rocas 🪨 al enfrentar a Absol.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra con Volcarona y usa Danza Aleteo x1.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/gaia/amoonguss.json
+++ b/src/data/sinnoh/gaia/amoonguss.json
@@ -2,22 +2,42 @@
   "id": "amoonguss",
   "name": "Amoonguss",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambiar a Slowbro💡",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Durant ➜ Bostezo , Protección vuelve a usar Bostezo ➜ frente a Rhyperior ➜ Teletransporte ➜ Poliwrath +6 🐸🥊(todos son lentos)",
-      "variant": []
-    },
-    {
-      "detail": "Rhyperior ➜ Usar Bostezo ",
+      "detail": "Si sale Durant, usa Bostezo.",
       "variant": [
         {
-          "detail": "Si se queda ➜ Usar Teletransporte ➜ entrar con Volcarona +1  🔔usar Psíquico al enfrentar a Gengar🔔",
-          "variant": []
+          "detail": "Luego usa Protección y vuelve a usar Bostezo.",
+          "variant": [
+            {
+              "detail": "Frente a Rhyperior, usa Teletransporte y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Todos son lentos.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Rhyperior, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Rhyperior se queda, usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1.",
+          "variant": [
+            {
+              "detail": "Usa Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Gengar ➜ Cambiar a Volcarona +1  🔔usar Psíquico al enfrentar a Gengar🔔",
-          "variant": []
+          "detail": "Si sale Gengar, cambia a Volcarona y usa Danza Aleteo x1.",
+          "variant": [
+            {
+              "detail": "Usa Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/sinnoh/gaia/blastoise.json
+++ b/src/data/sinnoh/gaia/blastoise.json
@@ -2,50 +2,58 @@
   "id": "blastoise",
   "name": "Blastoise",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 🔔(Si se queda usar Teletransporte)🔔",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Rhyperior --> Usar Teletransporte; cambiar a Slowbro y usar Bostezo 🔔(Seguir usando Bostezo al enfrentar a Quagsire)🔔",
+      "detail": "Si Blastoise se queda, usa Teletransporte.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Rhyperior, usa Teletransporte, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Megacuerno--> Observa la Precision",
-          "variant": [
-            {
-              "detail": "Acierta --> Usar Teletransporte; entrar con Volcarona +1",
-              "variant": []
-            },
-            {
-              "detail": "Falla --> Usar Protección y Relajo al enfrentar a Parasect; entrar con Volcarona +1",
-              "variant": []
-            }  
-          ]  
-        },
-        {
-          "detail": "Terremoto/Pedrada --> ⬇️Opciones para Resolver⬇️",
-          "variant": [
-            {
-              "detail": "Rapido --> Teletransporte, Volcarona +1 🔔(Psiquico a Gengar)🔔",
-              "variant": []
-            },
-            {  
-              "detail": "Ahorro --> Proteccion luego Bostezo frente a Gengar, Volcarona +1 🔔(Psiquico a Gengar)🔔",
-              "variant": []
-            }
-          ]  
-        },   
-        {
-          "detail": "Gengar --> Entrar con Volcarona +1 🔔(Psiquico a Gengar)🔔",
+          "detail": "Sigue usando Bostezo al enfrentar a Quagsire.",
           "variant": []
         },
         {
-          "detail": "Cambia a Parasect mientras usas Teletransporte --> Entrar con Volcarona +1",
+          "detail": "Si Rhyperior usa Megacuerno, revisa si acierta.",
+          "variant": [
+            {
+              "detail": "Si acierta, usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1.",
+              "variant": []
+            },
+            {
+              "detail": "Si falla, usa Protección y Relajo al enfrentar a Parasect. Luego entra con Volcarona y usa Danza Aleteo x1.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Terremoto o Pedrada, elige ruta rápida o de ahorro.",
+          "variant": [
+            {
+              "detail": "Ruta rápida: usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            },
+            {
+              "detail": "Ruta de ahorro: usa Protección y luego Bostezo frente a Gengar. Después entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Gengar, entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
+          "variant": []
+        },
+        {
+          "detail": "Si cambia a Parasect mientras usas Teletransporte, entra con Volcarona y usa Danza Aleteo x1.",
           "variant": []
         }
       ]
-    },  
+    },
     {
-      "detail": "Parasect --> Entrar con Volcarona +1",
+      "detail": "Si sale Parasect, entra con Volcarona y usa Danza Aleteo x1.",
       "variant": []
-    }  
+    }
   ]
 }

--- a/src/data/sinnoh/gaia/bronzong.json
+++ b/src/data/sinnoh/gaia/bronzong.json
@@ -2,40 +2,55 @@
   "id": "bronzong",
   "name": "Bronzong",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Parasect ➜ Cambiar a Volcarona",
+      "detail": "Si sale Parasect, cambia a Volcarona.",
       "variant": [
         {
-          "detail": "Si se queda ➜ Volcarona +1",
+          "detail": "Si Parasect se queda, Volcarona usa Danza Aleteo x1.",
           "variant": []
         },
         {
-          "detail": "Rhyperior ➜ Usa Gigadrenado para debilitarlo, al enfrentar a Blastoise cambiar a Slowbro y usar Bostezo",
+          "detail": "Si sale Rhyperior, usa Gigadrenado para debilitarlo.",
           "variant": [
             {
-              "detail": "Si se queda ➜ Usar Protección y Relajo al enfrentar a Parasect, entrar con Volcarona +1",
+              "detail": "Al enfrentar a Blastoise, cambia a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Si Blastoise se queda, usa Protección y Relajo al enfrentar a Parasect. Luego entra con Volcarona y usa Danza Aleteo x1.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si sale Parasect, entra con Volcarona y usa Danza Aleteo x1.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Rhyperior, usa Teletransporte y Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Identifica si porta Vidaesfera.",
+          "variant": [
+            {
+              "detail": "Si tiene Vidaesfera, usa Teletransporte, entra con Volcarona, usa Especial X y presiona.",
               "variant": []
             },
             {
-              "detail": "Parasect ➜ Entrar con Volcarona +1",
-              "variant": []
+              "detail": "Si no tiene Vidaesfera, usa Teletransporte, entra con Volcarona y usa Danza Aleteo x1.",
+              "variant": [
+                {
+                  "detail": "Ruta de ahorro: usa Protección y Relajo. Frente a Parasect, cambia a Volcarona y usa Danza Aleteo x1.",
+                  "variant": []
+                }
+              ]
             }
-          ] 
-        } 
-      ]  
-    },
-    {
-      "detail": "Rhyperior ➜ Usar Teletransporte, Slowbro usa Bostezo 🔔(Identifica si porta Vidasfera🔔)",
-      "variant": [
-        {
-          "detail": "Si tiene Vidasfera ➜ Usar Teletransporte, 💊entrar con Volcarona y usar atk. Especial X luego presionar💊",
-          "variant": []
-        },
-        {
-          "detail": "No tiene Vidasfera ➜ Usar Teletransporte, entrar con Volcarona +1 💰(Si quieres ahorrar en curas: Usa Proteccion y Relajo, frente a Parasect cambia a Volcarona +1)💰",
-          "variant": []
+          ]
         }
       ]
     }

--- a/src/data/sinnoh/gaia/camerupt.json
+++ b/src/data/sinnoh/gaia/camerupt.json
@@ -2,17 +2,22 @@
   "id": "camerupt",
   "name": "Camerupt",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambiar a Slowbro💡",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Rhyperior --> Usar Bostezo  🔔Revisar la precisión de Megacuerno 🔔",
+      "detail": "Si sale Rhyperior, usa Bostezo y revisa si Megacuerno acierta.",
       "variant": [
         {
-          "detail": "Si acierta --> Usar Teletransporte ; entrar con Volcarona , usar Especial X y presionar",
-          "variant": []
+          "detail": "Si Megacuerno acierta, usa Teletransporte.",
+          "variant": [
+            {
+              "detail": "Entra con Volcarona, usa Especial X y presiona.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Si falla --> Cambiar a Volcarona , usar Especial X y presionar",
+          "detail": "Si Megacuerno falla, cambia a Volcarona, usa Especial X y presiona.",
           "variant": []
         }
       ]

--- a/src/data/sinnoh/gaia/cloyster.json
+++ b/src/data/sinnoh/gaia/cloyster.json
@@ -2,35 +2,60 @@
   "id": "cloyster",
   "name": "Cloyster",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda --> Slowbro usa Bostezo",
+      "detail": "Si Cloyster se queda, Slowbro usa Bostezo.",
       "variant": [
         {
-          "detail": "Durant --> Usar Teletransporte ; entrar con Volcarona +1 y usar Especial X 🔔Si el HP de Druddigon baja del 35% dos veces, darle medicina primero🔔",
-          "variant": []
+          "detail": "Si sale Durant, usa Teletransporte, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": [
+            {
+              "detail": "Si el HP de Druddigon baja del 35% dos veces, usa medicina primero.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Gengar --> Entrar con Volcarona +1",
+          "detail": "Si sale Gengar, entra con Volcarona y usa Danza Aleteo x1.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Durant --> Slowbro usa Bostezo",
+      "detail": "Si sale Durant, Slowbro usa Bostezo.",
       "variant": [
         {
-          "detail": "Si se queda --> Usar Teletransporte ; entrar con Volcarona +1 y usar Especial X 🔔Si el HP de Druddigon baja del 36% dos veces, darle medicina primero🔔",
-          "variant": []
+          "detail": "Si Durant se queda, usa Teletransporte, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": [
+            {
+              "detail": "Si el HP de Druddigon baja del 36% dos veces, usa medicina primero.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Gengar --> Entrar con Volcarona +1 💡Usar Psíquico al enfrentar a Gengar 💡",
-          "variant": []
+          "detail": "Si sale Gengar, entra con Volcarona y usa Danza Aleteo x1.",
+          "variant": [
+            {
+              "detail": "Usa Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Emboar --> Slowbro usa Bostezo al enfrentar a Durant; usar Teletransporte ; entrar con Volcarona +1 y usar Especial X 🔔Si el HP de Druddigon baja del 36% dos veces, darle medicina primero🔔",
-          "variant": []
+          "detail": "Si sale Emboar, Slowbro usa Bostezo al enfrentar a Durant.",
+          "variant": [
+            {
+              "detail": "Usa Teletransporte, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+              "variant": [
+                {
+                  "detail": "Si el HP de Druddigon baja del 36% dos veces, usa medicina primero.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/sinnoh/gaia/donphan.json
+++ b/src/data/sinnoh/gaia/donphan.json
@@ -2,23 +2,32 @@
   "id": "donphan",
   "name": "Donphan",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 🥚No cambia usa Amortiguador 🥚",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Rhyperior --> Usar Encanto y cambiar a Slowbro",
+      "detail": "Si Donphan no cambia, usa Amortiguador. 🥚",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Rhyperior, usa Encanto y cambia a Slowbro.",
       "variant": [
         {
-          "detail": "Si se queda --> Usar Bostezo al enfrentar a 🦀Parasect🍄 entrar con Volcarona +1",
-          "variant": []
+          "detail": "Si Rhyperior se queda, usa Bostezo al enfrentar a Parasect. 🦀🍄",
+          "variant": [
+            {
+              "detail": "Luego entra con Volcarona y usa Danza Aleteo x1.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "🦀Parasect🍄--> Entrar con Volcarona +1",
+          "detail": "Si sale Parasect, entra con Volcarona y usa Danza Aleteo x1. 🦀🍄",
           "variant": []
         }
       ]
     },
     {
-      "detail": "🦀Parasect🍄 --> Entrar con Volcarona +1",
+      "detail": "Si sale Parasect, entra con Volcarona y usa Danza Aleteo x1. 🦀🍄",
       "variant": []
     }
   ]

--- a/src/data/sinnoh/gaia/druddigon.json
+++ b/src/data/sinnoh/gaia/druddigon.json
@@ -2,23 +2,58 @@
   "id": "druddigon",
   "name": "Druddigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda --> Usar Amortiguador y esperar a Rhyperior",
+      "detail": "Si Druddigon se queda, usa Amortiguador y espera a Rhyperior.",
       "variant": []
     },
     {
-      "detail": "Rhyperior --> Usar Teletransporte para enviar a Slowbro y usar Bostezo ; sacrificar a Politoed y entrar con Poliwrath +6 🔔Hielo golpea a Gengar🔔",
-      "variant": []
+      "detail": "Si sale Rhyperior, usa Teletransporte para enviar a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Hielo contra Gengar.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Emboar --> Cambiar a Slowbro y usar Bostezo al enfrentar a Durant ; usar Teletransporte ; entrar con Volcarona +1 y usar Especial X 🔔Si el HP de Druddigon baja del 35% dos veces, darle medicina primero🔔",
-      "variant": []
+      "detail": "Si sale Emboar, cambia a Slowbro y usa Bostezo al enfrentar a Durant.",
+      "variant": [
+        {
+          "detail": "Usa Teletransporte, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": [
+            {
+              "detail": "Si el HP de Druddigon baja del 35% dos veces, usa medicina primero.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Durant --> Gengar usa Otra Vez  cambiar a Slowbro  al enfrentar a Rhyperior; usar Bostezo al enfrentar a Durant usar Teletransporte ; entrar con Volcarona +1 y usar Especial X 🔔Si el HP de Druddigon baja del 35% dos veces, darle medicina primero🔔",
-      "variant": []
+      "detail": "Si sale Durant, Gengar usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro al enfrentar a Rhyperior y usa Bostezo al enfrentar a Durant.",
+          "variant": [
+            {
+              "detail": "Usa Teletransporte, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+              "variant": [
+                {
+                  "detail": "Si el HP de Druddigon baja del 35% dos veces, usa medicina primero.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/gaia/durant.json
+++ b/src/data/sinnoh/gaia/durant.json
@@ -2,77 +2,127 @@
   "id": "durant",
   "name": "Durant",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar usa Otra Vez",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Si se queda --> Bola Sombra",
+      "detail": "Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Se queda → Maquinación + Bola sombra para debilitar",
+          "detail": "Si Durant se queda, usa Bola Sombra.",
           "variant": [
             {
-              "detail": "Golem --> Cambiar a Chansey y usar Trampa Rocas si se queda; cambiar a Slowbro y usar Bostezo al enfrentar a Gengar; entrar con Volcarona +1 y usar Psíquico al enfrentar a Gengar",
-              "variant": []
+              "detail": "Si vuelve a quedarse, usa Maquinación y Bola Sombra para debilitarlo.",
+              "variant": [
+                {
+                  "detail": "Si sale Golem, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 si se queda.",
+                  "variant": [
+                    {
+                      "detail": "Luego cambia a Slowbro y usa Bostezo al enfrentar a Gengar. Entra con Volcarona, usa Danza Aleteo x1 y Psíquico al enfrentar a Gengar. 👻",
+                      "variant": []
+                    }
+                  ]
+                },
+                {
+                  "detail": "Si usa Maquinación y cambia a Hippowdon, cambia a Slowbro y usa Bostezo al enfrentar a Durant.",
+                  "variant": [
+                    {
+                      "detail": "Usa Protección y vuelve a usar Bostezo. Si sale Rhyperior, usa Teletransporte y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": []
+                    }
+                  ]
+                },
+                {
+                  "detail": "Si sale Cloyster, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             },
             {
-              "detail": "Si usa Maquinación y va hacia Hippowdon --> Cambiar a Slowbro y usar Bostezo al enfrentar a Durant; Usa protección y vuelve a usar Bostezo, sale Rhyperior → Teletransporte a Poliwrath +6",
-              "variant": []
-            },
-            {
-              "detail": "Cloyster → Politoed (sacrificar), Poliwrath +6",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Hippowdon --> Cambiar a Slowbro y usar Bostezo al enfrentar a Durant; Usa protección y vuelve a usar Bostezo, sale Amoonguss → Teletransporte a Poliwrath +6",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Rhyperior --> Revisar objeto",
-      "variant": [
-        {
-          "detail": "Restos --> Chansey, trampa rocas. Sale Emboar → Gengar, otra vez, +2",
-          "variant": [
-            {
-              "detail": "Se queda → Gengar, +4 (bola sombra a todos)",
-              "variant": []
-            },
-            {
-              "detail": "Druddigon → Politoed (sacrificar), Poliwrath + Atk X y presiona. (Puño Drenaje a Cloyster, Puño H a Dragonite y los demas cascada)",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Sin Restos --> Cambia a Slowbro, Bostezo",
-          "variant": [
-            {
-              "detail": "Se queda → Teletransporte a Volcarona, +1. Usa Gigadrenado para vencer a Rhyperior, sale Hippowdon → Toma un SpAtk X, presiona hasta que salga Walrein/Dewgong. + 1 Danza Aleteo, termina",
-              "variant": []
+              "detail": "Si sale Hippowdon, cambia a Slowbro y usa Bostezo al enfrentar a Durant.",
+              "variant": [
+                {
+                  "detail": "Usa Protección y vuelve a usar Bostezo. Si sale Amoonguss, usa Teletransporte y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             }
           ]
         }
       ]
     },
     {
-      "detail": "Si cambia a Rhyperior al usar Otra Vez --> Cambiar a Chansey y usar Trampa Rocas, toma 1 Max Poción ; Usa Amortiguador y Encanto hasta que cambie",
+      "detail": "Si sale Rhyperior, revisa su objeto.",
       "variant": [
         {
-          "detail": "Durant (Arriesgado) --> Volcarona, +1. (Psiquico a Gengar)",
-          "variant": []
+          "detail": "Si tiene Restos, entra Chansey y usa 🪨 Trampa Rocas 🪨.",
+          "variant": [
+            {
+              "detail": "Si sale Emboar, entra Gengar, usa Otra Vez y Maquinación hasta +2.",
+              "variant": [
+                {
+                  "detail": "Si Emboar se queda, Gengar usa Maquinación hasta +4 y barre con Bola Sombra.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si sale Druddigon, entra Politoed como pivote y entra con Poliwrath 🐸🥊. Usa Ataque X y presiona.",
+                  "variant": [
+                    {
+                      "detail": "Usa Puño Drenaje contra Cloyster, Puño Hielo contra Dragonite y Cascada contra los demás.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Durant (Estable) → Slowbro, bostezo. Sale Gengar → Cambia a Volcarona +1",
-          "variant": []
+          "detail": "Si no tiene Restos, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si Rhyperior se queda, usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1.",
+              "variant": [
+                {
+                  "detail": "Usa Gigadrenado para vencer a Rhyperior. Si sale Hippowdon, usa Especial X y presiona hasta que salga Walrein o Dewgong.",
+                  "variant": [
+                    {
+                      "detail": "Luego usa Danza Aleteo x1 más y termina.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Druddigon --> Sacrificar a Politoed ; entrar con Poliwrath +6 y usar Puño Drenaje para absorber y mantener la línea de HP",
-      "variant": []
+      "detail": "Si cambia a Rhyperior al usar Otra Vez, cambia a Chansey y usa 🪨 Trampa Rocas 🪨.",
+      "variant": [
+        {
+          "detail": "Usa una Max Poción, luego Amortiguador y Encanto hasta que cambie.",
+          "variant": [
+            {
+              "detail": "Ruta arriesgada contra Durant: entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico contra Gengar. 👻",
+              "variant": []
+            },
+            {
+              "detail": "Ruta estable contra Durant: cambia a Slowbro y usa Bostezo. Si sale Gengar, cambia a Volcarona y usa Danza Aleteo x1.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Druddigon, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y usa Puño Drenaje para absorber y mantener la línea de HP.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/gaia/emboar.json
+++ b/src/data/sinnoh/gaia/emboar.json
@@ -2,6 +2,21 @@
   "id": "emboar",
   "name": "Emboar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Sacrificar a Politoed, entrar con Slowbro  y usar Bostezo al enfrentar a Durant; usar Teletransporte  y entrar con Poliwrath +6 💡 Usar Cascada contra Rhyperior",
-  "tricks": []
+  "initialMove": "Entra Politoed como pivote.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Slowbro y usa Bostezo al enfrentar a Durant.",
+      "variant": [
+        {
+          "detail": "Usa Teletransporte y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Cascada contra Rhyperior.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/gaia/forretress.json
+++ b/src/data/sinnoh/gaia/forretress.json
@@ -2,15 +2,20 @@
   "id": "forretress",
   "name": "Forretress",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Cambiar a Volcarona🔔",
+  "initialMove": "Cambia a Volcarona.",
   "tricks": [
     {
-      "detail": "Si se queda --> Volcarona +1 y presionar",
+      "detail": "Si Forretress se queda, Volcarona usa Danza Aleteo x1 y presiona.",
       "variant": []
     },
     {
-      "detail": "Rhyperior --> Absorber hasta que debilite al enfrentar a Jellicent ; usar Danza Aleteo (+1 y presionar",
-      "variant": []
+      "detail": "Si sale Rhyperior, absorbe hasta que debilite al enfrentar a Jellicent.",
+      "variant": [
+        {
+          "detail": "Luego usa Danza Aleteo x1 y presiona.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/gaia/gengar.json
+++ b/src/data/sinnoh/gaia/gengar.json
@@ -2,42 +2,72 @@
   "id": "gengar",
   "name": "Gengar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Absol --> Cambiar a Slowbro y usar Bostezo ; entrar con Volcarona (moth) +1 🔔Usar Psíquico al enfrentar a Gengar🔔",
-      "variant": []
-    },
-    {
-      "detail": "Rhyperior --> Usar Teletransporte y revisar objeto",
+      "detail": "Si sale Absol, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Vidaesfera --> Slowbro usa Bostezo ; sacrificar a Politoed ; entrar con Poliwrath +6 y usar Puño Hielo contra Gengar",
-          "variant": []
-        },
-        {
-          "detail": "Sin Vidaesfera --> Enviar a Slowbro y usar Bostezo al enfrentar a Quagsire; continuar usando Bostezo",
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Si se queda --> Usar Teletransporte ; entrar con Volcarona  +1 🔔usar Psíquico al enfrentar a Gengar🔔 ",
-      "variant": []
-    },
-    {
-      "detail": "Gengar --> Entrar con Volcarona  +1 🔔usar Psíquico al enfrentar a Gengar🔔",
-      "variant": []
-    },
-    {
-      "detail": "Durant --> Opciones para resolver",
+      "detail": "Si sale Rhyperior, usa Teletransporte y revisa su objeto.",
       "variant": [
         {
-          "detail": "Estable --> Cambiar a Slowbro y usar Bostezo al enfrentar a Gengar; entrar con Volcarona +1 y usar Psíquico al enfrentar a Gengar ",
-          "variant": []
+          "detail": "Si tiene Vidaesfera, Slowbro usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Gengar.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Arriesgado --> Entrar con Volcarona +1",
+          "detail": "Si no tiene Vidaesfera, envía a Slowbro y usa Bostezo al enfrentar a Quagsire.",
+          "variant": [
+            {
+              "detail": "Continúa usando Bostezo según la ruta.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si Gengar se queda, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Gengar, entra con Volcarona y usa Danza Aleteo x1.",
+      "variant": [
+        {
+          "detail": "Usa Psíquico al enfrentar a Gengar. 👻",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Durant, elige ruta estable o arriesgada.",
+      "variant": [
+        {
+          "detail": "Ruta estable: cambia a Slowbro y usa Bostezo al enfrentar a Gengar.",
+          "variant": [
+            {
+              "detail": "Luego entra con Volcarona, usa Danza Aleteo x1 y Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Ruta arriesgada: entra con Volcarona y usa Danza Aleteo x1.",
           "variant": []
         }
       ]

--- a/src/data/sinnoh/gaia/gliscor.json
+++ b/src/data/sinnoh/gaia/gliscor.json
@@ -2,15 +2,40 @@
   "id": "gliscor",
   "name": "Gliscor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " 🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Emboar --> Cambiar a Slowbro y usar Bostezo al enfrentar a Durant; usar Teletransporte  entrar con Volcarona (moth) +1 y usar Especial X 🔔Si el HP de Druddigon baja del 36% dos veces, darle medicina primero🔔",
-      "variant": []
+      "detail": "Si sale Emboar, cambia a Slowbro y usa Bostezo al enfrentar a Durant.",
+      "variant": [
+        {
+          "detail": "Usa Teletransporte, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": [
+            {
+              "detail": "Si el HP de Druddigon baja del 36% dos veces, usa medicina primero.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Durant --> Gengar  usa Otra Vez cambiar a Slowbro  al enfrentar a Rhyperior; usar Bostezo al enfrentar a Durant; usar Teletransporte  entrar con Volcarona  +1 y usar Especial X 🔔Si el HP de Druddigon baja del 36% dos veces, darle medicina primero🔔",
-      "variant": []
+      "detail": "Si sale Durant, cambia a Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro al enfrentar a Rhyperior y usa Bostezo al enfrentar a Durant.",
+          "variant": [
+            {
+              "detail": "Usa Teletransporte, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+              "variant": [
+                {
+                  "detail": "Si el HP de Druddigon baja del 36% dos veces, usa medicina primero.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/gaia/golem.json
+++ b/src/data/sinnoh/gaia/golem.json
@@ -2,15 +2,30 @@
   "id": "golem",
   "name": "Golem",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨 al enfrentar a Durant",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Estable --> Cambiar a Slowbro y luego a Volcarona al enfrentar a Gengar; Volcarona +1 🔔Usar Psíquico al enfrentar a Gengar (ghost)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Arriesgado --> Entrar con Volcarona +1 🔔Usar Psíquico al enfrentar a Gengar 🔔",
-      "variant": []
+      "detail": "Al enfrentar a Durant, elige la ruta estable o arriesgada.",
+      "variant": [
+        {
+          "detail": "Ruta estable: cambia a Slowbro y luego entra con Volcarona al enfrentar a Gengar.",
+          "variant": [
+            {
+              "detail": "Volcarona usa Danza Aleteo x1 y presiona. Usa Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Ruta arriesgada: entra con Volcarona y usa Danza Aleteo x1.",
+          "variant": [
+            {
+              "detail": "Usa Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/gaia/hippowdon.json
+++ b/src/data/sinnoh/gaia/hippowdon.json
@@ -2,15 +2,30 @@
   "id": "hippowdon",
   "name": "Hippowdon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Opciones para resolver 💡",
+  "initialMove": "Elige una ruta.",
   "tricks": [
     {
-      "detail": "Estable --> Cambiar a Slowbro al enfrentar a Durant; usar Bostezo ; usar Teletransporte  entrar con Volcarona +1 para debilitar al enfrentar a Hippowdon; usar Especial X y presionar",
-      "variant": []
+      "detail": "Ruta estable: cambia a Slowbro al enfrentar a Durant.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo y luego Teletransporte.",
+          "variant": [
+            {
+              "detail": "Entra con Volcarona, usa Danza Aleteo x1 para debilitar al enfrentar a Hippowdon, luego usa Especial X y presiona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Rápido --> Usar Encanto al enfrentar a Durant; entrar con Volcarona +1 y usar Especial X",
-      "variant": []
+      "detail": "Ruta rápida: usa Encanto al enfrentar a Durant.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/gaia/nidoking.json
+++ b/src/data/sinnoh/gaia/nidoking.json
@@ -2,6 +2,16 @@
   "id": "nidoking",
   "name": "Nidoking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 al enfrentar a Absol; cambiar a Slowbro y usar Bostezo; entrar con Volcarona (moth) +1 🔔 Usar Psíquico al enfrentar a Gengar 🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Absol, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/gaia/parasect.json
+++ b/src/data/sinnoh/gaia/parasect.json
@@ -2,28 +2,28 @@
   "id": "parasect",
   "name": "Parasect",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Demolición --> Teletransporte ",
+      "detail": "Si Parasect usa Demolición, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Si se queda --> Volcarona +1",
+          "detail": "Si Parasect se queda, entra con Volcarona y usa Danza Aleteo x1.",
           "variant": []
         },
         {
-          "detail": "Rhyperior --> Slowbro, Bostezo (Mira la situación) ",
+          "detail": "Si sale Rhyperior, Slowbro usa Bostezo y revisa la situación.",
           "variant": [
             {
-              "detail": "Acierta --> Teletransporte a Volcarona +1",
+              "detail": "Si Megacuerno acierta, usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1.",
               "variant": []
             },
             {
-              "detail": "Falla --> Cambia a Volcarona +1",
-          "variant": []
+              "detail": "Si Megacuerno falla, cambia a Volcarona y usa Danza Aleteo x1.",
+              "variant": []
             },
             {
-              "detail": "Parasect --> Entrar con Volcarona +1",
+              "detail": "Si sale Parasect, entra con Volcarona y usa Danza Aleteo x1.",
               "variant": []
             }
           ]
@@ -31,27 +31,32 @@
       ]
     },
     {
-      "detail": "Rhyperior --> Usar Encanto y cambiar a Slowbro ",
+      "detail": "Si sale Rhyperior, usa Encanto y cambia a Slowbro.",
       "variant": [
         {
-          "detail": "Si se queda --> Usar Bostezo al enfrentar a Parasect  entrar con Volcarona +1",
+          "detail": "Si Rhyperior se queda, usa Bostezo al enfrentar a Parasect y entra con Volcarona para usar Danza Aleteo x1.",
           "variant": []
         },
         {
-          "detail": "Parasect --> Entrar con Volcarona +1",
+          "detail": "Si sale Parasect, entra con Volcarona y usa Danza Aleteo x1.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Durant --> Opciones para resolver",
+      "detail": "Si sale Durant, elige ruta estable o arriesgada.",
       "variant": [
         {
-          "detail": "Estable --> Cambiar a Slowbro y usar Bostezo al enfrentar a Gengar; entrar con Volcarona +1 🔔usar Psíquico al enfrentar a Gengar🔔",
-          "variant": []
+          "detail": "Ruta estable: cambia a Slowbro y usa Bostezo al enfrentar a Gengar.",
+          "variant": [
+            {
+              "detail": "Entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Arriesgado --> Entrar con Volcarona +1 🔔usar Psíquico al enfrentar a Gengar🔔",
+          "detail": "Ruta arriesgada: entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
           "variant": []
         }
       ]

--- a/src/data/sinnoh/gaia/quagsire.json
+++ b/src/data/sinnoh/gaia/quagsire.json
@@ -2,28 +2,43 @@
   "id": "quagsire",
   "name": "Quagsire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Cambiar a Slowbro 🔔",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Si se queda --> Usar Bostezo al enfrentar a Gengar entrar con Volcarona +1 🔔 Usar Psíquico al enfrentar a Gengar 🔔",
-      "variant": []
-    },
-    {
-      "detail": "Rhyperior --> Usar Bostezo ",
+      "detail": "Si Quagsire se queda, usa Bostezo al enfrentar a Gengar.",
       "variant": [
         {
-          "detail": "Megacuerno acierta --> Usar Teletransporte entrar con Volcarona  usar Especial X y presionar",
-          "variant": []
-        },
-        {
-          "detail": "Megacuerno falla --> Entrar con Volcarona , usar Especial X y presionar",
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Gengar --> Entrar con Volcarona +1 🔔 Usar Psíquico al enfrentar a Gengar 🔔",
-      "variant": []
+      "detail": "Si sale Rhyperior, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Megacuerno acierta, usa Teletransporte.",
+          "variant": [
+            {
+              "detail": "Entra con Volcarona, usa Especial X y presiona.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si Megacuerno falla, entra con Volcarona, usa Especial X y presiona.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Gengar, entra con Volcarona y usa Danza Aleteo x1.",
+      "variant": [
+        {
+          "detail": "Usa Psíquico al enfrentar a Gengar. 👻",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/gaia/rhyperior.json
+++ b/src/data/sinnoh/gaia/rhyperior.json
@@ -2,45 +2,101 @@
   "id": "rhyperior",
   "name": "Rhyperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda --> Revisar objeto ",
+      "detail": "Si Rhyperior se queda, revisa su objeto.",
       "variant": [
         {
-          "detail": "Vidaesfera  --> Usar Teletransporte enviar a Slowbro y usar Bostezo para ver movimientos",
+          "detail": "Si tiene Vidaesfera, usa Teletransporte para enviar a Slowbro y usa Bostezo para ver movimientos.",
           "variant": [
             {
-              "detail": "Terremoto --> Sacrificar a Politoed ; entrar con Poliwrath +6  🔔usar Puño Hielo contra Gengar🔔 ",
+              "detail": "Si usa Terremoto, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Hielo contra Gengar.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si Megacuerno acierta, usa Teletransporte.",
+              "variant": [
+                {
+                  "detail": "Entra con Volcarona, usa Especial X y presiona.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si Megacuerno falla, entra con Volcarona, usa Especial X y presiona.",
               "variant": []
             },
             {
-              "detail": "Megacuerno acierta --> Usar Teletransporte ; entrar con Volcarona , usar Especial X y presionar",
-              "variant": []
-            },
-            {
-              "detail": "Megacuerno falla --> Entrar con Volcarona , usar Especial X y presionar",
-              "variant": []
-            },
-            {
-              "detail": "Gengar --> Sacrificar a Politoed ; entrar con Poliwrath  +6 y usar Puño Hielo contra Gengar ",
-              "variant": []
+              "detail": "Si sale Gengar, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Hielo contra Gengar.",
+                  "variant": []
+                }
+              ]
             }
           ]
         },
         {
-          "detail": "Sin Vidaesfera --> Usar Amortiguador  y Encanto ; mantener línea de HP con Amortiguador; si el  🔔 HP está bajo, usar max pocion primero 🔔",
+          "detail": "Si no tiene Vidaesfera, usa Amortiguador y Encanto.",
           "variant": [
             {
-              "detail": "Si se queda --> Cambiar a Slowbro y usar Bostezo ",
+              "detail": "Mantén la línea de HP con Amortiguador. Si el HP está bajo, usa Max Poción primero.",
               "variant": []
             },
             {
-              "detail": "Terremoto --> Usar Teletransporte  entrar con Volcarona +1 🔔 Usar Psíquico al enfrentar a Gengar🔔",
+              "detail": "Si Rhyperior se queda, cambia a Slowbro y usa Bostezo.",
               "variant": []
             },
             {
-              "detail": "Gengar / Parasect --> Entrar con Volcarona +1 🔔 Usar Psíquico al enfrentar a Gengar🔔",
+              "detail": "Si usa Terremoto, usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1.",
+              "variant": [
+                {
+                  "detail": "Usa Psíquico al enfrentar a Gengar. 👻",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Gengar o Parasect, entra con Volcarona y usa Danza Aleteo x1.",
+              "variant": [
+                {
+                  "detail": "Usa Psíquico al enfrentar a Gengar. 👻",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Durant, envía a Slowbro y usa Bostezo al enfrentar a Gengar.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Parasect, cambia a Volcarona.",
+      "variant": [
+        {
+          "detail": "Si Parasect se queda, Volcarona usa Danza Aleteo x1.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rhyperior, absorbe hasta que te debilite al enfrentar a Blastoise.",
+          "variant": [
+            {
+              "detail": "Entra con Chansey para atraer a Parasect y luego entra con Volcarona para usar Danza Aleteo x1.",
               "variant": []
             }
           ]
@@ -48,63 +104,66 @@
       ]
     },
     {
-      "detail": "Durant --> Enviar a Slowbro y usar Bostezo al enfrentar a Gengar ; entrar con Volcarona +1 🔔usar Psíquico al enfrentar a Gengar🔔",
-      "variant": []
-    },
-    {
-      "detail": "Parasect --> Cambiar a Volcarona",
+      "detail": "Si sale Absol, cambia a Slowbro y luego a Volcarona.",
       "variant": [
         {
-          "detail": "Si se queda --> Volcarona +1",
-          "variant": []
-        },
-        {
-          "detail": "Rhyperior --> Absorber hasta que debilite al enfrentar a Blastoise ; entrar con Chansey y atraer a Parasect ; entrar con Volcarona +1",
+          "detail": "Al enfrentar a Gengar o Nidoking, Volcarona usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Absol --> Cambiar a Slowbro y luego a Volcarona ; al enfrentar a Gengar o Nidoking  Volcarona +1 🔔 Usar Psíquico al enfrentar a Gengar🔔",
-      "variant": []
-    },
-    {
-      "detail": "Absol --> Cambiar a Slowbro y usar Bostezo ; entrar con Volcarona +1 🔔 Usar Psíquico al enfrentar a Gengar🔔",
-      "variant": []
-    },
-    {
-      "detail": "Emboar --> Cambiar a Slowbro y usar Bostezo al enfrentar a Durant; usar Teletransporte ; entrar con Volcarona +1 y usar Especial X 🔔 Si el HP de Druddigon baja del 36% dos veces, darle medicina primero 🔔",
-      "variant": []
-    },
-    {
-      "detail": "Durant --> Usar Teletransporte ; enviar a Slowbro y usar Bostezo ",
+      "detail": "Ruta alternativa contra Absol: cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Si se queda --> Usar Teletransporte entrar con Volcarona +1 y usar Especial X",
-          "variant": []
-        },
-        {
-          "detail": "Gengar --> Entrar con Volcarona +1 🔔 Usar Psíquico al enfrentar a Gengar (ghost) 🔔",
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Parasect --> Cambiar a Volcarona ",
+      "detail": "Si sale Emboar, cambia a Slowbro y usa Bostezo al enfrentar a Durant.",
       "variant": [
         {
-          "detail": "Si se queda --> Volcarona +1",
-          "variant": []
-        },
-        {
-          "detail": "Rhyperior --> Absorber al enfrentar a Blastoise  entrar con Slowbro  y usar Bostezo ",
+          "detail": "Usa Teletransporte, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
           "variant": [
             {
-              "detail": "Si se queda --> Usar Protección  y Relajo  al enfrentar a Parasect ; entrar con Volcarona  +1",
+              "detail": "Si el HP de Druddigon baja del 36% dos veces, usa medicina primero.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Durant, usa Teletransporte, envía a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Durant se queda, usa Teletransporte, entra con Volcarona, usa Danza Aleteo x1 y Especial X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Gengar, entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Otra ruta contra Parasect: cambia a Volcarona.",
+      "variant": [
+        {
+          "detail": "Si Parasect se queda, Volcarona usa Danza Aleteo x1.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Rhyperior, absorbe al enfrentar a Blastoise, entra con Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si Rhyperior se queda, usa Protección y Relajo al enfrentar a Parasect. Luego entra con Volcarona y usa Danza Aleteo x1.",
               "variant": []
             },
             {
-              "detail": "Parasect --> Entrar con Volcarona +1",
+              "detail": "Si sale Parasect, entra con Volcarona y usa Danza Aleteo x1.",
               "variant": []
             }
           ]

--- a/src/data/sinnoh/gaia/sableye.json
+++ b/src/data/sinnoh/gaia/sableye.json
@@ -2,37 +2,57 @@
   "id": "sableye",
   "name": "Sableye",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Cambiar a Slowbro🔔",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Si se queda --> Usar Bostezo",
+      "detail": "Si Sableye se queda, usa Bostezo.",
       "variant": []
     },
     {
-      "detail": "Rhyperior / Camerupt --> Usar Teletransporte entrar con Volcarona , usar Especial X y presionar",
-      "variant": []
-    },
-    {
-      "detail": "Serperior --> Entrar con Volcarona +2",
-      "variant": []
-    },
-    {
-      "detail": "Durant --> Usar Teletransporte ; entrar con Volcarona +1 para debilitar al enfrentar a Hippowdon; usar Especial X y presionar",
-      "variant": []
-    },
-    {
-      "detail": "Durant --> Usar Bostezo ; usar Teletransporte ; entrar con Volcarona +1 para debilitar al enfrentar a Hippowdon; usar Especial X y presionar para completar",
-      "variant": []
-    },
-    {
-      "detail": "Rhyperior --> Usar Bostezo 🔔 Revisar si Megacuerno acierta 🔔",
+      "detail": "Si sale Rhyperior o Camerupt, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Acierta --> Usar Teletransporte ; entrar con Volcarona , usar Especial X y presionar",
+          "detail": "Entra con Volcarona, usa Especial X y presiona.",
           "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Serperior, entra con Volcarona y usa Danza Aleteo x2.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Durant, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Entra con Volcarona, usa Danza Aleteo x1 para debilitar al enfrentar a Hippowdon, luego usa Especial X y presiona.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta alternativa contra Durant: usa Bostezo y luego Teletransporte.",
+      "variant": [
+        {
+          "detail": "Entra con Volcarona, usa Danza Aleteo x1 para debilitar al enfrentar a Hippowdon, luego usa Especial X y presiona para completar.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Rhyperior, usa Bostezo y revisa si Megacuerno acierta.",
+      "variant": [
+        {
+          "detail": "Si Megacuerno acierta, usa Teletransporte.",
+          "variant": [
+            {
+              "detail": "Entra con Volcarona, usa Especial X y presiona.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Falla --> Cambiar a Volcarona , usar Especial X y presionar",
+          "detail": "Si Megacuerno falla, cambia a Volcarona, usa Especial X y presiona.",
           "variant": []
         }
       ]

--- a/src/data/sinnoh/gaia/seismitoad.json
+++ b/src/data/sinnoh/gaia/seismitoad.json
@@ -2,6 +2,21 @@
   "id": "seismitoad",
   "name": "Seismitoad",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro al enfrentar a Rhyperior; usar Bostezo ; sacrificar a Politoed ; entrar con Poliwrath +6 🔔 Usar Puño Hielo contra Gengar 🔔",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Rhyperior, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Hielo contra Gengar.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/gaia/skarmory.json
+++ b/src/data/sinnoh/gaia/skarmory.json
@@ -2,6 +2,21 @@
   "id": "skarmory",
   "name": "Skarmory",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨  al enfrentar a Absol; cambiar a Slowbro y usar Bostezo ; entrar con Volcarona (+1 🔔 Usar Psíquico al enfrentar a Gengar 🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Absol, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x1.",
+          "variant": [
+            {
+              "detail": "Usa Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/gaia/steelix.json
+++ b/src/data/sinnoh/gaia/steelix.json
@@ -2,6 +2,21 @@
   "id": "steelix",
   "name": "Steelix",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro al enfrentar a Rhyperior; usar Bostezo ; sacrificar a Politoed entrar con Poliwrath +6  🔔usar Puño Hielo contra Gengar🔔",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Rhyperior, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Hielo contra Gengar.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/gaia/sudowoodo.json
+++ b/src/data/sinnoh/gaia/sudowoodo.json
@@ -2,6 +2,21 @@
   "id": "sudowoodo",
   "name": "Sudowoodo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro y usar Bostezo ; sacrificar a Politoed entrar con Poliwrath  +6 🔔 Usar Puño Hielo contra Gengar 🔔",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Hielo contra Gengar.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/gaia/tangrowth.json
+++ b/src/data/sinnoh/gaia/tangrowth.json
@@ -2,17 +2,22 @@
   "id": "tangrowth",
   "name": "Tangrowth",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Cambiar a Slowbro💡",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Rhyperior --> Usar Bostezo y revisar si Megacuerno acierta",
+      "detail": "Si sale Rhyperior, usa Bostezo y revisa si Megacuerno acierta.",
       "variant": [
         {
-          "detail": "Acierta --> Usar Teletransporte  entrar con Volcarona , usar Especial X y presionar",
-          "variant": []
+          "detail": "Si Megacuerno acierta, usa Teletransporte.",
+          "variant": [
+            {
+              "detail": "Entra con Volcarona, usa Especial X y presiona.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Falla --> Cambiar a Volcarona , usar Especial X y presionar",
+          "detail": "Si Megacuerno falla, cambia a Volcarona, usa Especial X y presiona.",
           "variant": []
         }
       ]

--- a/src/data/sinnoh/gaia/walrein.json
+++ b/src/data/sinnoh/gaia/walrein.json
@@ -2,19 +2,44 @@
   "id": "walrein",
   "name": "Walrein",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Cambiar a Slowbro🔔",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Superdiente ➜ Cambiar a Chansey y usar Trampa Rocas ➜ Frente a Absol ➜ cambiar a Slowbro Bostezo ➜ al enfrentar  a Gengar/Nidoking ➜ entra con Volcarona x1 danza aleteo 🔔(Usar Psíquico al enfrentar a Gengar)🔔",
-      "variant": []
+      "detail": "Si Walrein usa Superdiente, cambia a Chansey y usa 🪨 Trampa Rocas 🪨.",
+      "variant": [
+        {
+          "detail": "Frente a Absol, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Al enfrentar a Gengar o Nidoking, entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Absol ➜ Cambiar a Chansey y usar Trampa Rocas, cambiar a Slowbro y usar Bostezo, entrar con Volcarona x1 danza aleteo 🔔(Usar Psíquico al enfrentar a Gengar)🔔",
-      "variant": []
+      "detail": "Si sale Absol, cambia a Chansey y usa 🪨 Trampa Rocas 🪨.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Entra con Volcarona y usa Danza Aleteo x1. Usa Psíquico al enfrentar a Gengar. 👻",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Durant ➜ Slowbro usa Protección y bostezo ➜ Usa bostezo o Teletransporte y cambia a Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Durant, Slowbro usa Protección y Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego usa Bostezo o Teletransporte y cambia a Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/gaia/whiscash.json
+++ b/src/data/sinnoh/gaia/whiscash.json
@@ -2,41 +2,55 @@
   "id": "whiscash",
   "name": "Whiscash",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Trampa Rocas🔔 Si no Cambia Usa Amortiguador",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Rhyperior ➜ Chansey Encanto y entra con Slowbro y usa Bostezo",
+      "detail": "Si Whiscash no cambia, usa Amortiguador.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Rhyperior, Chansey usa Encanto.",
       "variant": [
         {
-          "detail": "Si se queda ➜ Usa Bostezo otra vez Para que entre Parasect y entrar con Volcarona x1 danza aleteo",
-          "variant": []
-        },
-        {
-          "detail": "Parasect ➜ Entra con Volcarona x1 danza aleteo",
-          "variant": []
+          "detail": "Entra Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si Rhyperior se queda, usa Bostezo otra vez para que entre Parasect. Luego entra con Volcarona y usa Danza Aleteo x1.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Parasect, entra con Volcarona y usa Danza Aleteo x1.",
+              "variant": []
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Parasect ➜ Usa Teletransporte ",
+      "detail": "Si sale Parasect, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Si parasect se Queda ➜ volcarona x1 danza aleteo y lanzallamas",
+          "detail": "Si Parasect se queda, entra con Volcarona, usa Danza Aleteo x1 y Lanzallamas.",
           "variant": []
         },
         {
-          "detail": "Rhyperior ➜ Slowbro Bostezo (Mira si Megacuerno golpea o falla)",
+          "detail": "Si sale Rhyperior, Slowbro usa Bostezo y revisa si Megacuerno acierta.",
           "variant": [
             {
-              "detail": "Si Golpea ➜ slowbro usa Teletransporte ➜ Volcarona x1 Danza Aleteo (Si quieres ahorrar dinero usa proteccion y usa Bostezo entra Con Volcarona x1 Danza aleteo)",
+              "detail": "Si Megacuerno acierta, Slowbro usa Teletransporte y entra con Volcarona para usar Danza Aleteo x1.",
+              "variant": [
+                {
+                  "detail": "Ruta de ahorro: usa Protección y Bostezo, luego entra con Volcarona y usa Danza Aleteo x1.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si Megacuerno falla, entra con Volcarona y usa Danza Aleteo x1.",
               "variant": []
             },
             {
-              "detail": "Si Falla ➜  volcarona x1 Danza Aleteo",
-              "variant": []
-            },
-            {
-              "detail": "Sale Parasect ➜ Volcarona x1 Danza Aleteo",
+              "detail": "Si sale Parasect, entra con Volcarona y usa Danza Aleteo x1.",
               "variant": []
             }
           ]


### PR DESCRIPTION
## Summary
- Cleans all Sinnoh Gaia Spanish strategy JSON files.
- Keeps `initialMove` limited to the opening switch/action only.
- Moves follow-up routes into `tricks.detail` and nested `variant` entries.
- Replaces old Politoed sacrifice wording with pivot wording.
- Expands shorthand setup text for Poliwrath, Gengar, and Volcarona.
- Keeps `Especial X` wording for translation compatibility.

## Scope
- Sinnoh Gaia strategy JSON files only.
- No English translation changes.
- No asset changes.
- No frontend layout changes.

## Files
- 27 files under `src/data/sinnoh/gaia`.