### PR TITLE
Release Sinnoh Fausto Spanish structure cleanup

### DIFF
--- a/src/data/sinnoh/fausto/arcanine.json
+++ b/src/data/sinnoh/fausto/arcanine.json
@@ -2,6 +2,16 @@
   "id": "arcanine",
   "name": "Arcanine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Slowbro usa Bostezo  al enfrentar a Cacturne  sacrificar a Politoed  entrar con Poliwrath  +6 💡",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo al enfrentar a Cacturne.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/fausto/blaziken.json
+++ b/src/data/sinnoh/fausto/blaziken.json
@@ -2,6 +2,21 @@
   "id": "blaziken",
   "name": "Blaziken",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro y usar Bostezo al enfrentar a Cacturne; sacrificar a Politoed; entrar con Poliwrath +6 🔔(Puño Drenaje a Magmortar)🔔",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo al enfrentar a Cacturne.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Magmortar.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/fausto/bouffalant.json
+++ b/src/data/sinnoh/fausto/bouffalant.json
@@ -2,15 +2,44 @@
   "id": "bouffalant",
   "name": "Bouffalant",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Gengar usa Onda Certera y entra con Chansey y usa Trampa Rocas",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Camerupt ➜ Slowbro usa Bostezo y sacrifica a Politoed , Poliwrath  +6🐸🥊 🔔Puño Drenaje a Steelix / Magmortar🔔",
