### PR TITLE
Clean Sinnoh Cynthia Spanish strategy structure

### DIFF
--- a/src/data/sinnoh/cynthia/aerodactyl.json
+++ b/src/data/sinnoh/cynthia/aerodactyl.json
@@ -2,15 +2,30 @@
   "id": "aerodactyl",
   "name": "Aerodactyl",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "❤️ Encanto ❤️",
+  "initialMove": "Usa Encanto.",
   "tricks": [
     {
-      "detail": "Si se queda ➜ Usa Encanto hasta que salga Garchomp, cambiar a Slowbro (Mantener), Bostezo frentea a Glaceon o Roserade, sacrifica a Politoed, entra Poliwrath +6 🥊 🔔(Cascada contra Metagross)🔔",
-      "variant": []
+      "detail": "Si Aerodactyl se queda, usa Encanto hasta que salga Garchomp.",
+      "variant": [
+        {
+          "detail": "Cambia a Slowbro y mantén la ruta.",
+          "variant": [
+            {
+              "detail": "Usa Bostezo frente a Glaceon o Roserade. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Metagross.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Garchomp ➜ Cambiar a Slowbro (Mantener), Bostezo frente a Glaceon o Roserade, sacrifica a Politoed, Poliwrath +6 🥊 🔔(Cascada contra Metagross)🔔",
-      "variant": []
+      "detail": "Si sale Garchomp, cambia a Slowbro y mantén la ruta.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo frente a Glaceon o Roserade. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Metagross.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/altaria.json
+++ b/src/data/sinnoh/cynthia/altaria.json
@@ -2,6 +2,26 @@
   "id": "altaria",
   "name": "Altaria",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Teletransporte ➜ cambiar a Slowbro y usar Bostezo , usar Protección y Bostezo al enfrentar a Nidoqueen ➜ sacrifica a Politoed ➜ entra con Poliwrath +6 🥊 🔔(Usar Cascada contra Bronzong)🔔",
-  "tricks": []
+  "initialMove": "Usa Teletransporte.",
+  "tricks": [
+    {
+      "detail": "Cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Usa Protección y Bostezo al enfrentar a Nidoqueen.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Usa Cascada contra Bronzong.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/cynthia/arcanine.json
+++ b/src/data/sinnoh/cynthia/arcanine.json
@@ -2,24 +2,44 @@
   "id": "arcanine",
   "name": "Arcanine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚 Amortiguador 🥚",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Si se queda ➜ Usar Trampa Rocas ➜ cambiar a Slowbro y usar Bostezo",
+      "detail": "Si Arcanine se queda, usa 🪨 Trampa Rocas 🪨.",
       "variant": [
-       {
-         "detail": "Serperior ➜ Usar Protección y Bostezo al enfrentar a Jellicent, sacrifica a Politoed, entra con Poliwrath +6 🐸🥊",
-         "variant": []
-       },
-       {
-        "detail": "Jellicent ➜ Usar Protección, cambiar a Volcarona ante Serperior, 💊Volcarona +2 + atk. Especial X💊 🚨(Mantener PS por encima del 29%)🚨",
-        "variant": []
-       }
-      ]  
-    },  
+        {
+          "detail": "Luego cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Serperior, usa Protección y Bostezo al enfrentar a Jellicent.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Jellicent, usa Protección y cambia a Volcarona ante Serperior.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x2 y Especial X. Mantén PS por encima del 29%.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
     {
-      "detail": "Lucario ➜ Entrar con Gengar, Otra Vez +4",
-      "variant": []
+      "detail": "Si sale Lucario, entra con Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Luego Gengar usa Maquinación hasta +4.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/bastiodon.json
+++ b/src/data/sinnoh/cynthia/bastiodon.json
@@ -2,15 +2,30 @@
   "id": "bastiodon",
   "name": "Bastiodon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨; cambiar a Slowbro y usar Bostezo",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Serperior --> 💊Entrar con Volcarona +2 y usar Atk. Especial X💊 🚨(Mantener PS por encima del 29%)🚨",
-      "variant": []
-    },
-    {
-      "detail": "Jellicent --> Usar Protección, luego bostezo; cambiar a Volcarona ante Serperior; 💊Volcarona +2 y AtkSpecial X💊 🚨(Mantener PS por encima del 29%)🚨",
-      "variant": []
+      "detail": "Luego cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Serperior, entra con Volcarona.",
+          "variant": [
+            {
+              "detail": "Volcarona usa Danza Aleteo x2 y Especial X. Mantén PS por encima del 29%.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Jellicent, usa Protección y luego Bostezo.",
+          "variant": [
+            {
+              "detail": "Cambia a Volcarona ante Serperior. Volcarona usa Danza Aleteo x2 y Especial X. Mantén PS por encima del 29%.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/braviary.json
+++ b/src/data/sinnoh/cynthia/braviary.json
@@ -2,15 +2,30 @@
   "id": "braviary",
   "name": "Braviary",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 cambiar a Slowbro y usar Bostezo",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Serperior --> Usar Teletransporte; entrar con Volcarona +2 y usar Especial X 🔔(Mantener PS por encima del 29%)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Jellicent --> Usar Protección; cambiar a Volcarona ante Serperior; Volcarona +2 y usar Especial X 🔔(Mantener PS por encima del 29%)🔔",
-      "variant": []
+      "detail": "Luego cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Serperior, usa Teletransporte y entra con Volcarona.",
+          "variant": [
+            {
+              "detail": "Volcarona usa Danza Aleteo x2 y Especial X. Mantén PS por encima del 29%.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Jellicent, usa Protección y cambia a Volcarona ante Serperior.",
+          "variant": [
+            {
+              "detail": "Volcarona usa Danza Aleteo x2 y Especial X. Mantén PS por encima del 29%.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/bronzong.json
+++ b/src/data/sinnoh/cynthia/bronzong.json
@@ -2,35 +2,58 @@
   "id": "bronzong",
   "name": "Bronzong",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 (Si se queda, usar Amortiguador)",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Heracross --> Usar Teletransporte y revisar objeto",
+      "detail": "Si Bronzong se queda, usa Amortiguador.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Heracross, usa Teletransporte y revisa su objeto.",
       "variant": [
         {
-          "detail": "Vidasfera --> Entrar con Gengar +4 + Precisión",
+          "detail": "Si tiene Vidaesfera, entra con Gengar, usa Maquinación hasta +4 y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Sin Vidasfera --> Entrar con Gengar +6 (No usar Otra Vez) y usar Onda Certera contra Clefable",
+          "detail": "Si no tiene Vidaesfera, entra con Gengar y usa Maquinación hasta +6. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Usa Onda Certera contra Clefable.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si aparece Bronzong, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Cambio a Bronzong enemigo --> Sacrificar a Politoed; entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6; usar Cascada contra Bronzong",
-      "variant": []
-    },
-    {
-      "detail": "Lucario --> Usar Teletransporte; cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6",
+      "detail": "Si sale Garchomp, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Si Slowbro retrocede, saca politoed (sacrificar), Poliwrath +2 (con Ataque X), (manten HP 70%).",
-          "variant":  []
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Bronzong.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lucario, usa Teletransporte, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si Slowbro retrocede, entra Politoed como pivote y entra con Poliwrath 🐸🥊. Usa Ataque X para +2 Ataque y mantén HP sobre 70%.",
+          "variant": []
         }
       ]
     }

--- a/src/data/sinnoh/cynthia/chandelure.json
+++ b/src/data/sinnoh/cynthia/chandelure.json
@@ -2,24 +2,49 @@
   "id": "chandelure",
   "name": "Chandelure",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Llamarada --> Usar Teletransporte",
+      "detail": "Si Chandelure usa Llamarada, usa Teletransporte.",
       "variant": [
         {
-          "detail": "Si se queda --> Sacar a Gengar y usar Bola Sombra; cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6 🔔(Cascada a Bronzong)🔔",
-          "variant": []
+          "detail": "Si Chandelure se queda, entra con Gengar y usa Bola Sombra.",
+          "variant": [
+            {
+              "detail": "Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Usa Cascada contra Bronzong.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Garchomp --> Sacar a Gengar; luego cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed; entrar con Poliwrath +6",
-          "variant": []
-        }  
-      ]  
+          "detail": "Si sale Garchomp, entra con Gengar, luego cambia a Slowbro y usa Bostezo frente a Chandelure.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Garchomp --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6 🔔(Cascada a Bronzong)🔔",
-      "variant": []
+      "detail": "Si sale Garchomp directamente, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Cascada contra Bronzong.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
-}  
+}

--- a/src/data/sinnoh/cynthia/clefable.json
+++ b/src/data/sinnoh/cynthia/clefable.json
@@ -2,15 +2,30 @@
   "id": "clefable",
   "name": "Clefable",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚 Amortiguador 🥚",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Heracross --> Usar Teletransporte; entrar con Gengar +6 (No usar Otra Vez) y usar Onda Certera contra Clefable",
-      "variant": []
+      "detail": "Si sale Heracross, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar y usa Maquinación hasta +6. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Usa Onda Certera contra Clefable.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Cambio a Bronzong enemigo --> Sacrificar a Politoed; entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si el rival cambia a Bronzong, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/eelektross.json
+++ b/src/data/sinnoh/cynthia/eelektross.json
@@ -2,19 +2,39 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "❤️ Encanto ❤️",
+  "initialMove": "Usa Encanto.",
   "tricks": [
     {
-      "detail": "Fuerza Bruta --> Usar Amortiguador al enfrentar a Heracross; usar Teletransporte; entrar con Gengar +6 (No usar Otra Vez) y usar Onda Certera contra Clefable",
-      "variant": []
+      "detail": "Si usa Fuerza Bruta, usa Amortiguador al enfrentar a Heracross.",
+      "variant": [
+        {
+          "detail": "Luego usa Teletransporte y entra con Gengar.",
+          "variant": [
+            {
+              "detail": "Gengar usa Maquinación hasta +6. No uses Otra Vez. Usa Onda Certera contra Clefable.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Cambio a Bronzong enemigo --> Sacrificar a Politoed; entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si aparece Bronzong, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Lucario --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Lucario, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/excadrill.json
+++ b/src/data/sinnoh/cynthia/excadrill.json
@@ -2,22 +2,37 @@
   "id": "excadrill",
   "name": "Excadrill",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Cambiar a Politoed 💡",
+  "initialMove": "Cambia a Politoed.",
   "tricks": [
     {
-      "detail": "Si se queda --> Usar Cascada con Politoed hasta debilitarse al enfrentar a Jellicent; usar Amortiguador con Chansey al enfrentar a Heracross; usar Teletransporte; entrar con Gengar +4 + Precisión",
-      "variant": []
-    },
-    {
-      "detail": "Heracross --> Esperar a que debilite y revisar si tiene A bocajarro",
+      "detail": "Si Excadrill se queda, usa Cascada con Politoed hasta quedar debilitado al enfrentar a Jellicent.",
       "variant": [
         {
-          "detail": "Tiene A bocajarro --> Entrar con Gengar +4 + Precisión",
+          "detail": "Luego Chansey usa Amortiguador al enfrentar a Heracross, usa Teletransporte y entra con Gengar.",
+          "variant": [
+            {
+              "detail": "Gengar usa Maquinación hasta +4 y Precisión X.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Heracross, espera a que debilite y revisa si tiene A Bocajarro.",
+      "variant": [
+        {
+          "detail": "Si tiene A Bocajarro, entra con Gengar, usa Maquinación hasta +4 y Precisión X.",
           "variant": []
         },
         {
-          "detail": "No tiene A bocajarro --> Usar Teletransporte con Chansey; entrar con Gengar +4 + Precisión",
-          "variant": []
+          "detail": "Si no tiene A Bocajarro, usa Teletransporte con Chansey y entra con Gengar.",
+          "variant": [
+            {
+              "detail": "Gengar usa Maquinación hasta +4 y Precisión X.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/sinnoh/cynthia/garchomp.json
+++ b/src/data/sinnoh/cynthia/garchomp.json
@@ -2,80 +2,130 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Vidasfera + Terremoto ➜ Revisar daño",
+      "detail": "Si Garchomp tiene Vidaesfera y usa Terremoto, revisa el daño.",
       "variant": [
         {
-          "detail": "32 - 39% (Crítico 49 - 59%) ➜ Usar Amortiguador esperando a Heracross ➜ usar Teletransporte ➜ entrar con Gengar +4 + Precisión",
+          "detail": "Si hace 32 - 39%, o 49 - 59% con crítico, usa Amortiguador esperando a Heracross.",
+          "variant": [
+            {
+              "detail": "Luego usa Teletransporte y entra con Gengar para usar Maquinación hasta +4 y Precisión X.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si hace 40 - 48%, o 60% hasta Banda Focus con crítico, usa Encanto.",
+          "variant": [
+            {
+              "detail": "Luego cambia a Slowbro y usa Bostezo.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Roserade, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Cascada contra Metagross.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Eelektross, usa Protección y cambia rápido a Poliwrath.",
+          "variant": [
+            {
+              "detail": "Frente a Heracross, usa Tambor y deja que Poliwrath quede debilitado. Luego entra con Gengar, usa Maquinación hasta +6. No uses Otra Vez, Heracross tiene Pañuelo Elegido.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Lapras, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "40 - 48% (Crítico 60 - SASH %) ➜ Usar Encanto ➜ cambiar a Slowbro y usar Bostezo",
+          "detail": "Si sale Aerodactyl, usa Bostezo hasta forzar la salida de Glaceon o Roserade.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si Garchomp no tiene Vidaesfera y usa Terremoto, deja que Gengar quede debilitado.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro y usa Bostezo. Sigue usando Bostezo si se queda.",
+          "variant": [
+            {
+              "detail": "Si sale Nidoking, Nidoqueen, Lucario o Chandelure, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Usa Cascada contra Bronzong.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Jellicent, usa Protección y cambia a Volcarona ante Serperior.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x2 y Especial X. Mantén PS por encima del 29%.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Serperior, entra con Volcarona, usa Danza Aleteo x2 y Especial X. Mantén PS por encima del 29%.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Heracross, usa Teletransporte y revisa el objeto.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidaesfera, entra con Gengar y usa Maquinación hasta +4 y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Roserade ➜ Sacrifica a Politoed ➜  Poliwrath +6 usar Cascada contra Metagross",
-          "variant": []
+          "detail": "Si no tiene Vidaesfera, entra con Gengar y usa Maquinación hasta +6. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Usa Onda Certera contra Clefable.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Eelektross ➜ Usar Protección y cambia rapido a Poliwrath y frente Heracross usar Tambor y que muera ahora entra con Gengar +6 (No usar Otra Vez,Heracross Tiene Pañuelo)",
-          "variant": []
-        },
-        {
-          "detail": "Lapras ➜ Sacrifica a Politoed ➜ entra con Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Aerodactyl ➜ Usa Bostezo hasta forzar la salida de glaceon o Roserade y sacrifica a Politoed ➜ Poliwrath +6",
+          "detail": "Si el rival cambia a Bronzong, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Sin Vidasfera + Terremoto ➜ Sacrifica a Gengar ➜ cambia a Slowbro y usa Bostezo (Seguir usando Bostezo si se queda)",
+      "detail": "Si sale Lucario, usa Teletransporte y revisa el objeto.",
       "variant": [
         {
-          "detail": "Nidoking o Nidoqueen / Lucario / Chandelure ➜ Sacrifica a Politoed ➜ entra con Poliwrath +6 usar Cascada contra Bronzong",
-          "variant": []
+          "detail": "Si tiene Vidaesfera, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Jellicent ➜ Usar Protección ➜ cambiar a Volcarona ante Serperior ➜ Volcarona +2 y usar Especial X (mantener PS por encima del 29%)",
-          "variant": []
-        },
-        {
-          "detail": "Serperior ➜ Entrar con Volcarona +2 y usar Especial X (mantener PS por encima del 29%)",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Heracross ➜ Usar Teletransporte y revisar objeto",
-      "variant": [
-        {
-          "detail": "Vidasfera ➜ Entrar con Gengar +4 + Precisión X",
-          "variant": []
-        },
-        {
-          "detail": "Sin Vidasfera ➜ Entrar con Gengar +6 (No usar Otra Vez) y usar Onda Certera contra Clefable",
-          "variant": []
-        },
-        {
-          "detail": "Cambio a Bronzong enemigo ➜ Sacrifica a Politoed ➜ Poliwrath +6",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Lucario ➜ Usar Teletransporte y revisar objeto",
-      "variant": [
-        {
-          "detail": "Vidasfera ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Sin Vidasfera ➜ Entra con Gengar Otra vez +4 🔔Lucario Banda Focus🔔",
+          "detail": "Si no tiene Vidaesfera, entra con Gengar, usa Otra Vez y Maquinación hasta +4. Lucario tiene Banda Focus.",
           "variant": []
         }
       ]

--- a/src/data/sinnoh/cynthia/gastrodon.json
+++ b/src/data/sinnoh/cynthia/gastrodon.json
@@ -2,24 +2,39 @@
   "id": "gastrodon",
   "name": "Gastrodon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Terremoto --> Cambiar a Slowbro",
+      "detail": "Si Gastrodon usa Terremoto, cambia a Slowbro.",
       "variant": [
         {
-          "detail": "Si se queda --> Usar Bostezo al enfrentar a Chandelure; sacrificar a Politoed; entrar con Poliwrath +6",
-          "variant": []
+          "detail": "Si Gastrodon se queda, usa Bostezo al enfrentar a Chandelure.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Garchomp --> Usar Bostezo continuamente al enfrentar a Chandelure; sacrificar a Politoed; entrar con Poliwrath +6",
-          "variant": []
+          "detail": "Si sale Garchomp, usa Bostezo continuamente al enfrentar a Chandelure.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Garchomp --> Cambiar a Slowbro al enfrentar a Chandelure; sacrificar a Politoed; entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Garchomp, cambia a Slowbro al enfrentar a Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/glaceon.json
+++ b/src/data/sinnoh/cynthia/glaceon.json
@@ -2,6 +2,21 @@
   "id": "glaceon",
   "name": "Glaceon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Usar Encanto, cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6; usar Cascada contra Metagross 💡",
-  "tricks": []
+  "initialMove": "Usa Encanto.",
+  "tricks": [
+    {
+      "detail": "Luego cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Cascada contra Metagross.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/cynthia/heracross.json
+++ b/src/data/sinnoh/cynthia/heracross.json
@@ -2,19 +2,34 @@
   "id": "heracross",
   "name": "Heracross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Teletransporte 💡 (Revisar objeto)",
+  "initialMove": "Usa Teletransporte.",
   "tricks": [
     {
-      "detail": "Tiene Vidasfera --> Entrar con Gengar +4 + Precisión",
-      "variant": []
+      "detail": "Revisa el objeto de Heracross.",
+      "variant": [
+        {
+          "detail": "Si tiene Vidaesfera, entra con Gengar, usa Maquinación hasta +4 y Precisión X.",
+          "variant": []
+        },
+        {
+          "detail": "Si no tiene Vidaesfera, entra con Gengar y usa Maquinación hasta +6. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Usa Onda Certera contra Clefable.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Sin Vidasfera --> Entrar con Gengar +6 (No usar Otra Vez) y usar Onda Certera contra Clefable",
-      "variant": []
-    },
-    {
-      "detail": "Cambio a Bronzong enemigo --> Sacrificar a Politoed; entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si aparece Bronzong, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/jellicent.json
+++ b/src/data/sinnoh/cynthia/jellicent.json
@@ -2,23 +2,43 @@
   "id": "jellicent",
   "name": "Jellicent",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Salpicar --> Usar Teletransporte; entrar con Slowbro y usar Bostezo",
-      "variant": []
+      "detail": "Si usa Salpicar, usa Teletransporte y entra con Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Si se queda --> Sacrificar a Politoed; entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si Jellicent se queda, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Serperior --> Entrar con Volcarona +2 y usar Velocidad X (mantener PS por encima del 29%)",
-      "variant": []
+      "detail": "Si sale Serperior, entra con Volcarona.",
+      "variant": [
+        {
+          "detail": "Volcarona usa Danza Aleteo x2 y Velocidad X. Mantén PS por encima del 29%.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Heracross --> Usar Teletransporte; entrar con Gengar +4 + Precisión",
-      "variant": []
+      "detail": "Si sale Heracross, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Maquinación hasta +4 y Precisión X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/lapras.json
+++ b/src/data/sinnoh/cynthia/lapras.json
@@ -2,37 +2,66 @@
   "id": "lapras",
   "name": "Lapras",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador 🥚 Lapras se Queda Usa Amortiguador",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Lucario ➜ Usar Teletransporte",
+      "detail": "Si Lapras se queda, usa Amortiguador.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Lucario, usa Teletransporte.",
       "variant": [
         {
-          "detail": " Esfera Aural ➜ Entrar con Gengar Otra vez  +6 +2",
-          "variant": []
-        },
-        {
-          "detail": "A bocajarro ➜ Revisar objeto",
+          "detail": "Si usa Esfera Aural, entra con Gengar y usa Otra Vez.",
           "variant": [
             {
-              "detail": "Vidasfera ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜ entra con Poliwrath +6 🐸🥊",
+              "detail": "Luego Gengar usa Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
               "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa A Bocajarro, revisa el objeto.",
+          "variant": [
+            {
+              "detail": "Si tiene Vidaesfera, cambia a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             },
             {
-              "detail": "Sin Vidasfera ➜ Entra con Gengar otra vez +4 🔔(lucario Banda Focus) (Bola Sombra a todo)🔔",
-              "variant": []
+              "detail": "Si no tiene Vidaesfera, entra con Gengar, usa Otra Vez y Maquinación hasta +4. Lucario tiene Banda Focus.",
+              "variant": [
+                {
+                  "detail": "Usa Bola Sombra contra todos.",
+                  "variant": []
+                }
+              ]
             },
             {
-              "detail": "Garchomp ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜  Poliwrath +6 🐸🥊",
-              "variant": []
+              "detail": "Si sale Garchomp, cambia a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             }
           ]
         }
       ]
     },
     {
-      "detail": "Garchomp ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si sale Garchomp, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/lickilicky.json
+++ b/src/data/sinnoh/cynthia/lickilicky.json
@@ -2,19 +2,34 @@
   "id": "lickilicky",
   "name": "Lickilicky",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Golpe Cuerpo --> Usar Teletransporte; entrar con Slowbro y usar Bostezo al enfrentar a Chandelure; sacrificar a Politoed; entrar con Poliwrath +6 🔔usar Cascada contra Bronzong🔔",
+      "detail": "Si usa Golpe Cuerpo, usa Teletransporte y entra con Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo al enfrentar a Chandelure.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Bronzong.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si Slowbro queda contra Garchomp, usa Protección y Bostezo al enfrentar a Chandelure.",
       "variant": []
     },
     {
-      "detail": "Slowbro contra Garchomp --> Usar Protección y Bostezo al enfrentar a Chandelure",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp --> Cambiar a Slowbro y usar Bostezo al enfrentar a Chandelure; sacrificar a Politoed; entrar con Poliwrath +6 🔔usar Cascada contra Bronzong🔔",
-      "variant": []
+      "detail": "Si sale Garchomp, cambia a Slowbro y usa Bostezo al enfrentar a Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Bronzong.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/lucario.json
+++ b/src/data/sinnoh/cynthia/lucario.json
@@ -2,28 +2,48 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Teletransporte💡",
+  "initialMove": "Usa Teletransporte.",
   "tricks": [
     {
-      "detail": "A bocajarro ➜ Revisar objeto",
+      "detail": "Si Lucario usa A Bocajarro, revisa su objeto.",
       "variant": [
         {
-          "detail": "Vidasfera ➜ Entra con Slowbro y usa Bostezo y sacrifica a Politoed y entra con Poliwrath +6🐸🥊",
-          "variant": []
+          "detail": "Si tiene Vidaesfera, entra con Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Sin Vidasfera ➜ Entra con Gengar Otra vez +4  (Bola Sombra a todo Lucario Banda focus)",
+          "detail": "Si no tiene Vidaesfera, entra con Gengar, usa Otra Vez y Maquinación hasta +4.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos. Lucario tiene Banda Focus.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si usa Esfera Aural, entra con Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Esfera Aural ➜ Entra con Gengar  Otra Vez +6 +2",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp ➜ Entra con Slowbro y usa Bostezo y sacrifica a Politoed y entra con Poliwrath +6🐸🥊",
-      "variant": []
+      "detail": "Si sale Garchomp, entra con Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/metagross.json
+++ b/src/data/sinnoh/cynthia/metagross.json
@@ -2,7 +2,21 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " 💡 Encanto, entrar con Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6 💡 Usar Cascada contra Metagross",
-  "tricks": []
+  "initialMove": "Usa Encanto.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Cascada en el cierre de la ruta.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
-  

--- a/src/data/sinnoh/cynthia/milotic.json
+++ b/src/data/sinnoh/cynthia/milotic.json
@@ -2,19 +2,44 @@
   "id": "milotic",
   "name": "Milotic",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Heracross ➜ Usar Teletransporte ➜ entra con Gengar +6 (No usar Otra Vez) 🔔usar Onda Certera contra Clefable🔔",
-      "variant": []
+      "detail": "Si sale Heracross, usa Teletransporte.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar y usa Maquinación hasta +6. No uses Otra Vez.",
+          "variant": [
+            {
+              "detail": "Usa Onda Certera contra Clefable.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Cambio a Bronzong ➜ Sacrifica a Politoed ➜ entrar con Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Si cambia a Bronzong, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Garchomp ➜ Usar Encanto ➜ Slowbro usa Bostezo y si garchomp se duerme usa bostezo hasta que entre Glaceon/Roserade ➜ sacrifica a Politoed ➜  Poliwrath +6 🐸🥊 🔔 Cascada contra Metagross🔔",
-      "variant": []
+      "detail": "Si sale Garchomp, usa Encanto.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo. Si Garchomp se duerme, sigue usando Bostezo hasta que entre Glaceon o Roserade.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Metagross.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/mismagius.json
+++ b/src/data/sinnoh/cynthia/mismagius.json
@@ -2,6 +2,21 @@
   "id": "mismagius",
   "name": "Mismagius",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚 Amortiguador 🥚 Frente a Lucario ➜ Cambia a Gengar Otra Vez +4  ⚠️Lucario Tiene Banda Focus , Usa otra vez al final de bostearte⚠️",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Frente a Lucario, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez y Maquinación hasta +4.",
+          "variant": [
+            {
+              "detail": "Lucario tiene Banda Focus. Usa Otra Vez al final del boosteo.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/cynthia/nidoqueen.json
+++ b/src/data/sinnoh/cynthia/nidoqueen.json
@@ -2,6 +2,21 @@
   "id": "nidoqueen",
   "name": "Nidoqueen",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Teletransporte; entrar con Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6 💡 Usar Cascada contra Bronzong",
-  "tricks": []
+  "initialMove": "Usa Teletransporte.",
+  "tricks": [
+    {
+      "detail": "Entra con Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Cascada contra Bronzong.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/cynthia/rayquaza.json
+++ b/src/data/sinnoh/cynthia/rayquaza.json
@@ -2,24 +2,39 @@
   "id": "rayquaza",
   "name": "Rayquaza",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 Usar Teletransporte 🔔(Para ver la habilidad)🔔",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Sin Velocidad Extrema --> Entrar con Politoed para sacrificarlo 🔔(Mira la Habilidad)🔔",
+      "detail": "Usa Teletransporte para revisar su habilidad.",
       "variant": [
         {
-          "detail": "Velocidad Extrema --> Entrar con Gengar +4",
-          "variant": []
+          "detail": "Si no muestra Velocidad Extrema, entra Politoed como pivote y revisa el movimiento.",
+          "variant": [
+            {
+              "detail": "Si usa Velocidad Extrema, entra con Gengar y usa Maquinación hasta +4.",
+              "variant": []
+            },
+            {
+              "detail": "Si usa Garra Dragón, entra con Poliwrath 🐸🥊 y barre hasta Garchomp.",
+              "variant": [
+                {
+                  "detail": "Luego usa Ataque X y sigue barriendo.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Garra Dragón --> Entrar con Poliwrath y Barrer hasta Garchmop, luego usa un Ataque X y sigue Barriendo;",
-          "variant": []
-        }  
-      ]  
-    },
-    {
-      "detail": "Velocidad Extrema --> Entrar con Gengar +4 🔔(Barre con Bola Sombra)🔔",
-      "variant": []
+          "detail": "Si usa Velocidad Extrema, entra con Gengar y usa Maquinación hasta +4.",
+          "variant": [
+            {
+              "detail": "Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/sinnoh/cynthia/roserade.json
+++ b/src/data/sinnoh/cynthia/roserade.json
@@ -2,6 +2,21 @@
   "id": "roserade",
   "name": "Roserade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡 Encanto, entrar con Slowbro y usar Bostezo; sacrificar a Politoed; entrar con Poliwrath +6 💡 (Cascada contra Metagross)",
-  "tricks": []
+  "initialMove": "Usa Encanto.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Cascada contra Metagross.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/cynthia/serperior.json
+++ b/src/data/sinnoh/cynthia/serperior.json
@@ -2,6 +2,21 @@
   "id": "serperior",
   "name": "Serperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨, Teletransporte ➜ Slowbro usa Bostezo usar Protección con Slowbro y se duerme el rival usa  bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Luego usa Teletransporte y entra con Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo. Usa Protección para dormir al rival y vuelve a usar Bostezo si corresponde.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/cynthia/spiritomb.json
+++ b/src/data/sinnoh/cynthia/spiritomb.json
@@ -2,6 +2,16 @@
   "id": "spiritomb",
   "name": "Spiritomb",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡🐚Slowbro usa Bostezo; sacrificar a Politoed; Poliwrath +6 🐸 💡",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/cynthia/togekiss.json
+++ b/src/data/sinnoh/cynthia/togekiss.json
@@ -2,6 +2,16 @@
   "id": "togekiss",
   "name": "Togekiss",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " 🔄 Cambiar a Slowbro y usar Bostezo ➜ sacrificar a Politoed ➜ 🐸Poliwrath +6 🥊",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/cynthia/tyranitar.json
+++ b/src/data/sinnoh/cynthia/tyranitar.json
@@ -2,6 +2,16 @@
   "id": "tyranitar",
   "name": "Tyranitar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 frente a Heracross; sacrificar a Politoed; Gengar Otra vez +4 + Precisión X",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Heracross, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Precisión X.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/sinnoh/cynthia/umbreon.json
+++ b/src/data/sinnoh/cynthia/umbreon.json
@@ -2,6 +2,21 @@
   "id": "umbreon",
   "name": "Umbreon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 frente a Garchomp; Slowbro usa Bostezo frente a Chandelure; sacrificar a Politoed; Poliwrath +6 🔔 Cascada a Bronzong 🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Garchomp, Slowbro usa Bostezo al enfrentar a Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Cascada contra Bronzong.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Cleans all Sinnoh Cynthia Spanish strategy JSON files.
- Keeps `initialMove` limited to the opening switch/action only.
- Moves follow-up routes into `tricks.detail` and nested `variant` entries.
- Replaces old Politoed sacrifice wording with pivot wording.
- Expands shorthand setup text for Poliwrath, Gengar, and Volcarona.
- Keeps `Especial X` wording for translation compatibility.

## Scope
- Sinnoh Cynthia strategy JSON files only.
- No English translation changes.
- No asset changes.
- No frontend layout changes.

## Files
- 29 files under `src/data/sinnoh/cynthia`.