### PR TITLE
Clean Sinnoh Delos Spanish strategy structure

### DIFF
--- a/src/data/sinnoh/delos/absol.json
+++ b/src/data/sinnoh/delos/absol.json
@@ -2,40 +2,65 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔 Gengar usa Otra Vez y cambiar a Slowbro🔔 Ver que item tiene ",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Vidasfera --> Usar Bostezo ",
+      "detail": "Gengar usa Otra Vez y luego cambia a Slowbro para revisar el objeto de Absol.",
       "variant": [
         {
-          "detail": "Ninetales --> Usar Protección  y Bostezo  sacrificar a Politoed entrar con Poliwrath  +6",
-          "variant": []
-        },
-        {
-          "detail": "Gallade --> Sacrificar a Politoed entrar con Poliwrath  +6; abrir y observar la situación",
+          "detail": "Si tiene Vidaesfera, usa Bostezo.",
           "variant": [
             {
-              "detail": "Situación ① Girafarig  vs Ninetales (primer enfrentamiento) --> Usar Velocidad X y presionar de nuevo",
-              "variant": []
+              "detail": "Si sale Ninetales, usa Protección y Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             },
             {
-              "detail": "Situación ② Ninetales vs Girafarig (primer enfrentamiento) --> Presionar directamente; si no hay golpe crítico  no debilita; si hay golpe crítico y cae, entrar con Gengar +2 para completar",
-              "variant": []
+              "detail": "Si sale Gallade, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Abre y observa la situación.",
+                  "variant": [
+                    {
+                      "detail": "Situación ① Girafarig contra Ninetales en el primer enfrentamiento: usa Velocidad X y presiona de nuevo.",
+                      "variant": []
+                    },
+                    {
+                      "detail": "Situación ② Ninetales contra Girafarig en el primer enfrentamiento: presiona directo. Si hay crítico y cae, entra con Gengar y usa Maquinación hasta +2 para completar.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "detail": "Sin Vidasfera --> Cambiar a Chansey  y usar Trampa Rocas ",
-      "variant": [
-        {
-          "detail": "Golduck --> Entrar con Gengar  +4 +2; cambiar Gengar ante Gallade  No usar Otra Vez  y seguir fortaleciendo",
-          "variant": []
         },
         {
-          "detail": "Gallade --> Entrar con Gengar  +4 +2 No usar Otra Vez 🔔usar Bola Sombra a todos🔔",
-          "variant": []
+          "detail": "Si no tiene Vidaesfera, cambia a Chansey y usa 🪨 Trampa Rocas 🪨.",
+          "variant": [
+            {
+              "detail": "Si sale Golduck, entra con Gengar y usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+              "variant": [
+                {
+                  "detail": "Cambia Gengar ante Gallade. No uses Otra Vez y sigue fortaleciendo.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Gallade, entra con Gengar y usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No uses Otra Vez.",
+              "variant": [
+                {
+                  "detail": "Usa Bola Sombra contra todos.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/sinnoh/delos/alakazam.json
+++ b/src/data/sinnoh/delos/alakazam.json
@@ -2,6 +2,20 @@
   "id": "alakazam",
   "name": "Alakazam",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Usar Amortiguador al enfrentar a Lucario; entrar con Gengar  +2 +2 + Precisión 💡 Si no cambia, usa Amortiguador",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Lucario, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si Alakazam permanece en campo, usa Amortiguador.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/sinnoh/delos/bronzong.json
+++ b/src/data/sinnoh/delos/bronzong.json
@@ -2,6 +2,16 @@
   "id": "bronzong",
   "name": "Bronzong",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 al enfrentar a Gallade; entrar con Gengar  +6 +2 + Precisión ",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Gallade, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +6, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/delos/dragonite.json
+++ b/src/data/sinnoh/delos/dragonite.json
@@ -2,33 +2,48 @@
   "id": "dragonite",
   "name": "Dragonite",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚 Amortiguador 🥚",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Fuerza Bruta --> Entrar con Slowbro y usar Bostezo ",
+      "detail": "Si Dragonite usa Fuerza Bruta, entra con Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Ninetales --> Usar Protección  y Bostezo ; sacrificar a Politoed ; entrar con Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Absol --> Sacrificar a Politoed  entrar con Poliwrath  +6; abrir y observar la situación",
+          "detail": "Si sale Ninetales, usa Protección y Bostezo.",
           "variant": [
             {
-              "detail": "Situación ① Girafarig  vs Ninetales (primer enfrentamiento) --> Usar Velocidad X y presionar de nuevo",
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
-            },
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Absol, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
             {
-              "detail": "Situación ② Ninetales vs Girafarig  (primer enfrentamiento) --> Presionar directamente; si no hay golpe crítico no debilita; si hay golpe crítico y cae, entrar con Gengar  +2 para completar",
-              "variant": []
+              "detail": "Abre y observa la situación.",
+              "variant": [
+                {
+                  "detail": "Situación ① Girafarig contra Ninetales en el primer enfrentamiento: usa Velocidad X y presiona de nuevo.",
+                  "variant": []
+                },
+                {
+                  "detail": "Situación ② Ninetales contra Girafarig en el primer enfrentamiento: presiona directo. Si hay crítico y cae, entra con Gengar y usa Maquinación hasta +2 para completar.",
+                  "variant": []
+                }
+              ]
             }
           ]
         }
       ]
     },
     {
-      "detail": "Gallade--> Entrar con Slowbro y usar Bostezo al enfrentar a Raichu; sacrificar a Politoed  entrar con Poliwrath  +6",
-      "variant": []
+      "detail": "Si sale Gallade, entra con Slowbro y usa Bostezo al enfrentar a Raichu.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/delos/empoleon.json
+++ b/src/data/sinnoh/delos/empoleon.json
@@ -2,6 +2,16 @@
   "id": "empoleon",
   "name": "Empoleon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6🔔",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/delos/espeon.json
+++ b/src/data/sinnoh/delos/espeon.json
@@ -2,6 +2,16 @@
   "id": "espeon",
   "name": "Espeon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro ante Gallade ; usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Frente a Gallade, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/delos/gallade.json
+++ b/src/data/sinnoh/delos/gallade.json
@@ -2,102 +2,137 @@
   "id": "gallade_2",
   "name": "Gallade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Cambia a Gengar👻",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Espada Santa ➜ Gengar usa Otra Vez",
+      "detail": "Si Gallade usa Espada Santa, Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Gallade pega Segundo ➜ Cambiar a Slowbro",
+          "detail": "Si Gallade pega segundo, cambia a Slowbro.",
           "variant": [
             {
-              "detail": "Si se queda ➜ Usar Bostezo😴",
+              "detail": "Si Gallade se queda, usa Bostezo.",
               "variant": [
-                 {
-                   "detail": "Gardevoir ➜ Entrar con Chansey y usar Trampa Rocas ➜ Frente a Gallade 💊entra con Gengar +6 +2 + Precisión X💊",
-                   "variant": []
-                 },
-                 {         
-                   "detail": "Golduck / Absol ➜ Cambia a Chansey y usar Trampa Rocas",
-                   "variant": [
-                     {         
-                       "detail": "Absol ➜ 👻Cambia a Gengar 4+2👻",
-                       "variant": []
-                     },
-                     { 
-                       "detail": "Gallade ➜ 👻Cambia a Gengar 4+2👻 🔔(No usar Otra Vez)🔔",
-                       "variant": []
-                     }
-                   ] 
-                 },
-                 { 
-                   "detail": "Hydreigon ➜ Sacrifica a Politoed 🔔(Identifica el Movimiento)🔔",
-                   "variant": [
-                     { 
-                       "detail": "Pulso Dragon ➜ Cambiar a Chansey y usar Trampa Rocas ➜ Frente a Gallade ➜ 💊entra con Gengar +6 +2 + Precisión X💊",
-                       "variant": []
-                     },
-                     {   
-                       "detail": "Pulso Umbrío ➜ Entrar con Poliwrath +6",
-                       "variant": []
-                     } 
-                   ]
-                 },
-                 {  
-                    "detail": "Raichu ➜ Sacrifica a Politoed ➜ Poliwrath +6",
-                    "variant": []
-                 }   
-               ]
-            },
-            {  
-              "detail": "Dragonite ➜ Usar Bostezo😴",
-              "variant": [
-                {  
-                  "detail": "Raichu ➜ Sacrifica a Politoed ➜ Poliwrath +6",
-                  "variant": []
-                },
                 {
-                  "detail": "Absol ➜ Sacrifica a Politoed ➜ Poliwrath +6 🔔(Observa tu situación)🔔",
+                  "detail": "Si sale Gardevoir, entra Chansey y usa 🪨 Trampa Rocas 🪨.",
                   "variant": [
                     {
-                      "detail": "Si entra Girafarig primero que ninetales ➜ Usar Velocidad X y presionar de nuevo",
+                      "detail": "Frente a Gallade, entra con Gengar, usa Maquinación hasta +6, Velocidad X para +2 Velocidad y Precisión X.",
                       "variant": []
-                    },
-                    {  
-                      "detail": "Si entra Ninetales Primero que Girafarig ➜ Sigue Atacando si no hay golpe crítico no debilita 🚨(Si hay golpe crítico y cae, entra con Gengar +2 para completar)🚨",
-                      "variant": []
-                    }  
+                    }
                   ]
                 },
                 {
-                  "detail": "Ninetales ➜ Usar Protección y Bostezo ➜ Frente a Absol ➜ sacrifica a Politoed ➜ Poliwrath +6",
+                  "detail": "Si sale Golduck o Absol, cambia a Chansey y usa 🪨 Trampa Rocas 🪨.",
+                  "variant": [
+                    {
+                      "detail": "Si sale Absol, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+                      "variant": []
+                    },
+                    {
+                      "detail": "Si sale Gallade, cambia a Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No uses Otra Vez.",
+                      "variant": []
+                    }
+                  ]
+                },
+                {
+                  "detail": "Si sale Hydreigon, entra Politoed como pivote para identificar movimiento.",
+                  "variant": [
+                    {
+                      "detail": "Si usa Pulso Dragón, cambia a Chansey y usa 🪨 Trampa Rocas 🪨.",
+                      "variant": [
+                        {
+                          "detail": "Frente a Gallade, entra con Gengar, usa Maquinación hasta +6, Velocidad X para +2 Velocidad y Precisión X.",
+                          "variant": []
+                        }
+                      ]
+                    },
+                    {
+                      "detail": "Si usa Pulso Umbrío, entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": []
+                    }
+                  ]
+                },
+                {
+                  "detail": "Si sale Raichu, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
                   "variant": []
                 }
               ]
-            }  
-          ]  
+            },
+            {
+              "detail": "Si sale Dragonite, usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Si sale Raichu, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si sale Absol, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Observa tu situación.",
+                  "variant": [
+                    {
+                      "detail": "Si entra Girafarig antes que Ninetales, usa Velocidad X y presiona de nuevo.",
+                      "variant": []
+                    },
+                    {
+                      "detail": "Si entra Ninetales antes que Girafarig, sigue atacando. Si no hay crítico, no debilita; si hay crítico y cae, entra con Gengar y usa Maquinación hasta +2 para completar.",
+                      "variant": []
+                    }
+                  ]
+                },
+                {
+                  "detail": "Si sale Ninetales, usa Protección y Bostezo.",
+                  "variant": [
+                    {
+                      "detail": "Frente a Absol, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Gallade Pega primero ➜ 💊Gengar 2+2 + Precision X💊 🔔(No usar Otra Vez)🔔",
+          "detail": "Si Gallade pega primero, Gengar usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. No uses Otra Vez.",
           "variant": []
         },
         {
-          "detail": "Lo atrapas en Golpe bajo ➜ Sacrifica a Politoed ➜ Poliwrath +6",
+          "detail": "Si queda atrapado en Golpe Bajo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Gallade usa Proteccion ➜ Gengar usa Maquinación y atacar hasta debilitar ➜ al enfrentar a Raichu ➜ entra con Chansey y usar Trampa Rocas al enfrentar a Absol ➜ entra con Gengar +4 +2",
-          "variant": []
+          "detail": "Si Gallade usa Protección, Gengar usa Maquinación y ataca hasta quedar debilitado.",
+          "variant": [
+            {
+              "detail": "Al enfrentar a Raichu, entra con Chansey y usa 🪨 Trampa Rocas 🪨 al enfrentar a Absol.",
+              "variant": [
+                {
+                  "detail": "Luego entra con Gengar y usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Cambia a Dragonite ➜ Cambiar a Slowbro y usar Bostezo ➜ Frente a Raichu ➜ sacrifica a Politoed ➜ entra con Poliwrath +6",
-          "variant": []          
-        } 
-      ]  
+          "detail": "Si cambia a Dragonite, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Frente a Raichu, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Segundo Gallade ➜ Sacrifica a Politoed ➜ enviar a Chansey ➜ entra con Gengar +6 🔔(Usar Bola Sombra para Barrer)🔔",
-      "variant": []
+      "detail": "Si aparece el segundo Gallade, entra Politoed como pivote y luego envía a Chansey.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Maquinación hasta +6 y barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/delos/gardevoir.json
+++ b/src/data/sinnoh/delos/gardevoir.json
@@ -2,6 +2,16 @@
   "id": "gardevoir",
   "name": "Gardevoir",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 al enfrentar a Gallade o Roserade; entrar con Gengar +6 +2 + Precisión",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Gallade o Roserade, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +6, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/delos/girafarig.json
+++ b/src/data/sinnoh/delos/girafarig.json
@@ -2,36 +2,55 @@
   "id": "girafarig",
   "name": "Girafarig",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Mira abajo como seguir🔔 ",
+  "initialMove": "Elige una ruta.",
   "tricks": [
     {
-      "detail": " Ruta Arriesgada ➜ Usar Trampa Rocas Frente a Gallade ➜ entra con Gengar Otra vez  +2 si entra Dragonite usa bola sombra 🔔usa Onda Certera a Girafarig 🔔",
+      "detail": "Ruta arriesgada: usa 🪨 Trampa Rocas 🪨 frente a Gallade.",
       "variant": [
         {
-          "detail": "Si Absol debilita a Gengar ➜ Entra con Volcarona x1 danza aleteo y presionar; revisar qué Pokémon quedan",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": " Ruta Estable ➜ Entra con Slowbro y usa Bostezo",
-      "variant": [
-        {
-          "detail": "Absol ➜ Sacrifica a Politoed ➜ entra con Poliwrath +6🐸🥊  observa quien sale primero ",
+          "detail": "Entra con Gengar, usa Otra Vez y Maquinación hasta +2.",
           "variant": [
             {
-              "detail": "Si Girafarig sale primero que  Ninetales ➜ Usar Velocidad X y presionar de nuevo",
-              "variant": []
-            },
-            {
-              "detail": "Si Ninetales sale primero que  Girafarig ➜ Presionar directamente; si no hay golpe crítico no debilita; si hay golpe crítico y cae, entrar con Gengar +2 para completar",
+              "detail": "Si entra Dragonite, usa Bola Sombra. Usa Onda Certera contra Girafarig.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Ninetales ➜ Usa Protección y Bostezo y Frente a Absol; sacrifica a Politoed y entra con Poliwrath +6🐸🥊",
-          "variant": []
+          "detail": "Si Absol debilita a Gengar, entra con Volcarona y usa Danza Aleteo x1.",
+          "variant": [
+            {
+              "detail": "Presiona y revisa qué Pokémon quedan.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Ruta estable: entra con Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Observa quién sale primero.",
+          "variant": [
+            {
+              "detail": "Si Girafarig sale antes que Ninetales, usa Velocidad X y presiona de nuevo.",
+              "variant": []
+            },
+            {
+              "detail": "Si Ninetales sale antes que Girafarig, presiona directo. Si hay crítico y cae, entra con Gengar y usa Maquinación hasta +2 para completar.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Ninetales, usa Protección y Bostezo frente a Absol.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/sinnoh/delos/golduck.json
+++ b/src/data/sinnoh/delos/golduck.json
@@ -2,24 +2,44 @@
   "id": "golduck",
   "name": "Golduck",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Tajo Cruzado --> Cambiar a Gengar",
+      "detail": "Si Golduck usa Tajo Cruzado, cambia a Gengar.",
       "variant": [
         {
-          "detail": "Si se queda --> Entrar con Gengar +4/+2 y usar Bola Sombra a todos",
-          "variant": []
+          "detail": "Si Golduck permanece en campo, Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Gallade / Roserade --> Entrar con Gengar +4/+2 (No usar Otra Vez) y usar Bola Sombra a todos",
-          "variant": []
+          "detail": "Si sale Gallade o Roserade, Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Gallade / Roserade --> Entrar con Gengar +4/+2 (No usar Otra Vez) y usar Bola Sombra a todos",
-      "variant": []
+      "detail": "Si sale Gallade o Roserade directamente, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/delos/hydreigon.json
+++ b/src/data/sinnoh/delos/hydreigon.json
@@ -2,15 +2,30 @@
   "id": "hydreigon",
   "name": "Hydreigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚 Amortiguador 🥚 y observa qué objeto tienen",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Vidasfera --> Cambiar a Slowbro ante Gallade o Roserade; usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Sin Vidasfera --> Usar Trampa Rocas al enfrentar a Gallade o Roserade; entrar con Gengar +4 +2 + Precisión",
-      "variant": []
+      "detail": "Observa qué objeto tiene Hydreigon.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidaesfera, cambia a Slowbro ante Gallade o Roserade y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si no tiene Vidaesfera, usa 🪨 Trampa Rocas 🪨 al enfrentar a Gallade o Roserade.",
+          "variant": [
+            {
+              "detail": "Luego entra con Gengar, usa Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/delos/kecleon.json
+++ b/src/data/sinnoh/delos/kecleon.json
@@ -2,11 +2,16 @@
   "id": "kecleon",
   "name": "Kecleon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " 🥚Usa Amortiguador🥚",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Frente a Lucario ➜ entra con Gengar +2 +2 + Precisión X (lucario no tiene banda focus)",
-      "variant": []
+      "detail": "Frente a Lucario, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. Lucario no tiene Banda Focus.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/delos/lucario.json
+++ b/src/data/sinnoh/delos/lucario.json
@@ -2,15 +2,34 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Cambiar a Gengar👻",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "A bocajarro ➜ Entrar con Gengar +2 +2 + Precisión X",
+      "detail": "Si Lucario usa A Bocajarro, Gengar usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
       "variant": []
     },
     {
-      "detail": "Gallade ➜ Cambiar a Slowbro y usar Bostezo ➜ Frente a Golduck ➜ cambiar a Chansey, Trampa Rocas (si se queda usar Amortiguador) Frente a Gallade ➜ entrar con Gengar +4 +2 (No usar Otra Vez) Bola Sombra a todos",
-      "variant": []
+      "detail": "Si sale Gallade, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Golduck, cambia a Chansey y usa 🪨 Trampa Rocas 🪨.",
+          "variant": [
+            {
+              "detail": "Si Golduck se queda, usa Amortiguador.",
+              "variant": []
+            },
+            {
+              "detail": "Frente a Gallade, entra con Gengar y usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No uses Otra Vez.",
+              "variant": [
+                {
+                  "detail": "Usa Bola Sombra contra todos.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/delos/medicham.json
+++ b/src/data/sinnoh/delos/medicham.json
@@ -2,6 +2,16 @@
   "id": "medicham",
   "name": "Medicham",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Cambiar a Slowbro y usar Bostezo al enfrentar a Raichu; sacrificar a Politoed; entrar con Poliwrath +6 💡",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo al enfrentar a Raichu.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/delos/metagross.json
+++ b/src/data/sinnoh/delos/metagross.json
@@ -2,44 +2,59 @@
   "id": "metagross_5",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🐸Elige que ruta usar🐸",
+  "initialMove": "Elige una ruta.",
   "tricks": [
     {
-      "detail": "Arriesgado --> Usar Trampa Rocas y cambiar a Gengar",
+      "detail": "Ruta arriesgada: usa 🪨 Trampa Rocas 🪨 y cambia a Gengar.",
       "variant": [
         {
-          "detail": "Si se queda --> Entrar con Gengar +2 al enfrentar a Dragonite; presionar directamente con Onda Certera a Girafarig restante con Bola Sombra 【5% de probabilidad de Absol aleatorio】",
-          "variant": []
-        },
-        {
-          "detail": "Si Absol debilita a Gengar --> Entrar con Volcarona +1 y presionar; revisar qué Pokémon quedan",
-          "variant": []
-        },
-        {
-          "detail": "Gallade / Roserade --> Entrar con Slowbro y usar Bostezo (ver abajo)",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Estable --> Entrar con Slowbro y usar Bostezo",
-      "variant": [
-        {
-          "detail": "Absol --> Sacrificar a Politoed; entrar con Poliwrath +6; observar la situación",
+          "detail": "Si Metagross se queda, entra con Gengar y usa Maquinación hasta +2 al enfrentar a Dragonite.",
           "variant": [
             {
-              "detail": "Situación ① Girafarig vs Ninetales (primer enfrentamiento) --> Usar Velocidad X y presionar de nuevo",
-              "variant": []
-            },
-            {
-              "detail": "Situación ② Ninetales vs Girafarig (primer enfrentamiento) --> Presionar directamente; si no hay golpe crítico no debilita; si hay golpe crítico y cae, entrar con Gengar +2 para completar",
+              "detail": "Presiona directo con Onda Certera. Usa Bola Sombra contra Girafarig restante. Hay 5% de Absol aleatorio.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Ninetales --> Usar Protección y Bostezo al enfrentar a Absol; sacrificar a Politoed; entrar con Poliwrath +6",
+          "detail": "Si Absol debilita a Gengar, entra con Volcarona y usa Danza Aleteo x1.",
+          "variant": [
+            {
+              "detail": "Presiona y revisa qué Pokémon quedan.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Gallade o Roserade, entra con Slowbro y usa Bostezo.",
           "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Ruta estable: entra con Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Absol, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Observa la situación.",
+          "variant": [
+            {
+              "detail": "Situación ① Girafarig contra Ninetales en el primer enfrentamiento: usa Velocidad X y presiona de nuevo.",
+              "variant": []
+            },
+            {
+              "detail": "Situación ② Ninetales contra Girafarig en el primer enfrentamiento: presiona directo. Si hay crítico y cae, entra con Gengar y usa Maquinación hasta +2 para completar.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Ninetales, usa Protección y Bostezo al enfrentar a Absol.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/sinnoh/delos/mismagius.json
+++ b/src/data/sinnoh/delos/mismagius.json
@@ -2,6 +2,16 @@
   "id": "mismagius",
   "name": "Mismagius",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6 💡",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/delos/ninetales.json
+++ b/src/data/sinnoh/delos/ninetales.json
@@ -2,38 +2,58 @@
   "id": "ninetales",
   "name": "Ninetales",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 frente a Gallade; Gengar +2",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda --> Gengar +6 +2 + Precisión",
-      "variant": []
-    },
-    {
-      "detail": "Dragonite 【Arriesgado】 --> Presionar directamente; Girafarig  usa Onda Certera; Gengar termina con Bola Sombra 【5% de probabilidad de que salga Absol】",
-      "variant": []
-    },
-    {
-      "detail": "Sale Absol y Gengar es debilitado --> Volcarona +1; presionar filas traseras; informar quién queda",
-      "variant": []
-    },
-    {
-      "detail": "Dragonite 【Seguro】 --> Slowbro usa Bostezo",
-      "variant": []
-    },
-    {
-      "detail": "Ninetales --> Usar Protección y Bostezo; sacrificar a Politoed; Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Absol --> Sacrificar a Politoed; Poliwrath +6; observar la situación",
+      "detail": "Frente a Gallade, entra con Gengar y usa Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Situación 1 Girafarig  vs. Ninetales (primer enfrentamiento) --> Usar Velocidad X y presionar de nuevo",
+          "detail": "Si Gallade permanece en campo, Gengar usa Maquinación hasta +6, Velocidad X para +2 Velocidad y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Situación 2 Ninetales vs. Girafarig (primer enfrentamiento) --> Presionar directamente; si no es golpe crítico no debilita; si es golpe crítico y cae, Gengar +2 para completar",
+          "detail": "Si sale Dragonite en ruta arriesgada, presiona directo.",
+          "variant": [
+            {
+              "detail": "Usa Onda Certera contra Girafarig y termina con Bola Sombra. Hay 5% de probabilidad de que salga Absol.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Absol y debilita a Gengar, entra con Volcarona y usa Danza Aleteo x1.",
+          "variant": [
+            {
+              "detail": "Presiona filas traseras e informa quién queda.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Dragonite en ruta segura, Slowbro usa Bostezo.",
           "variant": []
+        },
+        {
+          "detail": "Si sale Ninetales, usa Protección y Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Absol, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Observa la situación.",
+          "variant": [
+            {
+              "detail": "Situación ① Girafarig contra Ninetales en el primer enfrentamiento: usa Velocidad X y presiona de nuevo.",
+              "variant": []
+            },
+            {
+              "detail": "Situación ② Ninetales contra Girafarig en el primer enfrentamiento: presiona directo. Si hay crítico y cae, entra con Gengar y usa Maquinación hasta +2 para completar.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/sinnoh/delos/noctowl.json
+++ b/src/data/sinnoh/delos/noctowl.json
@@ -2,6 +2,16 @@
   "id": "noctowl",
   "name": "Noctowl",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 al enfrentar a Gallade o Roserade; entrar con Gengar +6/+2 + Precisión",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Gallade o Roserade, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +6, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/delos/raichu.json
+++ b/src/data/sinnoh/delos/raichu.json
@@ -2,50 +2,65 @@
   "id": "raichu",
   "name": "Raichu",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Lucario ➜ Gengar usa Otra Vez",
+      "detail": "Si sale Lucario, Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Si se queda ➜ Entrar con Gengar +2/+2 + Precisión",
+          "detail": "Si Lucario permanece en campo, Gengar usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Dragonite ➜ Cambiar a Slowbro y usar bostezo hasta que cambie a Gallade o Roserade ➜ usa Protección y Bostezo ➜ Frente a Raichu ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-          "variant": []
+          "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo hasta que cambie a Gallade o Roserade.",
+          "variant": [
+            {
+              "detail": "Usa Protección y Bostezo. Frente a Raichu, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Gallade / Roserade --> Gengar usa Otra Vez",
+      "detail": "Si sale Gallade o Roserade, Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Protección ➜ Entrar con Gengar +4/+2 (No usar Otra Vez) y usar Bola Sombra a todos",
-          "variant": []
-        },
-        {
-          "detail": "Espada Santa (vs Gengar rápido) --> Entrar con Gengar +2/+2 + Precisión (No usar Otra Vez)",
-          "variant": []
-        },
-        {
-          "detail": "Espada Santa (vs Gengar lento) --> Entrar con Gengar +4/+2 (No usar Otra Vez)",
-          "variant": []
-        },
-        {
-          "detail": "Golpe Bajo --> Sacrificar a Politoed; entrar con Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Al enfrentar a Dragonite --> Cambiar a Slowbro y usar Bostezo",
+          "detail": "Si usan Protección, entra con Gengar y usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No uses Otra Vez.",
           "variant": [
             {
-              "detail": "Raichu --> Sacrificar a Politoed; entrar con Poliwrath +6",
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usan Espada Santa contra Gengar rápido, entra con Gengar y usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si usan Espada Santa contra Gengar lento, entra con Gengar y usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No uses Otra Vez.",
+          "variant": []
+        },
+        {
+          "detail": "Si usan Golpe Bajo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Al enfrentar a Dragonite, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Raichu, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             },
             {
-              "detail": "Gallade / Roserade (Alakazam) --> Usar Protección y Bostezo al enfrentar a Raichu; sacrificar a Politoed; entrar con Poliwrath +6",
-              "variant": []
+              "detail": "Si sale Gallade o Roserade con Alakazam, usa Protección y Bostezo al enfrentar a Raichu.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             }
           ]
         }

--- a/src/data/sinnoh/delos/sigilyph.json
+++ b/src/data/sinnoh/delos/sigilyph.json
@@ -2,6 +2,21 @@
   "id": "sigilyph",
   "name": "Sigilyph",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 al enfrentar a Gallade o Roserade; entrar con Gengar +4/+2 (No usar Otra Vez) y usar Bola Sombra para todos",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Gallade o Roserade, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/delos/stantler.json
+++ b/src/data/sinnoh/delos/stantler.json
@@ -2,6 +2,16 @@
   "id": "stantler",
   "name": "Stantler",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🐸 Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6 🐸",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Cleans all Sinnoh Delos Spanish strategy JSON files.
- Keeps `initialMove` limited to the opening switch/action only.
- Moves follow-up routes into `tricks.detail` and nested `variant` entries.
- Replaces old Politoed sacrifice wording with pivot wording.
- Expands shorthand setup text for Poliwrath, Gengar, and Volcarona.
- Keeps `Especial X` wording for translation compatibility.

## Scope
- Sinnoh Delos strategy JSON files only.
- No English translation changes.
- No asset changes.
- No frontend layout changes.

## Files
- 21 files under `src/data/sinnoh/delos`.