-      "variant": []
+      "detail": "Gengar usa Onda Certera.",
+      "variant": [
+        {
+          "detail": "Luego entra Chansey y usa 🪨 Trampa Rocas 🪨.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Maractus ➜ Teletransporte, Slowbro usa Bostezo y sacrifica a Politoed , Poliwrath a +6🐸🥊 🔔Puño Drenaje a Steelix / Magmortar🔔",
-      "variant": []
+      "detail": "Si sale Camerupt, Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Steelix o Magmortar.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Maractus, usa Teletransporte y Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Steelix o Magmortar.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/fausto/bronzong.json
+++ b/src/data/sinnoh/fausto/bronzong.json
@@ -2,32 +2,57 @@
   "id": "bronzong",
   "name": "Bronzong",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Infernape ➜ Usar Amortiguador o Teletransporte ➜ entrar con Gengar Otra Vez +4 +2  🔔 Usar Bola Sombra a todos 🔔",
-      "variant": []
-    },
-    {
-      "detail": "Medicham ➜ Entrar con Gengar +4 (No usar Otra Vez) 🔔 Usar Bola Sombra a todos 🔔",
-      "variant": []
-    },
-    {
-      "detail": "Blaziken / Arcanine ➜ Cambiar a Slowbro y usar Bostezo al enfrentar a Cacturne ",
+      "detail": "Si sale Infernape, usa Amortiguador o Teletransporte.",
       "variant": [
         {
-          "detail": "Rápido ➜ Sacrifica a Politoed ➜ entra con Poliwrath +6 (puño drenaje a magmortar ",
-          "variant": []
-        },
+          "detail": "Entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Medicham, entra con Gengar y usa Maquinación hasta +4.",
+      "variant": [
         {
-          "detail": "Ahorrar dinero ➜ Entrar con Volcarona +3",
+          "detail": "No uses Otra Vez. Usa Bola Sombra contra todos.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Haxorus ➜ Usar Amortiguador o Teletransporte  entrar con Gengar ➡ Otra Vez +6 🔔 Usar Bola Sombra  a todos 🔔",
-      "variant": []
+      "detail": "Si sale Blaziken o Arcanine, cambia a Slowbro y usa Bostezo al enfrentar a Cacturne.",
+      "variant": [
+        {
+          "detail": "Ruta rápida: entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Magmortar.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta de ahorro: entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Haxorus, usa Amortiguador o Teletransporte.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Otra Vez y Maquinación hasta +6.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/fausto/cacturne.json
+++ b/src/data/sinnoh/fausto/cacturne.json
@@ -2,6 +2,21 @@
   "id": "cacturne",
   "name": "Cacturne",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔 Gengar Otra Vez +4 +2 (Bola Sombra a Todos) 🔔",
-  "tricks": []
+  "initialMove": "Cambia a Gengar.",
+  "tricks": [
+    {
+      "detail": "Usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/fausto/camerupt.json
+++ b/src/data/sinnoh/fausto/camerupt.json
@@ -2,18 +2,32 @@
   "id": "camerupt",
   "name": "Camerupt",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 Frente a Bouffalant (cinta elegida) ➜ cambiar a Gengar y usa Maquinación ➜ Dragonite atacar con bola sombra",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Magmortar ➜ Sacrifica a Politoed ➜  Poliwrath +6🐸🥊 (puño drenaje Magmortar) ",
-      "variant": []
-    },
-    {
-      "detail": "Steelix ➜  Slowbro, Bostezo ➜ sacrifica a Politoed  ➜ Poliwrath +6🐸🥊(puño drenaje steelix) ",
+      "detail": "Frente a Bouffalant con Cinta Elegida, cambia a Gengar y usa Maquinación.",
       "variant": [
         {
-          "detail": "Arriesgado ➜ Sacrifica a Politoed  ➜ Poliwrath +6🐸🥊",
-          "variant": []
+          "detail": "Al enfrentar a Dragonite, ataca con Bola Sombra.",
+          "variant": [
+            {
+              "detail": "Si sale Magmortar, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Magmortar.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Steelix, Slowbro usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Steelix.",
+                  "variant": []
+                },
+                {
+                  "detail": "Ruta arriesgada: entra Politoed como pivote directo y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/sinnoh/fausto/charizard.json
+++ b/src/data/sinnoh/fausto/charizard.json
@@ -2,15 +2,25 @@
   "id": "charizard",
   "name": "Charizard",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 TRAMPA ROCAS 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Lopunny ➜ Cambiar a Slowbro y usar Bostezo al enfrentar a Maractus entrar con Volcarona +3 🔔puede usar Especial X y Gigadrenado a Steelix🔔",
-      "variant": []
+      "detail": "Si sale Lopunny, cambia a Slowbro y usa Bostezo al enfrentar a Maractus.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X y Gigadrenado contra Steelix.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Maractus ➜ Gengar usa Bola Sombra para romper la Banda Focus ➜ entrar con Volcarona +3 🔔puede usar Especial X y Gigadrenado a Steelix🔔",
-      "variant": []
+      "detail": "Si sale Maractus, Gengar usa Bola Sombra para romper la Banda Focus.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X y Gigadrenado contra Steelix.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/fausto/conkeldurr.json
+++ b/src/data/sinnoh/fausto/conkeldurr.json
@@ -2,19 +2,44 @@
   "id": "conkeldurr",
   "name": "Conkeldurr",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨  Gengar Otra vez +2",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Conkeldur ➜ Gengar +4 + Precisión X ",
-      "variant": []
-    },
-    {
-      "detail": "Salamence ➜ Bola sombra a Salamence ➜Frente a Steelix ➜ sacrifica a Politoed ➜ Poliwrath usar Ataque X y presionar 🔔 Cascada  a Steelix / Conkeldurr Puño Drenaje🔔 ",
-      "variant": []
-    },
-    {
-      "detail": "Ludicolo ➜  Slowbro , Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊",
-      "variant": []
+      "detail": "Luego entra con Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +2.",
+          "variant": [
+            {
+              "detail": "Si Conkeldurr se queda, Gengar usa Maquinación hasta +4 y Precisión X.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Salamence, usa Bola Sombra contra Salamence.",
+              "variant": [
+                {
+                  "detail": "Frente a Steelix, entra Politoed como pivote y entra con Poliwrath 🐸🥊. Usa Ataque X y presiona.",
+                  "variant": [
+                    {
+                      "detail": "Usa Cascada contra Steelix y Puño Drenaje contra Conkeldurr.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Ludicolo, Slowbro usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/fausto/dragonite.json
+++ b/src/data/sinnoh/fausto/dragonite.json
@@ -2,38 +2,52 @@
   "id": "dragonite",
   "name": "Dragonite",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Blaziken ➜ Slowbro , Bostezo ➜ Frente a Maractus 🔔Mira Abajo 🔔 ",
+      "detail": "Si sale Blaziken, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Rápido ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño drenaje Magmortar)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Ahorrar dinero ➜ Entrar con Volcarona x3 Danza aleteo",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Bouffalant ➜ Gengar usa Maquinación ➜ Si entra Dragonite eliminalo con bola sombra",
-      "variant": [
-        {
-          "detail": "Magmortar ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño drenaje contra Magmortar)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Steelix ➜  Slowbro , Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño drenaje contra Magmortar)🔔",
+          "detail": "Frente a Maractus, elige ruta rápida o de ahorro.",
           "variant": [
             {
-              "detail": "🚨Arriesgado🚨 ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊",
+              "detail": "Ruta rápida: entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Magmortar.",
+              "variant": []
+            },
+            {
+              "detail": "Ruta de ahorro: entra con Volcarona y usa Danza Aleteo x3.",
               "variant": []
             }
           ]
         }
-      ]   
+      ]
+    },
+    {
+      "detail": "Si sale Bouffalant, Gengar usa Maquinación.",
+      "variant": [
+        {
+          "detail": "Si entra Dragonite, elimínalo con Bola Sombra.",
+          "variant": [
+            {
+              "detail": "Si sale Magmortar, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Magmortar.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Steelix, Slowbro usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Magmortar.",
+                  "variant": []
+                },
+                {
+                  "detail": "Ruta arriesgada: entra Politoed como pivote directo y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
-  ]   
-}  
+  ]
+}

--- a/src/data/sinnoh/fausto/drifblim.json
+++ b/src/data/sinnoh/fausto/drifblim.json
@@ -2,6 +2,16 @@
   "id": "drifblim",
   "name": "Drifblim",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔 Slowbro, Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/fausto/entei.json
+++ b/src/data/sinnoh/fausto/entei.json
@@ -2,6 +2,16 @@
   "id": "entei",
   "name": "Entei",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨 cambia a Slowbro , Bostezo ➜ Frente a Maractus ➜ Volcarona +3 ",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Luego cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Maractus, entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/fausto/flareon.json
+++ b/src/data/sinnoh/fausto/flareon.json
@@ -2,6 +2,25 @@
   "id": "flareon",
   "name": "Flareon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Gengar otra vez +6 usar Bola Sombra a todos 💡 si cambia a Bronzong ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 ",
-  "tricks": []
+  "initialMove": "Cambia a Gengar.",
+  "tricks": [
+    {
+      "detail": "Usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +6 y barre con Bola Sombra.",
+          "variant": []
+        },
+        {
+          "detail": "Si cambia a Bronzong, entra Politoed como pivote.",
+          "variant": [
+            {
+              "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/fausto/haxorus.json
+++ b/src/data/sinnoh/fausto/haxorus.json
@@ -2,11 +2,25 @@
   "id": "haxorus",
   "name": "Haxorus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar Otra vez +6 💡 Bola Sombra a todos (haxorus no tiene banda focus)",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Si Cambia a Bronzong ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊 ",
-      "variant": []
+      "detail": "Usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +6 y barre con Bola Sombra. Haxorus no tiene Banda Focus.",
+          "variant": []
+        },
+        {
+          "detail": "Si cambia a Bronzong, entra Politoed como pivote.",
+          "variant": [
+            {
+              "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/fausto/houndoom.json
+++ b/src/data/sinnoh/fausto/houndoom.json
@@ -2,11 +2,16 @@
   "id": "houndoom",
   "name": "Houndoom",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Frente a Medicham ➜ Gengar +4 🔔No usar Otra Vez / Medichan Tiene Pañuelo🔔",
-      "variant": []
+      "detail": "Frente a Medicham, entra con Gengar y usa Maquinación hasta +4.",
+      "variant": [
+        {
+          "detail": "No uses Otra Vez, Medicham tiene Pañuelo Elegido.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/fausto/infernape.json
+++ b/src/data/sinnoh/fausto/infernape.json
@@ -2,6 +2,21 @@
   "id": "infernape",
   "name": "Infernape",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Usa Amortiguador o Teletransporte y cambia a Gengar otra vez +4 +2 💡 Bola Sombra a todos",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "También puedes usar Teletransporte para entrar con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/fausto/lopunny.json
+++ b/src/data/sinnoh/fausto/lopunny.json
@@ -2,6 +2,16 @@
   "id": "lopunny",
   "name": "Lopunny",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 Slowbro, Bostezo ➜ Frente a Maractus ➜ Volcarona +3",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Luego cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Maractus, entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/fausto/lucario.json
+++ b/src/data/sinnoh/fausto/lucario.json
@@ -2,6 +2,16 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Usar Amortiguador ➜ Frente a Haxorus usar Amortiguador o Teletransporte ➜ Gengar  otra vez +6🔔",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Frente a Haxorus, usa Amortiguador o Teletransporte.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Otra Vez y Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/fausto/ludicolo.json
+++ b/src/data/sinnoh/fausto/ludicolo.json
@@ -2,26 +2,51 @@
   "id": "ludicolo",
   "name": "Ludicolo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Medicham ➜ Entrar con Gengar +4 (No usar Otra Vez , Medichan tiene pañuelo elegido)",
-      "variant": []
-    },
-    {
-      "detail": "Conkeldurr ➜ Entrar con Gengar Otra vez +2",
+      "detail": "Si sale Medicham, entra con Gengar y usa Maquinación hasta +4.",
       "variant": [
         {
-          "detail": "Si conkeldur se queda ➜ Gengar +4 + Precisión X",
+          "detail": "No uses Otra Vez, Medicham tiene Pañuelo Elegido.",
           "variant": []
-        },
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Conkeldurr, entra con Gengar y usa Otra Vez.",
+      "variant": [
         {
-          "detail": " Sale Salamence ➜ Ataca con bola sombra a Salamence ➜ si entra Steelix ➜ sacrifica a Politoed ➜ Poliwrath  usa Ataque X 🔔 Cascada a Steelix / Conkeldurr Puño Drenaje🔔",
-          "variant": []
-        },
-        {
-          "detail": "Ludicolo ➜  Slowbro Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-          "variant": []
+          "detail": "Luego Gengar usa Maquinación hasta +2.",
+          "variant": [
+            {
+              "detail": "Si Conkeldurr se queda, Gengar usa Maquinación hasta +4 y Precisión X.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Salamence, ataca con Bola Sombra.",
+              "variant": [
+                {
+                  "detail": "Si entra Steelix, entra Politoed como pivote y luego entra con Poliwrath 🐸🥊. Usa Ataque X.",
+                  "variant": [
+                    {
+                      "detail": "Usa Cascada contra Steelix y Conkeldurr. Usa Puño Drenaje contra el resto.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Ludicolo, Slowbro usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/sinnoh/fausto/magmortar.json
+++ b/src/data/sinnoh/fausto/magmortar.json
@@ -2,110 +2,174 @@
   "id": "magmortar",
   "name": "Magmortar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Se Queda Magmortar ➜ Observar Que Movimiento usa ",
+      "detail": "Si Magmortar se queda, observa qué movimiento usa.",
       "variant": [
         {
-          "detail": "Tajo Cruzado ➜ Gengar Otra vez +2 y atacar ➜ Frente a Steelix ➜ cambia a Slowbro, Bostezo ➜ Frente a Maractus ➜  Volcarona  +3 ",
-          "variant": []
-        },
-        {
-          "detail": "Llamarada ➜ Usar Amortiguador Hasta que se retire ",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Conkeldurr ➜ Entrar con Gengar otra vez +2",
-      "variant": [
-        {
-          "detail": "Conkeldur no cambia ➜ Gengar +4 + Precisión X ",
-          "variant": []
-        },
-        {
-          "detail": "Salamence ➜ Gengar Bola sombra a Salamence ➜ Frente a Steelix ➜ sacrifica a Politoed ➜ Poliwrath usar Ataque X y presionar 🔔 Cascada a Steelix / Conkeldurr Puño Drenaje 🔔",
-          "variant": []
-        },
-        {
-          "detail": "Ludicolo ➜ Cambiar a Slowbro  y usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Medicham ➜ Usar Teletransporte ",
-      "variant": [
-        {
-          "detail": "Vidasfera ➜ Slowbro usa Bostezo ➜ Frente a Maractus ➜ Volcarona +3 ",
-          "variant": []
-        },
-        {
-          "detail": "Sin Vidasfera ➜ Gengar +4 (No usar Otra Vez)",
-          "variant": []
-        },
-        {
-          "detail": "Si no acierta el golpe ➜ Cambiar a Slowbro  y usar Bostezo ",
+          "detail": "Si usa Tajo Cruzado, entra con Gengar, usa Otra Vez, Maquinación hasta +2 y ataca.",
           "variant": [
             {
-              "detail": "Maractus ➜ Volcarona  +3 🔔 puede usar Especial X 🔔",
+              "detail": "Frente a Steelix, cambia a Slowbro y usa Bostezo. Frente a Maractus, entra con Volcarona y usa Danza Aleteo x3.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Llamarada, usa Amortiguador hasta que se retire.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Conkeldurr, entra con Gengar, usa Otra Vez y Maquinación hasta +2.",
+      "variant": [
+        {
+          "detail": "Si Conkeldurr no cambia, Gengar usa Maquinación hasta +4 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Salamence, usa Bola Sombra contra Salamence.",
+          "variant": [
+            {
+              "detail": "Frente a Steelix, entra Politoed como pivote y entra con Poliwrath 🐸🥊. Usa Ataque X y presiona.",
+              "variant": [
+                {
+                  "detail": "Usa Cascada contra Steelix y Puño Drenaje contra Conkeldurr.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Ludicolo, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Medicham, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidaesfera, Slowbro usa Bostezo. Frente a Maractus, entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        },
+        {
+          "detail": "Si no tiene Vidaesfera, entra con Gengar y usa Maquinación hasta +4. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si no acierta el golpe, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Maractus, entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X.",
               "variant": []
             },
             {
-              "detail": "Magmortar ➜ Cambiar a Chansey  y usar Amortiguador ➜ Frente a Medicham ➜ Gengar, +2 (se suicida el medicham, es Pañuelo), sale Bronzong ➜ Volcarona +1, si se queda Bronzong o si sale Houndoom  usar Especial X y presionar para completar",
-              "variant": []
+              "detail": "Si sale Magmortar, cambia a Chansey y usa Amortiguador.",
+              "variant": [
+                {
+                  "detail": "Frente a Medicham, entra con Gengar y usa Maquinación hasta +2. Deja que Medicham lo debilite; tiene Pañuelo Elegido.",
+                  "variant": [
+                    {
+                      "detail": "Si sale Bronzong, entra con Volcarona y usa Danza Aleteo x1. Si Bronzong se queda o sale Houndoom, usa Especial X y presiona para completar.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
       ]
     },
     {
-      "detail": "Blaziken / Arcanine ➜ Cambiar a Slowbro, Bostezo ➜ Frente a Maractus ➜ sacrifica a Politoed  ➜ Poliwrath  +6",
-      "variant": []
-    },
-    {
-      "detail": "Infernape ➜ Usar Amortiguador o Teletransporte ➜ Gengar otra vez +4 +2 🔔usar Bola Sombra a todos🔔",
-      "variant": []
-    },
-    {
-      "detail": "Haxorus --> Usar Amortiguador o Teletransporte ➜  Gengar otra vez +6",
-      "variant": []
-    },
-    {
-      "detail": "Bouffalant ➜ Gengar usa Maquinación ➜ Frente a Dragonite ➜ atacar con bola sombra",
+      "detail": "Si sale Blaziken o Arcanine, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Magmortar ➜ Sacrifica a Politoed ➜ Poliwrath +6",
+          "detail": "Frente a Maractus, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
-        },
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Infernape, usa Amortiguador o Teletransporte.",
+      "variant": [
         {
-          "detail": "Steelix ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6",
+          "detail": "Entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Usa Bola Sombra contra todos.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Haxorus, usa Amortiguador o Teletransporte.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Otra Vez y Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Bouffalant, Gengar usa Maquinación.",
+      "variant": [
+        {
+          "detail": "Frente a Dragonite, ataca con Bola Sombra.",
           "variant": [
             {
-              "detail": "Arriesgado ➜ Sacrifica directamente a Politoed ➜ Poliwrath +6",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Maractus ➜ Usar Trampa Rocas para recibir Esfuerzo y usar Amortiguador ",
-          "variant": [
-            {
-              "detail": "Lopunny / Medicham ➜ Cambiar a Slowbro y usar Bostezo ➜ Frente a Maractus entrar con Volcarona +3 🔔 puedes usar Especial X y Gigadrenado a Steelix 🔔",
+              "detail": "Si sale Magmortar, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             },
             {
-              "detail": "Magmortar ➜ Gengar otra vez +2 y presionar hasta tener en frente a  Steelix ➜ cambiar a Slowbro y usar Bostezo ➜ Frente a Maractus ➜  Volcarona  +3 🔔 Gigadrenado a Steelix, puedes usar Especial X 🔔",
-              "variant": []
+              "detail": "Si sale Steelix, cambia a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                },
+                {
+                  "detail": "Ruta arriesgada: entra Politoed como pivote directo y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Maractus, usa 🪨 Trampa Rocas 🪨 para recibir Esfuerzo y luego usa Amortiguador.",
+              "variant": [
+                {
+                  "detail": "Si sale Lopunny o Medicham, cambia a Slowbro y usa Bostezo. Frente a Maractus, entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X y Gigadrenado contra Steelix.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si sale Magmortar, entra con Gengar, usa Otra Vez y Maquinación hasta +2. Presiona hasta tener a Steelix enfrente.",
+                  "variant": [
+                    {
+                      "detail": "Luego cambia a Slowbro y usa Bostezo. Frente a Maractus, entra con Volcarona y usa Danza Aleteo x3. Usa Gigadrenado contra Steelix y puedes usar Especial X.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
       ]
     },
     {
-      "detail": "Camerupt ➜ Usar Amortiguador  y esperar a Bouffalant ➜ ver estrategia de Bouffalant",
-      "variant": []
+      "detail": "Si sale Camerupt, usa Amortiguador y espera a Bouffalant.",
+      "variant": [
+        {
+          "detail": "Luego sigue la ruta de Bouffalant.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/fausto/maractus.json
+++ b/src/data/sinnoh/fausto/maractus.json
@@ -2,41 +2,65 @@
   "id": "maractus",
   "name": "Maractus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda → Observar habilidad/movimiento",
+      "detail": "Si Maractus se queda, observa habilidad o movimiento.",
       "variant": [
         {
-          "detail": "Puño Drenaje → Teletransporte → Slowbro → Bostezo → Sacrificar a Politoed → Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Esfuerzo → Amortiguador",
+          "detail": "Si usa Puño Drenaje, usa Teletransporte y envía a Slowbro.",
           "variant": [
             {
-              "detail": "Lopunny / Medicham → Slowbro → Bostezo (vs Maractus) → Volcarona +3 🔔 Puede usar Especial X y Gigadrenado a Steelix 🔔",
-              "variant": []
-            },
-            {
-              "detail": "Magmortar → Gengar +2 → Presionar hasta Steelix → Slowbro → Bostezo (vs Maractus) → Volcarona +3 🔔 Puede usar Especial X y Gigadrenado a Steelix 🔔",
+              "detail": "Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Bouffalant → Gengar → Maquinación (vs Dragonite) → Atacar hasta debilitar",
+          "detail": "Si usa Esfuerzo, usa Amortiguador.",
           "variant": [
             {
-              "detail": "Magmortar → Sacrificar a Politoed → Poliwrath +6",
-              "variant": []
-            },
-            {
-              "detail": "Steelix → Slowbro → Bostezo → Sacrificar a Politoed → Poliwrath +6",
+              "detail": "Si sale Lopunny o Medicham, cambia a Slowbro y usa Bostezo al enfrentar a Maractus.",
               "variant": [
                 {
-                  "detail": "Arriesgado → Sacrificar directamente a Politoed → Poliwrath +6",
+                  "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X y Gigadrenado contra Steelix.",
                   "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Magmortar, entra con Gengar y usa Maquinación hasta +2. Presiona hasta Steelix.",
+              "variant": [
+                {
+                  "detail": "Luego cambia a Slowbro y usa Bostezo al enfrentar a Maractus. Entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X y Gigadrenado contra Steelix.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Bouffalant, cambia a Gengar y usa Maquinación al enfrentar a Dragonite.",
+          "variant": [
+            {
+              "detail": "Ataca hasta quedar debilitado.",
+              "variant": [
+                {
+                  "detail": "Si sale Magmortar, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si sale Steelix, cambia a Slowbro y usa Bostezo.",
+                  "variant": [
+                    {
+                      "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": []
+                    },
+                    {
+                      "detail": "Ruta arriesgada: entra Politoed como pivote directo y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": []
+                    }
+                  ]
                 }
               ]
             }
@@ -45,25 +69,35 @@
       ]
     },
     {
-      "detail": "Lopunny / Medicham → Slowbro → Bostezo (vs Maractus) → Volcarona +3 🔔 Puede usar Especial X y Gigadrenado a Steelix 🔔",
-      "variant": []
-    },
-    {
-      "detail": "Blaziken / Arcanine → Slowbro → Bostezo (vs Maractus)",
+      "detail": "Si sale Lopunny o Medicham, cambia a Slowbro y usa Bostezo al enfrentar a Maractus.",
       "variant": [
         {
-          "detail": "Rápido → Sacrificar a Politoed → Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Ahorrar dinero → Volcarona +3",
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X y Gigadrenado contra Steelix.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Camerupt → Slowbro → Bostezo → Sacrificar a Politoed → Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Blaziken o Arcanine, cambia a Slowbro y usa Bostezo al enfrentar a Maractus.",
+      "variant": [
+        {
+          "detail": "Ruta rápida: entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Ruta de ahorro: entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Camerupt, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/fausto/medicham.json
+++ b/src/data/sinnoh/fausto/medicham.json
@@ -2,22 +2,42 @@
   "id": "medicham",
   "name": "Medicham",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Cambiar a Slowbro y luego a Chansey💡",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Cacturne --> Usar Trampa Rocas para recibir Esfuerzo  usar Amortiguador al enfrentar el Trueno  de Medicham  cambiar a Slowbro  y usar Bostezo  al enfrentar a Cacturne  entrar con Volcarona  +3, 🔔puede usar Especial X y Gigadrenado a Steelix🔔",
-      "variant": []
-    },
-    {
-      "detail": "Magmortar --> Usar Trampa Rocas al enfrentar el Trueno  de Medicham  revisar la salud de Medicham ",
+      "detail": "Luego cambia a Chansey.",
       "variant": [
         {
-          "detail": "Vida completa --> Entrar con Gengar +4 (No usar Otra Vez)",
-          "variant": []
+          "detail": "Si sale Cacturne, usa 🪨 Trampa Rocas 🪨 para recibir Esfuerzo.",
+          "variant": [
+            {
+              "detail": "Usa Amortiguador al enfrentar el Trueno de Medicham, cambia a Slowbro y usa Bostezo al enfrentar a Cacturne.",
+              "variant": [
+                {
+                  "detail": "Entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X y Gigadrenado contra Steelix.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Vida baja  --> Entrar con Gengar  +2 y suicidarse al enfrentar a Bronzong  entrar con Volcarona  +1 si se queda o si sale Houndoom; usar Especial X y presionar para completar",
-          "variant": []
+          "detail": "Si sale Magmortar, usa 🪨 Trampa Rocas 🪨 al enfrentar el Trueno de Medicham y revisa su vida.",
+          "variant": [
+            {
+              "detail": "Si tiene vida completa, entra con Gengar y usa Maquinación hasta +4. No uses Otra Vez.",
+              "variant": []
+            },
+            {
+              "detail": "Si tiene vida baja, entra con Gengar y usa Maquinación hasta +2.",
+              "variant": [
+                {
+                  "detail": "Deja que Gengar quede debilitado al enfrentar a Bronzong. Luego entra con Volcarona y usa Danza Aleteo x1 si Bronzong se queda o si sale Houndoom. Usa Especial X y presiona para completar.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/sinnoh/fausto/ninetales.json
+++ b/src/data/sinnoh/fausto/ninetales.json
@@ -2,6 +2,16 @@
   "id": "ninetales",
   "name": "Ninetales",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 al enfrentar a Medicham; entrar con Gengar +4 (No usar Otra Vez)",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Medicham, entra con Gengar y usa Maquinación hasta +4.",
+      "variant": [
+        {
+          "detail": "No uses Otra Vez.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/fausto/rapidash.json
+++ b/src/data/sinnoh/fausto/rapidash.json
@@ -2,19 +2,39 @@
   "id": "rapidash",
   "name": "Rapidash",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 al enfrentar a Conkeldurr; entrar con Gengar +2",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda --> Gengar +4 + Precisión ",
-      "variant": []
-    },
-    {
-      "detail": "Salamence --> Atacar hasta debilitar al enfrentar a Steelix; sacrificar a Politoed (皇); entrar con Poliwrath , usar Ataque X y presionar con Cascada  a Steelix / Conkeldurr restante con Puño Drenaje ",
-      "variant": []
-    },
-    {
-      "detail": "Ludicolo --> Cambiar a Slowbro  y usar Bostezo  sacrificar a Politoed  entrar con Poliwrath  +6",
-      "variant": []
+      "detail": "Al enfrentar a Conkeldurr, entra con Gengar y usa Maquinación hasta +2.",
+      "variant": [
+        {
+          "detail": "Si Conkeldurr se queda, Gengar usa Maquinación hasta +4 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si sale Salamence, ataca hasta quedar debilitado al enfrentar a Steelix.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊. Usa Ataque X y presiona.",
+              "variant": [
+                {
+                  "detail": "Usa Cascada contra Steelix y Conkeldurr. Usa Puño Drenaje contra el resto.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Ludicolo, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/fausto/rotom_fuego.json
+++ b/src/data/sinnoh/fausto/rotom_fuego.json
@@ -2,6 +2,25 @@
   "id": "rotom_fuego",
   "name": "Rotom Fuego",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Usar Amortiguador al enfrentar a Infernape  entrar con Gengar +4 +2 💡 Usar Bola Sombra  a todos si cambia a Bronzong  sacrificar a Politoed  entrar con Poliwrath +6",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Infernape, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            },
+            {
+              "detail": "Si cambia a Bronzong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/fausto/salamence.json
+++ b/src/data/sinnoh/fausto/salamence.json
@@ -2,32 +2,62 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Usar Trampa Rocas🔔",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Conkeldurr ➜ Entrar con Gengar otra vez +2",
+      "detail": "Si sale Conkeldurr, entra con Gengar y usa Otra Vez.",
       "variant": [
         {
-          "detail": "Si Conkeldur se queda ➜ Gengar +4 + Precisión",
+          "detail": "Luego Gengar usa Maquinación hasta +2.",
+          "variant": [
+            {
+              "detail": "Si Conkeldurr se queda, Gengar usa Maquinación hasta +4 y Precisión X.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Salamence, ataca con Bola Sombra.",
+      "variant": [
+        {
+          "detail": "Frente a Steelix, entra Politoed como pivote y entra con Poliwrath 🐸🥊. Usa Ataque X.",
+          "variant": [
+            {
+              "detail": "Usa Cascada contra Steelix y Puño Drenaje contra Conkeldurr.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Ludicolo, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Salamence ➜ Ataca con bola sombra ➜ y frente a  Steelix ➜ sacrifica a Politoed y entras con Poliwrath usar Ataque X  🔔 Cascada a Steelix / Conkeldurr con Puño Drenaje 🔔",
-      "variant": []
+      "detail": "Si sale Medicham, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Maractus, entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X y Gigadrenado contra Steelix.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Ludicolo ➜  Cambia a Slowbro y usa Bostezo ➜ sacrifica a Politoed y entrar con Poliwrath +6🐸🥊",
-      "variant": []
-    },
-    {
-      "detail": "Medicham ➜ Cambiar a Slowbro y usa Bostezo ➜ Frente a Maractus ➜ entra con Volcarona +3 🔔puedes usar Especial X y Gigadrenado a Steelix🔔",
-      "variant": []
-    },
-    {
-      "detail": "Haxorus ➜ Usa Amortiguador o Teletransporte y entra con Gengar +6",
-      "variant": []
+      "detail": "Si sale Haxorus, usa Amortiguador o Teletransporte.",
+      "variant": [
+        {
+          "detail": "Luego entra con Gengar y usa Maquinación hasta +6.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/fausto/steelix.json
+++ b/src/data/sinnoh/fausto/steelix.json
@@ -2,63 +2,111 @@
   "id": "steelix",
   "name": "Steelix",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 🔔(Si se queda usa Amortiguador)🔔",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Conkeldurr --> Entrar con Gengar +2",
-      "variant": [
-        {
-          "detail": "Si se queda --> 💊Gengar +4 + Precisión X💊",
-          "variant": []
-        },
-        {
-          "detail": "Salamence --> Atacar hasta debilitar al enfrentar a Steelix, sacrificar a Politoed, 💊entrar con Poliwrath + Ataque X💊 y presionar 🔔(Cascada contra Steelix/Conkeldurr y Puño Drenaje contra los demas)🔔 ",
-          "variant": []
-        },
-        {
-          "detail": "Ludicolo --> Cambiar a Slowbro  y usar Bostezo  sacrificar a Politoed  entrar con Poliwrath +6",
-          "variant": []
-        } 
-      ]  
+      "detail": "Si Steelix se queda, usa Amortiguador. 🥚",
+      "variant": []
     },
     {
-      "detail": "Cacturne --> Luego usar Trampa Rocas  para recibir Esfuerzo  usar Amortiguador ",
+      "detail": "Si sale Conkeldurr, entra con Gengar y usa Maquinación hasta +2.",
       "variant": [
-        { 
-          "detail": "Lopunny/Medicham --> Cambiar a Slowbro  y usar Bostezo al enfrentar a Cacturne, entrar con Volcarona +3 🔔(Puedes usar Especial X y Gigadrenado a Steelix)🔔",
+        {
+          "detail": "Si Conkeldurr se queda, Gengar usa Maquinación hasta +4 y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Magmortar --> Entrar con Gengar +2 y presionar hasta Steelix; cambiar a Slowbro y usar Bostezo  al enfrentar a Cacturne  entrar con Volcarona +3 🔔(Puedes usar Especial X y Gigadrenado a Steelix)🔔",
-          "variant": []
-        }
-      ]  
-    },
-    {
-      "detail": "Bouffalant --> Cambiar a Gengar y usar Maquinación, al enfrentar a Dragonite, atacar hasta debilitar",
-      "variant": [
-        {
-          "detail": "Magmortar --> Sacrificar a Politoed entrar con Poliwrath +6 🔔(Puño drenaje contra Magmortar)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Steelix --> Cambiar a Slowbro  y usar Bostezo  sacrificar a Politoed  entrar con Poliwrath +6 🔔(Puño drenaje contra Magmortar)🔔",
+          "detail": "Si sale Salamence, ataca hasta quedar debilitado al enfrentar a Steelix.",
           "variant": [
             {
-              "detail": "🚨Arriesgado🚨 --> Sacrificar directamente a Politoed  entrar con Poliwrath +6",
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊. Usa Ataque X y presiona.",
+              "variant": [
+                {
+                  "detail": "Usa Cascada contra Steelix y Conkeldurr. Usa Puño Drenaje contra los demás.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Ludicolo, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
-          ]  
-        }  
-      ]    
+          ]
+        }
+      ]
     },
     {
-      "detail": "Lopunny/Medicham --> Cambiar a Slowbro  y usar Bostezo al enfrentar a Cacturne ; entrar con Volcarona +3 🔔(Puedes usar Especial X y Gigadrenado a Steelix)🔔",
-      "variant": []
+      "detail": "Si sale Cacturne, usa 🪨 Trampa Rocas 🪨 para recibir Esfuerzo y luego usa Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Lopunny o Medicham, cambia a Slowbro y usa Bostezo al enfrentar a Cacturne.",
+          "variant": [
+            {
+              "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X y Gigadrenado contra Steelix.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Magmortar, entra con Gengar y usa Maquinación hasta +2. Presiona hasta Steelix.",
+          "variant": [
+            {
+              "detail": "Luego cambia a Slowbro y usa Bostezo al enfrentar a Cacturne. Entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X y Gigadrenado contra Steelix.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Camerupt --> Usar Amortiguador y esperar al cambio de Bouffalant; ver estrategia de Bouffalant☝️",
-      "variant": []
+      "detail": "Si sale Bouffalant, cambia a Gengar y usa Maquinación.",
+      "variant": [
+        {
+          "detail": "Al enfrentar a Dragonite, ataca hasta quedar debilitado.",
+          "variant": [
+            {
+              "detail": "Si sale Magmortar, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Magmortar.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Steelix, cambia a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Magmortar.",
+                  "variant": []
+                },
+                {
+                  "detail": "Ruta arriesgada: entra Politoed como pivote directo y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lopunny o Medicham, cambia a Slowbro y usa Bostezo al enfrentar a Cacturne.",
+      "variant": [
+        {
+          "detail": "Luego entra con Volcarona y usa Danza Aleteo x3. Puedes usar Especial X y Gigadrenado contra Steelix.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Camerupt, usa Amortiguador y espera el cambio a Bouffalant.",
+      "variant": [
+        {
+          "detail": "Luego sigue la ruta de Bouffalant.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/fausto/typhlosion.json
+++ b/src/data/sinnoh/fausto/typhlosion.json
@@ -2,6 +2,21 @@
   "id": "typhlosion",
   "name": "Typhlosion",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 para que salga Medicham; usa a Slowbro con Bostezo para que salga Cacturne y entra con Volcarona +3",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Busca que salga Medicham.",
+      "variant": [
+        {
+          "detail": "Usa Slowbro con Bostezo para que salga Cacturne.",
+          "variant": [
+            {
+              "detail": "Luego entra con Volcarona y usa Danza Aleteo x3.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Releases the completed Sinnoh Fausto Spanish strategy structure cleanup from `develop` to `main`.
- Publishes all 27 Fausto strategy JSON files.
- Keeps English translations untouched for the final global translation pass.

## Scope
- Release PR from `develop` to `main`.
- Sinnoh Fausto strategy JSON files only.
- No asset changes.
- No frontend layout changes.