### PR TITLE
Clean Teselia Anis Spanish strategy structure

### DIFF
--- a/src/data/teselia/anis/absol.json
+++ b/src/data/teselia/anis/absol.json
@@ -2,11 +2,30 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambia a Slowbro y usa Bostezo frente a Hydreigon, cambia a Chansey y usa Trampa Rocas frente a Luxray, cambia a Gengar Otra Vez 4+2💡",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Si cambia a Bronzong ➜ Sacrifica a Politoed, Poliwrath +6 🐸🥊",
-      "variant": []
+      "detail": "Usa Bostezo frente a Hydreigon.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Chansey y usa 🪨 Trampa Rocas 🪨 frente a Luxray.",
+          "variant": [
+            {
+              "detail": "Después entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si cambia a Bronzong, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/anis/banette.json
+++ b/src/data/teselia/anis/banette.json
@@ -2,11 +2,25 @@
   "id": "banette",
   "name": "Banette",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 🔔(Si no cambia usa Amortiguador)🔔",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Sale Absol --> Cambia a Gengar, Otra Vez 4+2 🔔(Barre con Bola Sombra, Absol No tiene banda focus)🔔",
+      "detail": "Si Banette se queda, usa Amortiguador.",
       "variant": []
+    },
+    {
+      "detail": "Si sale Absol, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Barre con Bola Sombra. Absol no tiene Banda Focus.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/anis/bisharp.json
+++ b/src/data/teselia/anis/bisharp.json
@@ -2,68 +2,107 @@
   "id": "bisharp",
   "name": "Bisharp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Se queda ➜ Ver el ataque",
+      "detail": "Si Bisharp se queda, revisa el ataque.",
       "variant": [
         {
-          "detail": "Patada Baja ➡ Amortiguador 4 veces",
+          "detail": "Si usa Patada Baja, usa Amortiguador 4 veces.",
           "variant": [
             {
-              "detail": "Patada Baja ➡ Volcarona +3 🔔(Gigadrenado al Pokemon en 2da Posición (Zoroark), Psiquico al verdadero Chandelure)🔔",
+              "detail": "Si vuelve a usar Patada Baja, entra con Volcarona y usa Danza Aleteo x3.",
               "variant": [
                 {
-                  "detail": "☠️Si muere por Critico☠️ ➜ Gengar 2+2 + Precisión X",
+                  "detail": "Usa Gigadrenado contra el Pokémon en segunda posición, que es Zoroark. Usa Psíquico contra el Chandelure verdadero.",
                   "variant": []
-                },  
-                {  
-                  "detail": "Te Bosteas y Entra Dragonite ➜ 💊Toma un Especial X luego Barre💊 🔔(Gigadrenado a Frosslas)🔔",
+                },
+                {
+                  "detail": "Si Volcarona queda debilitada por crítico, entra con Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si te duermes y entra Dragonite, usa Especial X y barre. Usa Gigadrenado contra Froslass.",
                   "variant": []
                 }
               ]
-            },  
-            {
-              "detail": "Cabeza de Hierro ➡ Cambiar a Slowbro y usar Bostezo frente a Chandelure, sacrifica a Politoed, Poliwrath +6🐸🥊 🔔(Puño Hielo a Frosslas y Cascada a Dragonite)🔔",
-              "variant": []
-            }  
-          ]
-        },
-        {
-          "detail": "Cabeza de Hierro ➡ Cambiar a Slowbro y usar Bostezo frente a Chandelure/Eelektross, sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño Hielo a Frosslas y Cascada a Dragonite)🔔",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Eelektross ➡ Gengar usa Otra Vez luego cambia a Slowbro",
-      "variant": [
-        {
-          "detail": "Se queda ➡ Bostezo ",
-          "variant": [
-            {
-              "detail": "Gengar ➡ Protección , cambiar a Poliwrath frente Chandelurem Volcarona +2 🔔(Psiquico a Gengar)🔔",
-              "variant": []
             },
             {
-              "detail": "Chandelure ➡ Protección , Bostezo frente a Gengar, Teletransporte, Volcarona +2 🔔(Psiquico a Gengar)🔔",
-              "variant": []
+              "detail": "Si usa Cabeza de Hierro, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+                  "variant": []
+                }
+              ]
             }
           ]
         },
         {
-          "detail": "Dragonite ➡ Cambia a Slowbro y usa Bostezo, sacrifica a Politoed, Poliwrath +6🐸🥊 🔔(Puño Hielo a Frosslas y Cascada a Dragonite)🔔",
+          "detail": "Si usa Cabeza de Hierro, cambia a Slowbro y usa Bostezo frente a Chandelure o Eelektross.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez y cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Si Eelektross se queda, usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Gengar, usa Protección y cambia a Poliwrath 🐸🥊 frente a Chandelure.",
+              "variant": [
+                {
+                  "detail": "Luego entra con Volcarona y usa Danza Aleteo x2. Usa Psíquico contra Gengar.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Chandelure, usa Protección y Bostezo frente a Gengar.",
+              "variant": [
+                {
+                  "detail": "Luego usa Teletransporte y entra con Volcarona. Volcarona usa Danza Aleteo x2 y Psíquico contra Gengar.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Toxicroak, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Toxicroak ➡ Cambiar a Slowbro, Bostezo frente a Chandelure, sacrifica a Politoed, Poliwrath +6🐸🥊",
-      "variant": []
-    },
-    {
-      "detail": "Dragonite ➡ Cambiar a Slowbro y usar Bostezo, sacrifica a Politoed, Poliwrath +6🐸🥊 🔔(Puño Hielo a Frosslas y Cascada a Dragonite)🔔",
-      "variant": []
+      "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/anis/bronzong.json
+++ b/src/data/teselia/anis/bronzong.json
@@ -2,6 +2,21 @@
   "id": "bronzong",
   "name": "Bronzong",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨 Frente a Absol, Gengar Otra vez 4+2 🔔(Barre con Bola Sombra)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Absol, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/anis/chandelure.json
+++ b/src/data/teselia/anis/chandelure.json
@@ -2,126 +2,186 @@
   "id": "chandelure",
   "name": "Chandelure",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si usa Onda Certera es【Zoroark】➜ Cambiar a Gengar 🔔(Mira abajo)🔔",
+      "detail": "Si usa Onda Certera, es Zoroark. Cambia a Gengar.",
       "variant": [
         {
-          "detail": "Si se queda ➜ Gengar 4+2 + Precisión X 🔔(No usar Otra Vez Zoroark tiene gafas elegidas)🔔",
+          "detail": "Si Zoroark se queda, Gengar usa Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. No uses Otra Vez porque Zoroark tiene Gafas Elegidas.",
           "variant": []
         },
         {
-          "detail": "Dragonite ➜ Cambia a Slowbro luego Cambia a Chansey y usa Amortiguador",
+          "detail": "Si sale Dragonite, cambia a Slowbro y luego a Chansey. Usa Amortiguador.",
           "variant": [
             {
-              "detail": "Si se queda ➜ Cambia a Gengar otra vez +2 luego Barre hasta que entre Bisharp ➜ sacrifica a Politoed ➜ entrar con Poliwrath +6🔔(Cascada a Cofragius/Bronzong)🔔",
-              "variant": []
-            },
-            {
-              "detail": " Bisharp ➜ Sacrifica a Politoed ➜ entrar con Poliwrath +6 🔔(Cascada a Cofragius/Bronzong)",
-              "variant": []
-            },
-            {
-              "detail": "Si entra el Segundo Chandelure ➜ Cambia a Gengar",
+              "detail": "Si Dragonite se queda, cambia a Gengar, usa Otra Vez y Maquinación hasta +2. Barre hasta que entre Bisharp.",
               "variant": [
                 {
-                  "detail": "Si se queda  ➜ Gengar 4+2 + Precision X (No usar otra vez)",
-                  "variant": []
-                },
-                {
-                  "detail": "Dragonite ➜ Cambia a Slowbro luego Cambia a Chansey y usa Amortiguador 🔔(Ver Arriba la estrategia de Dragonite)🔔",
-                  "variant": []
-                }
-              ]  
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "detail": "Eelektross ➜ Gengar usa Otra Vez luego cambiar a Slowbro",
-      "variant": [
-        {
-          "detail": "Se queda ➜ Usar Bostezo",
-          "variant": [
-            {
-              "detail": "Gengar ➜ Usar Protección, cambiar a Poliwrath ➜ frente Chandelure ➜ Volcarona +2 🔔(Psiquico a Gengar)🔔",
-              "variant": []
-            },
-            {
-              "detail": "Chandelure ➜ Usar Protección, Bostezo ➜ frente a Gengar ➜ Teletransporte ➜ Volcarona +2 🔔(Psiquico a Gengar)🔔",
-              "variant": []
-            }
-          ]
-        },
-        {
-          "detail": "Dragonite ➜ Slowbro Usar Bostezo ➜ sacrifica a Politoed ➜ entrar con Poliwrath +6 🔔(Puño Hielo a Frosslas y Cascada a Dragonite)🔔",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Hydreigon ➜ Gengar 6+2 🔔(Onda Certera a Purugly)🔔",
-      "variant": [
-        {
-          "detail": "Ida y Vuelta activa Cuerpo Maldito ➜ Gengar usa Otra Vez, cambiar a Poliwrath Puño drenaje y debilitar",
-          "variant": []
-        },
-        {
-          "detail": "Cambia a Milotic ➜ Cambiar a Chansey, usar Amortiguador para atraer a Golurk ➜ entrar con Gengar 6+2",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Toxicroak ➜ Cambiar a Slowbro, Bostezo ➜ frente a Chandelure ➜ sacrifica a Politoed ➜ entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Lucario ➜ Gengar, Otra Vez 4+2 + Precision X",
-      "variant": []
-    },
-    {
-      "detail": "Absol ➜ Gengar, Otra Vez 4+2 🔔(Barre con Bola Sombra)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Dragonite ➜ Cambia a Slowbro luego a Chansey",
-      "variant": [
-        {
-          "detail": "Chandelure/lucario ➜ Amortiguador 🔔(Aguanta la Onda Certera o A bocajarro y sigue la guia de arriba segun el pokemon que a salido)🔔",
-          "variant": [
-            {
-              "detail": "Dragonite ➜ Gengar Otra Vez +2 🔔(Mira el Objeto)🔔",
-              "variant": [
-                {
-                  "detail": "Con Restos ➜ Ataca a Dragonite hasta que entre Bisharp ➜ Sacrifica a Politoed ➜ Poliwrath +6 🔔(Cascada a Cofagrigus/Bronzong)🔔",
-                  "variant": []
-                },
-                {
-                  "detail": "Sin Restos ➜ Slowbro usa Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6 🔔(Puño Hielo a Frosslas y Cascada a Dragonite)",
+                  "detail": "Frente a Bisharp, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Cofagrigus o Bronzong.",
                   "variant": []
                 }
               ]
             },
             {
-              "detail": "Bisharp ➜ Sacrifica a Politoed ➜ entra con Poliwrath +6 🔔(Cascada a Cofragius/Bronzong)🔔",
+              "detail": "Si sale Bisharp, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Cofagrigus o Bronzong.",
               "variant": []
             },
             {
-              "detail": "Eelektross ➜ Gengar Otra Vez luego cambia a Slowbro y usa Bostezo ➜ sacrifica a Politoed ➜ entrar con Poliwrath +6 🔔(Puño Hielo a Frosslas y Cascada a Dragonite)🔔",
-              "variant": []
+              "detail": "Si entra el segundo Chandelure, cambia a Gengar.",
+              "variant": [
+                {
+                  "detail": "Si se queda, Gengar usa Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. No uses Otra Vez.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si sale Dragonite, cambia a Slowbro y luego a Chansey. Usa Amortiguador y sigue la ruta de Dragonite.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez y luego cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Si Eelektross se queda, usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Gengar, usa Protección y cambia a Poliwrath 🐸🥊 frente a Chandelure.",
+              "variant": [
+                {
+                  "detail": "Luego entra con Volcarona y usa Danza Aleteo x2. Usa Psíquico contra Gengar.",
+                  "variant": []
+                }
+              ]
             },
             {
-              "detail": "Si Sale el segundo chanselure [Zoroark] Usa Amoritguador para ver si usa onda certera y cambiar a gengar +4 +2 + Precision x 🔔Si sabes que es zoruark no usar otra vez🔔",
-              "variant": []
+              "detail": "Si sale Chandelure, usa Protección y Bostezo frente a Gengar.",
+              "variant": [
+                {
+                  "detail": "Luego usa Teletransporte y entra con Volcarona. Volcarona usa Danza Aleteo x2 y Psíquico contra Gengar.",
+                  "variant": []
+                }
+              ]
             }
           ]
         },
         {
-          "detail": "Eelektross ➜ Gengar Otra Vez luego cambia a Slowbro y usa Bostezo ➜ sacrifica a Politoed ➜ entrar con Poliwrath +6 🔔(Puño Hielo a Frosslas y Cascada a Dragonite)🔔",
+          "detail": "Si sale Dragonite, Slowbro usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Hydreigon, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad. Usa Onda Certera contra Purugly.",
+          "variant": [
+            {
+              "detail": "Si Ida y Vuelta activa Cuerpo Maldito, Gengar usa Otra Vez y cambia a Poliwrath 🐸🥊 para usar Puño Drenaje y debilitarlo.",
+              "variant": []
+            },
+            {
+              "detail": "Si cambia a Milotic, cambia a Chansey y usa Amortiguador para atraer a Golurk.",
+              "variant": [
+                {
+                  "detail": "Luego entra con Gengar, usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Toxicroak, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lucario, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Absol, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Dragonite, cambia a Slowbro y luego a Chansey.",
+      "variant": [
+        {
+          "detail": "Si sale Chandelure o Lucario, usa Amortiguador para aguantar Onda Certera o A Bocajarro y sigue la ruta correspondiente de arriba.",
+          "variant": [
+            {
+              "detail": "Si vuelve Dragonite, Gengar usa Otra Vez y Maquinación hasta +2. Revisa el objeto.",
+              "variant": [
+                {
+                  "detail": "Con Restos, ataca a Dragonite hasta que entre Bisharp. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Cofagrigus o Bronzong.",
+                  "variant": []
+                },
+                {
+                  "detail": "Sin Restos, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Bisharp, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Cascada contra Cofagrigus o Bronzong.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Eelektross, Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale el segundo Chandelure como Zoroark, usa Amortiguador para revisar si usa Onda Certera.",
+              "variant": [
+                {
+                  "detail": "Luego cambia a Gengar, usa Maquinación hasta +4, Velocidad X para +2 Velocidad y Precisión X. Si sabes que es Zoroark, no uses Otra Vez.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Eelektross, Gengar usa Otra Vez. Luego cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/teselia/anis/dragonite.json
+++ b/src/data/teselia/anis/dragonite.json
@@ -2,15 +2,35 @@
   "id": "dragonite",
   "name": "Dragonite",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Fuerza Bruta ➡ 🪨TrampaRocas🪨 + Amortiguador frente a Eelektross, Gengar usa Otra Vez, cambiar a Slowbro frente a Dragonite, usar Bostezo, sacrifica a Politoed, Poliwrath +6 🔔(Puño Hielo a Frosslas y Cascada a Dragonite)🔔",
-      "variant": []
+      "detail": "Si Dragonite usa Fuerza Bruta, usa 🪨 Trampa Rocas 🪨.",
+      "variant": [
+        {
+          "detail": "Luego usa Amortiguador frente a Eelektross.",
+          "variant": [
+            {
+              "detail": "Gengar usa Otra Vez. Después cambia a Slowbro frente a Dragonite y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Toxicroak ➡ Cambia a Slowbro y usa Bostezo, sacrifica a Politoed, Poliwrath +6 🔔(Puño Drenaje a Bisharp)🔔",
-      "variant": []
+      "detail": "Si sale Toxicroak, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Bisharp.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/anis/drifblim.json
+++ b/src/data/teselia/anis/drifblim.json
@@ -2,11 +2,35 @@
   "id": "drifblim",
   "name": "Drifblim",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚 esperar a Lucario, Gengar Otra Vez, cambiar a Slowbro  y usar Bostezo, frente a Jolteon, sacrifica a Politoed, Poliwrath +6🐸🥊",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "👾TESTEO👾 ➜ Cambiar a Slowbro, sacrifica a Politoed, Poliwrath +6🐸🥊",
-      "variant": []
-    }  
-  ]  
+      "detail": "Espera a Lucario.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez.",
+          "variant": [
+            {
+              "detail": "Luego cambia a Slowbro y usa Bostezo frente a Jolteon.",
+              "variant": [
+                {
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Ruta alternativa: cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/anis/eelektross.json
+++ b/src/data/teselia/anis/eelektross.json
@@ -2,54 +2,78 @@
   "id": "eelektross",
   "name": "Eelektross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Gengar usa Otra Vez👻, cambiar a Slowbro y luego cambiar a Chansey",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Gengar ➜ 🪨Trampa Rocas🪨 frente a Eelektross, Gengar usa Otra Vez, cambiar a Slowbro y usar Bostezo 🚨(Si se queda usando Onda Certera, cambia a Volcarona +2)🚨",
+      "detail": "Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Chandelure ➜ Usar Protección y Bostezo frente a Gengar ➜ entrar con Volcarona +2 🔔(Psíquico a Gengar y Lanzallamas a Chandelure)🔔",
+          "detail": "Luego cambia a Slowbro y después a Chansey.",
           "variant": []
-        },
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Gengar, usa 🪨 Trampa Rocas 🪨 frente a Eelektross.",
+      "variant": [
         {
-          "detail": "Gengar ➜ Usar Protección ➜ cambia a Poliwrath, frente a Chandelure ➜ Volcarona +2 🔔(Psíquico a Gengar)🔔",
+          "detail": "Gengar usa Otra Vez, cambia a Slowbro y usa Bostezo. Si Eelektross se queda usando Onda Certera, cambia a Volcarona y usa Danza Aleteo x2.",
           "variant": [
             {
-              "detail": "🪨Trampa Rocas🪨, ante un Onda Certera inesperado mantenerse ➜ Gengar 2+2 + Precisión X 🔔No usar Otra Vez)🔔",
+              "detail": "Si sale Chandelure, usa Protección y Bostezo frente a Gengar. Luego entra con Volcarona y usa Danza Aleteo x2. Usa Psíquico contra Gengar y Lanzallamas contra Chandelure.",
               "variant": []
+            },
+            {
+              "detail": "Si sale Gengar, usa Protección y cambia a Poliwrath 🐸🥊 frente a Chandelure. Luego entra con Volcarona y usa Danza Aleteo x2. Usa Psíquico contra Gengar.",
+              "variant": [
+                {
+                  "detail": "Si aparece una Onda Certera inesperada, mantén la ruta: usa 🪨 Trampa Rocas 🪨, entra con Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X. No uses Otra Vez.",
+                  "variant": []
+                }
+              ]
             }
           ]
         }
       ]
     },
     {
-      "detail": "Chandelure ➜ 🪨Trampa Rocas🪨.",
+      "detail": "Si sale Chandelure, usa 🪨 Trampa Rocas 🪨.",
       "variant": [
         {
-          "detail": "Eelektross ➜ Gengar usa Otra Vez, cambiar a Slowbro",
+          "detail": "Si sale Eelektross, Gengar usa Otra Vez y luego cambia a Slowbro.",
           "variant": [
             {
-              "detail": "Si se queda ➜ Usar Bostezo",
+              "detail": "Si Eelektross se queda, usa Bostezo.",
               "variant": [
                 {
-                  "detail": "Gengar ➜ Usar Protección ➜ cambiar a Poliwrath frente a Chandelure ➜ Volcarona +2 🔔(Psíquico a Gengar)🔔",
+                  "detail": "Si sale Gengar, usa Protección y cambia a Poliwrath 🐸🥊 frente a Chandelure. Luego entra con Volcarona y usa Danza Aleteo x2. Usa Psíquico contra Gengar.",
                   "variant": []
                 },
                 {
-                  "detail": "Chandelure ➜ Usar Protección y Bostezo frente a Gengar ➜ Teletransporte ➜ Volcarona con +2 🔔(Psíquico a Gengar y Lanzallamas a Chandelure)🔔",
+                  "detail": "Si sale Chandelure, usa Protección y Bostezo frente a Gengar. Luego usa Teletransporte y entra con Volcarona en +2. Usa Psíquico contra Gengar y Lanzallamas contra Chandelure.",
                   "variant": []
                 }
               ]
             },
             {
-              "detail": "Dragonite ➜ Slowbro usa Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6 🐸🥊 🔔(Puño Hielo a Froslass y Cascada a Dragonite)🔔",
-              "variant": []
+              "detail": "Si sale Dragonite, Slowbro usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+                  "variant": []
+                }
+              ]
             }
           ]
         },
         {
-          "detail": "Dragonite ➜ Slowbro usa Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño Hielo a Froslass y Cascada a Dragonite)🔔",
-          "variant": []
+          "detail": "Si sale Dragonite directamente, Slowbro usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/teselia/anis/froslass.json
+++ b/src/data/teselia/anis/froslass.json
@@ -2,15 +2,30 @@
   "id": "froslass",
   "name": "Froslass",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Eelektross --> Gengar usa Otra Vez, cambiar a Slowbro frente a Dragonite; usar Bostezo, sacrificar a Politoed, entra con Poliwrath +6 🔔(Puño Hielo a Froslass y Cascada a Dragonite)🔔",
-      "variant": []
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro frente a Dragonite y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Dragonite --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed, entrar con Poliwrath +6 🔔(Puño Hielo a Froslass y Cascada a Dragonite)🔔",
-      "variant": []
+      "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/anis/gengar.json
+++ b/src/data/teselia/anis/gengar.json
@@ -2,18 +2,33 @@
   "id": "gengar",
   "name": "Gengar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Eelektross ➜ Gengar usa Otra Vez, cambiar a Slowbro y usar Bostezo",
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Gengar ➜ Usar Protección, cambiar a Poliwrath frente a Chandelure, Volcarona +2 🔔(Psiquico a Gengar)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Chandelure ➜ Usar Protección y Bostezo frente a Gengar, Teletransporte, Volcarona +2 🔔(Psiquico a Gengar y puedes usar Lanzallamas contra Chandelure)🔔",
-          "variant": []
+          "detail": "Luego cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Gengar, usa Protección y cambia a Poliwrath 🐸🥊 frente a Chandelure.",
+              "variant": [
+                {
+                  "detail": "Después entra con Volcarona y usa Danza Aleteo x2. Usa Psíquico contra Gengar.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Chandelure, usa Protección y Bostezo frente a Gengar.",
+              "variant": [
+                {
+                  "detail": "Luego usa Teletransporte, entra con Volcarona y usa Danza Aleteo x2. Usa Psíquico contra Gengar y puedes usar Lanzallamas contra Chandelure.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/teselia/anis/golurk.json
+++ b/src/data/teselia/anis/golurk.json
@@ -2,11 +2,30 @@
   "id": "golurk",
   "name": "Golurk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Gengar usa Bola Sombra para debilitar a Milotic; camibia Chansey y usa Trampa rocas, si Hydreigon entra al campo; Gengar Otra vez 6+2",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "🔔(Onda Certera contra purugly)🔔 // 🔔(Ida y Vuelta activa Cuerpo Maldito --> Gengar usa Otra Vez, cambiar a Poliwrath para eliminarlo)🔔",
-      "variant": []
+      "detail": "Gengar usa Bola Sombra para debilitar a Milotic.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Chansey y usa 🪨 Trampa Rocas 🪨.",
+          "variant": [
+            {
+              "detail": "Si Hydreigon entra al campo, entra con Gengar, usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+              "variant": [
+                {
+                  "detail": "Usa Onda Certera contra Purugly.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si Ida y Vuelta activa Cuerpo Maldito, Gengar usa Otra Vez y luego cambia a Poliwrath 🐸🥊 para eliminarlo.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/anis/hydreigon.json
+++ b/src/data/teselia/anis/hydreigon.json
@@ -2,20 +2,35 @@
   "id": "hydreigon",
   "name": "Hydreigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Tiene Vidasfera --> 🪨TrampaRocas🪨 frente a Golurk, Gengar Otra Vez 6+2 🔔(Onda Certera a Purugly)🔔",
+      "detail": "Revisa si Hydreigon tiene Vidaesfera.",
       "variant": [
         {
-          "detail": "Ida y Vuelta activa Cuerpo Maldito --> Gengar usa Otra Vez, cambiar a Poliwrath para matarlo",
-          "variant": []
+          "detail": "Si tiene Vidaesfera, usa 🪨 Trampa Rocas 🪨 frente a Golurk.",
+          "variant": [
+            {
+              "detail": "Entra con Gengar, usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad. Usa Onda Certera contra Purugly.",
+              "variant": [
+                {
+                  "detail": "Si Ida y Vuelta activa Cuerpo Maldito, Gengar usa Otra Vez y cambia a Poliwrath 🐸🥊 para eliminarlo.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si no tiene Vidaesfera, usa 🪨 Trampa Rocas 🪨 frente a Absol.",
+          "variant": [
+            {
+              "detail": "Entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+              "variant": []
+            }
+          ]
         }
       ]
-    },
-    {
-      "detail": "Sin Vidasfera --> 🪨TrampaRocas🪨 frente a Absol, Gengar Otra Vez 4+2",
-      "variant": []
     }
   ]
 }

--- a/src/data/teselia/anis/jolteon.json
+++ b/src/data/teselia/anis/jolteon.json
@@ -2,6 +2,16 @@
   "id": "jolteon",
   "name": "Jolteon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Cambiar a Slowbro frente a Lucario luego usar Bostezo, sacrificar a Politoed, entrar con Poliwrath +6🔔",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Frente a Lucario, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/anis/liepard.json
+++ b/src/data/teselia/anis/liepard.json
@@ -2,18 +2,33 @@
   "id": "liepard",
   "name": "Liepard",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TRAMPA ROCAS🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Eelektross ➜ Gengar usa Otra Vez, cambiar a Slowbro y usar Bostezo",
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Gengar ➜ Usar Protección, cambiar a Poliwrath frente a Chandelure, Volcarona +2 🔔(Psiquico a Gengar)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Chandelure ➜ Usar Protección y Bostezo frente a Gengar, Teletransporte, Volcarona +2 🔔(Psiquico a Gengar y puedes usar Lanzallamas contra Chandelure)🔔",
-          "variant": []
+          "detail": "Luego cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Gengar, usa Protección y cambia a Poliwrath 🐸🥊 frente a Chandelure.",
+              "variant": [
+                {
+                  "detail": "Después entra con Volcarona y usa Danza Aleteo x2. Usa Psíquico contra Gengar.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Chandelure, usa Protección y Bostezo frente a Gengar.",
+              "variant": [
+                {
+                  "detail": "Luego usa Teletransporte, entra con Volcarona y usa Danza Aleteo x2. Usa Psíquico contra Gengar y puedes usar Lanzallamas contra Chandelure.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/teselia/anis/lucario.json
+++ b/src/data/teselia/anis/lucario.json
@@ -2,35 +2,65 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "A bocajarro --> revisar el estado de salud de Chansey",
+      "detail": "Si usa A Bocajarro, revisa la salud de Chansey.",
       "variant": [
         {
-          "detail": "🔴PS bajos🔴 --> Usar Teletransporte para sacrificar; Slowbro usa Bostezo; sacrificar a Politoed, entrar con Poliwrath +6",
-          "variant": []
+          "detail": "Si Chansey queda con PS bajos, usa Teletransporte para dar entrada segura a Slowbro.",
+          "variant": [
+            {
+              "detail": "Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "☠️Debilitado☠️ --> Slowbro usa Bostezo; sacrificar a Politoed, entrar con Poliwrath +6",
+          "detail": "Si Chansey queda debilitada, entra con Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Dragonite, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Dragonite --> cambiar a Slowbro y usar Bostezo; sacrificar a Politoed, entrar con Poliwrath +6 🔔(Puño Hielo a Froslass y Cascada a Dragonite)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Eelektross --> Gengar usa Otra Vez, cambiar a Slowbro frente a Dragonite; usar Bostezo, sacrificar a Politoed, entrar con Poliwrath +6 🔔(Puño Hielo a Froslass y Cascada a Dragonite)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Hydreigon --> Gengar Otra Vez 6+2 🔔(Onda Certera a Purugly)🔔",
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Ida y Vuelta activa Cuerpo Maldito --> Gengar usa Otra Vez, cambiar a Poliwrath para matarlo",
-          "variant": []
+          "detail": "Luego cambia a Slowbro frente a Dragonite y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Hielo contra Froslass y Cascada contra Dragonite.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Hydreigon, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad. Usa Onda Certera contra Purugly.",
+          "variant": [
+            {
+              "detail": "Si Ida y Vuelta activa Cuerpo Maldito, Gengar usa Otra Vez y cambia a Poliwrath 🐸🥊 para eliminarlo.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/teselia/anis/luxray.json
+++ b/src/data/teselia/anis/luxray.json
@@ -2,6 +2,25 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Cambia a Gengar Otra Vez +2 luego Derrota a luxray, si entra Hydreigon, entra Chansey y usa Trampa Rocas frente a Absol, Gengar Otra Vez 4+2👻",
-  "tricks": []
+  "initialMove": "Cambia a Gengar.",
+  "tricks": [
+    {
+      "detail": "Gengar usa Otra Vez y Maquinación hasta +2.",
+      "variant": [
+        {
+          "detail": "Luego derrota a Luxray.",
+          "variant": []
+        },
+        {
+          "detail": "Si entra Hydreigon, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 frente a Absol.",
+          "variant": [
+            {
+              "detail": "Después entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/anis/milotic.json
+++ b/src/data/teselia/anis/milotic.json
@@ -2,14 +2,23 @@
   "id": "milotic",
   "name": "Milotic",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Hydreigon ➜ Gengar, Otra Vez 6+2 🔔(Onda Certera a Purugly)🔔",
+      "detail": "Si sale Hydreigon, entra con Gengar.",
       "variant": [
         {
-          "detail": "Ida y Vuelta se anula por cuepor maldito → Gengar Otra Vez, Poliwrath Puño Drenaje",
-          "variant": []
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Usa Onda Certera contra Purugly.",
+              "variant": []
+            },
+            {
+              "detail": "Si Ida y Vuelta se anula por Cuerpo Maldito, Gengar usa Otra Vez y entra con Poliwrath 🐸🥊 para usar Puño Drenaje.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/teselia/anis/mismagius.json
+++ b/src/data/teselia/anis/mismagius.json
@@ -2,6 +2,21 @@
   "id": "mismagius",
   "name": "Mismagius",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨 frente a Toxicroak; cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed , entrar con Poliwrath +6",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Toxicroak, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo frente a Chandelure.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/anis/purugly.json
+++ b/src/data/teselia/anis/purugly.json
@@ -2,14 +2,23 @@
   "id": "purugly",
   "name": "Purugly",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Hydreigon --> Gengar Otra Vez 6+2 🔔(Onda Certera a Purugly)🔔",
+      "detail": "Si sale Hydreigon, entra con Gengar.",
       "variant": [
         {
-          "detail": "Ida y Vuelta activa Cuerpo Maldito --> Gengar usa Otra Vez, cambiar a Poliwrath para matar a purugly 🐈",
-          "variant": []
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +6 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Usa Onda Certera contra Purugly.",
+              "variant": []
+            },
+            {
+              "detail": "Si Ida y Vuelta activa Cuerpo Maldito, Gengar usa Otra Vez y cambia a Poliwrath 🐸🥊 para eliminar a Purugly.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/teselia/anis/rotom_agua.json
+++ b/src/data/teselia/anis/rotom_agua.json
@@ -2,22 +2,47 @@
   "id": "rotom_agua",
   "name": "Rotom Agua",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Lucario ➜ Gengar usa Otra Vez, Slowbro usa Bostezo, sacrificar a Politoed , entrar con Poliwrath +6 🐸🥊",
-      "variant": []
-    },
-    {
-      "detail": "Eelektross ➜ Gengar usa Otra Vez, cambiar a Slowbro y usar Bostezo",
+      "detail": "Si sale Lucario, Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Gengar ➜ Usar Protección, cambiar a Poliwrath frente a Chandelure, Volcarona +2 🔔(Psíquico a Gengar)🔔",
-          "variant": []
-        },
+          "detail": "Luego Slowbro usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Eelektross, Gengar usa Otra Vez.",
+      "variant": [
         {
-          "detail": "Chandelure ➜ Usar Protección y Bostezo frente a Gengar, Teletransporte, saca a Volcarona +2 🔔(Psíquico a Gengar y Lanzallamas a Chandelure)🔔",
-          "variant": []
+          "detail": "Luego cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Gengar, usa Protección y cambia a Poliwrath 🐸🥊 frente a Chandelure.",
+              "variant": [
+                {
+                  "detail": "Después entra con Volcarona y usa Danza Aleteo x2. Usa Psíquico contra Gengar.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Chandelure, usa Protección y Bostezo frente a Gengar.",
+              "variant": [
+                {
+                  "detail": "Luego usa Teletransporte y entra con Volcarona. Volcarona usa Danza Aleteo x2, Psíquico contra Gengar y Lanzallamas contra Chandelure.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/teselia/anis/toxicroak.json
+++ b/src/data/teselia/anis/toxicroak.json
@@ -2,11 +2,25 @@
   "id": "toxicroak",
   "name": "Toxicroak",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro luego cambiar a Chansey y frente a Chandelure 🪨TrampaRocas🪨",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Si Entra Toxicroak ➜ cambia a Slowbro y usa Bostezo ➜ frente a Chandelure, sacrifica a Politoed ➜ Poliwrath +6 🚨(No usar Cascada contra Toxicroak)🚨",
+      "detail": "Luego cambia a Chansey y usa 🪨 Trampa Rocas 🪨 frente a Chandelure.",
       "variant": []
+    },
+    {
+      "detail": "Si entra Toxicroak, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Chandelure, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "No uses Cascada contra Toxicroak.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/anis/umbreon.json
+++ b/src/data/teselia/anis/umbreon.json
@@ -2,15 +2,35 @@
   "id": "umbreon",
   "name": "Umbreon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Lucario --> Cambiar a Gengar y usar Otra Vez, cambiar a Slowbro y usar Bostezo, sacrificar a Politoed, entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Lucario, cambia a Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Toxicroak --> Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Toxicroak, cambia a Slowbro.",
+      "variant": [
+        {
+          "detail": "Usa Bostezo frente a Chandelure.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Cleans all Teselia Anis Spanish strategy JSON files.
- Keeps `initialMove` limited to the opening switch/action only.
- Moves follow-up routes into `tricks.detail` and nested `variant` entries.
- Replaces old Politoed sacrifice wording with pivot wording.
- Expands shorthand setup text for Poliwrath, Gengar, and Volcarona.
- Keeps `Especial X` wording for translation compatibility.

## Scope
- Teselia Anis strategy JSON files only.
- No English translation changes.
- No asset changes.
- No frontend layout changes.

## Files
- 22 files under `src/data/teselia/anis`.