### PR TITLE
Clean Teselia Aza Spanish strategy structure

### DIFF
--- a/src/data/teselia/aza/absol.json
+++ b/src/data/teselia/aza/absol.json
@@ -2,6 +2,16 @@
   "id": "absol",
   "name": "Absol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Gengar +2 + Precisión X + Otra Vez👻 🔔(Absol tiene Banda Focus)🔔",
-  "tricks": []
+  "initialMove": "Cambia a Gengar.",
+  "tricks": [
+    {
+      "detail": "Gengar usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Luego Gengar usa Maquinación hasta +2 y Precisión X. Absol tiene Banda Focus.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/aza/bisharp.json
+++ b/src/data/teselia/aza/bisharp.json
@@ -2,73 +2,124 @@
   "id": "bisharp",
   "name": "Bisharp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔(Revisar si tiene Globo Helio)🔔",
+  "initialMove": "Revisa si tiene Globo Helio.",
   "tricks": [
     {
-      "detail": "Si tiene Globo Helio --> Amortiguador frente a Samurott, 💊Gengar 2+2 + Precisión X💊",
+      "detail": "Si tiene Globo Helio, usa Amortiguador frente a Samurott.",
       "variant": [
         {
-          "detail": "⚠️Testeo⚠️ --> Encanto contra samurot, usar Amortiguador frente a Tyranitar, sacrificar a Politoed, entrar con Poliwrath +6",
-          "variant": []
-        }  
-      ]  
-    },
-    {
-      "detail": "No tiene Globo Helio --> 🪨Trampa Rocas🪨",
-      "variant": [
-        {
-          "detail": "Si se Queda --> Teletransporte entra Slowbro y usa Bostezo, sacrificar a Politoed, entra Poliwrath +6 🔔(Usar Proteccion y Bostezo contra Serperior)🔔",
+          "detail": "Luego entra con Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
           "variant": []
         },
         {
-          "detail": "Scrafty --> Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Honchkrow --> Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Absol --> 💊Gengar +2 + Precisión X + Otra Vez💊 🔔(Absol tiene Banda Focus)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Garchomp --> Teletransporte para Ver Movimiento",
+          "detail": "Ruta alternativa: usa Encanto contra Samurott y Amortiguador frente a Tyranitar.",
           "variant": [
             {
-              "detail": "Terremoto --> Sacar a Slowbro y usar Bostezo para ver si es Golpe Crítico ",
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si no tiene Globo Helio, usa 🪨 Trampa Rocas 🪨.",
+      "variant": [
+        {
+          "detail": "Si Bisharp se queda, usa Teletransporte, entra con Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Protección y Bostezo contra Serperior.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Scrafty, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Honchkrow, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Absol, entra con Gengar.",
+          "variant": [
+            {
+              "detail": "Gengar usa Otra Vez, Maquinación hasta +2 y Precisión X. Absol tiene Banda Focus.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Garchomp, usa Teletransporte para revisar movimiento.",
+          "variant": [
+            {
+              "detail": "Si usa Terremoto, saca a Slowbro y usa Bostezo para revisar si fue crítico.",
               "variant": [
                 {
-                  "detail": "Sin Critico --> (mantener) Bostezo frente a Chandelure, sacrificar a Politoed, entrar con Poliwrath +6",
+                  "detail": "Sin crítico, mantén Bostezo frente a Chandelure. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
                   "variant": []
                 },
                 {
-                  "detail": "Con Critico --> Sacrificar a Politoed, entrar con Poliwrath +6",
+                  "detail": "Con crítico, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
                   "variant": []
-                } 
-              ]  
+                }
+              ]
             },
-            {  
-              "detail": "🔥Colmillo Ígneo🔥 --> sacar a Slowbro y (mantener) Bostezo frente a Chandelure, sacrificar a Politoed, entrar con Poliwrath +6",
+            {
+              "detail": "Si usa Colmillo Ígneo, saca a Slowbro y mantén Bostezo frente a Chandelure.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Staraptor, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
-            }  
-          ]    
-        },
-        { 
-          "detail": "Staraptor --> Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6",
-          "variant": []
+            }
+          ]
         },
         {
-          "detail": "Samurott --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed, entrar con Poliwrath +6",
-          "variant": []
+          "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Haxorus --> Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6 🔔(Si Haxorus se queda, continuar usando Bostezo)🔔",
-          "variant": []
-        }  
-      ]  
+          "detail": "Si sale Haxorus, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+          "variant": [
+            {
+              "detail": "Si Haxorus se queda, continúa usando Bostezo.",
+              "variant": []
+            },
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
-  ]  
-}  
-    
-
+  ]
+}

--- a/src/data/teselia/aza/chandelure.json
+++ b/src/data/teselia/aza/chandelure.json
@@ -2,49 +2,89 @@
   "id": "chandelure",
   "name": "Chandelure",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Honchkrow --> Gengar usa Otra Vez, entra Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed, entra Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Haxorus --> Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty --> Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Garchomp --> Teletransporte para Ver Movimiento",
+      "detail": "Si sale Honchkrow, Gengar usa Otra Vez.",
       "variant": [
         {
-          "detail": "Terremoto --> sacar a Slowbro y usar Bostezo para ver si es Golpe Crítico",
+          "detail": "Luego entra Slowbro y usa Bostezo frente a Chandelure.",
           "variant": [
             {
-              "detail": "Sin Critico --> Seguir con Bostezo frente a Chandelure, sacrificar a Politoed, entrar con Poliwrath +6",
-              "variant": []
-            },
-            {
-              "detail": "Con Critico --> Sacrificar a Politoed, entrar con Poliwrath +6",
+              "detail": "Entra Politoed como pivote y luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Haxorus, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
         {
-          "detail": "Colmillo Ígneo --> Seguir con Bostezo frente a Chandelure, sacrificar a Politoed, entrar con Poliwrath +6",
+          "detail": "Entra Politoed como pivote y luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Staraptor --> Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Scrafty, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Entra Politoed como pivote y luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Samurott --> 💊Gengar 2+2 + Precisión X💊",
-      "variant": []
+      "detail": "Si sale Garchomp, usa Teletransporte para revisar movimiento.",
+      "variant": [
+        {
+          "detail": "Si usa Terremoto, saca a Slowbro y usa Bostezo para revisar si fue crítico.",
+          "variant": [
+            {
+              "detail": "Sin crítico, sigue con Bostezo frente a Chandelure.",
+              "variant": [
+                {
+                  "detail": "Entra Politoed como pivote y luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Con crítico, entra Politoed como pivote y luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Colmillo Ígneo, sigue con Bostezo frente a Chandelure.",
+          "variant": [
+            {
+              "detail": "Entra Politoed como pivote y luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Staraptor, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Entra Politoed como pivote y luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Samurott, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/aza/crobat.json
+++ b/src/data/teselia/aza/crobat.json
@@ -2,6 +2,16 @@
   "id": "crobat",
   "name": "Crobat",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Gengar luego cambiar a Slowbro; Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6",
-  "tricks": []
+  "initialMove": "Cambia a Gengar.",
+  "tricks": [
+    {
+      "detail": "Después cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Entra Politoed como pivote y luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/aza/espeon.json
+++ b/src/data/teselia/aza/espeon.json
@@ -2,28 +2,52 @@
   "id": "espeon",
   "name": "Espeon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚 🔔(Si se queda sigue usando Amortiguador)🔔",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Garchomp --> Poner Trampas y resistir el golpe, usar Teletransporte cambia a Slowbro y usar Bostezo 🔔(Ver si el Terremoto de Garchomp es golpe crítico)🔔",
+      "detail": "Si Espeon se queda, sigue usando Amortiguador.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Garchomp, usa 🪨 Trampa Rocas 🪨 y resiste el golpe.",
       "variant": [
         {
-          "detail": "No hay Golpe Critico --> (Mantener) Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6",
-          "variant": []
-        },
+          "detail": "Usa Teletransporte, cambia a Slowbro y usa Bostezo. Revisa si Terremoto fue crítico.",
+          "variant": [
+            {
+              "detail": "Si no fue crítico, mantén Bostezo frente a Chandelure.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si fue crítico, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Haxorus, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
         {
-          "detail": "Si hay Golpe Crítico --> sacrificar a Politoed, entrar con Poliwrath +6",
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Haxorus --> Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Scrafty --> Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed, entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Scrafty, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/aza/garchomp.json
+++ b/src/data/teselia/aza/garchomp.json
@@ -2,28 +2,48 @@
   "id": "garchomp",
   "name": "Garchomp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Terremoto --> Usa Teletransporte y sacar a Slowbro luego usar Bostezo 🔔(Ver si el Golpe es Critico)🔔",
+      "detail": "Si usa Terremoto, usa Teletransporte y saca a Slowbro.",
       "variant": [
         {
-          "detail": "Sin Critico --> Seguir con Bostezo frente a Chandelure, sacrificar a Politoed, entrar con Poliwrath +6",
-          "variant": []
-        },
+          "detail": "Slowbro usa Bostezo y revisa si fue crítico.",
+          "variant": [
+            {
+              "detail": "Sin crítico, sigue con Bostezo frente a Chandelure.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Con crítico, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si usa Colmillo Ígneo, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
         {
-          "detail": "Con Critico --> Sacrificar a Politoed, entrar con Poliwrath +6",
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Colmillo Ígneo ➜ Cambiar a Slowbro, usar Bostezo frente a Chandelure; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Samurott ➜ Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Samurott, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/aza/gyarados.json
+++ b/src/data/teselia/aza/gyarados.json
@@ -2,15 +2,30 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Garchomp, usar Teletransporte para sacar a Slowbro y usar Bostezo 🔔(Ver si el Terremoto es Golpe Crítico)🔔",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si no hay golpe crítico --> Usar Bostezo frente a Chandelure, sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Si hay crítico  --> Sacrificar a Politoed entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Frente a Garchomp, usa Teletransporte para sacar a Slowbro y usar Bostezo.",
+      "variant": [
+        {
+          "detail": "Revisa si Terremoto fue crítico.",
+          "variant": [
+            {
+              "detail": "Si no fue crítico, usa Bostezo frente a Chandelure.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si fue crítico, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/aza/haxorus.json
+++ b/src/data/teselia/aza/haxorus.json
@@ -2,6 +2,16 @@
   "id": "haxorus",
   "name": "Haxorus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro  y usar Bostezo  frente a Chandelure; sacrificar a Politoed y entrar con Poliwrath 🐸 +6",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/aza/honchkrow.json
+++ b/src/data/teselia/aza/honchkrow.json
@@ -2,6 +2,21 @@
   "id": "honchkrow",
   "name": "Honchkrow",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": " 💡Gengar usa Otra Vez  cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed , entrar con Poliwrath +6💡 ",
-  "tricks": []
+  "initialMove": "Cambia a Gengar.",
+  "tricks": [
+    {
+      "detail": "Gengar usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro y usa Bostezo frente a Chandelure.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/aza/houndoom.json
+++ b/src/data/teselia/aza/houndoom.json
@@ -2,6 +2,16 @@
   "id": "houndoom",
   "name": "Houndoom",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro frente a Samurott, usar Bostezo sacrificar a Politoed y entrar con Poliwrath 🐸 +6",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Frente a Samurott, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/aza/kingdra.json
+++ b/src/data/teselia/aza/kingdra.json
@@ -2,6 +2,16 @@
   "id": "kingdra",
   "name": "Kingdra",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro frente a Honchkrow , usar Bostezo ante Chandelure ; sacrificar a Politoed y entrar con Poliwrath +6",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Frente a Honchkrow, usa Bostezo ante Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/aza/krookodile.json
+++ b/src/data/teselia/aza/krookodile.json
@@ -2,6 +2,16 @@
   "id": "krookodile",
   "name": "Krookodile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro frente a Honchkrow, usar Bostezo ante la salida de Chandelure sacrificar a Politoed y entrar con Poliwrath +6",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Frente a Honchkrow, usa Bostezo ante la salida de Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/aza/liepard.json
+++ b/src/data/teselia/aza/liepard.json
@@ -2,15 +2,30 @@
   "id": "liepard",
   "name": "Liepard",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨TrampaRocas🪨 frente a Garchomp, usar Teletransporte para sacar a Slowbro y usar Bostezo",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Sin crítico --> Usar Bostezo continuamente hasta que salga Chandelure; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Si hay crítico --> sacrificar a Politoed , entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Frente a Garchomp, usa Teletransporte para sacar a Slowbro y usar Bostezo.",
+      "variant": [
+        {
+          "detail": "Revisa si el golpe fue crítico.",
+          "variant": [
+            {
+              "detail": "Sin crítico, usa Bostezo continuamente hasta que salga Chandelure.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si fue crítico, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/aza/luxray.json
+++ b/src/data/teselia/aza/luxray.json
@@ -2,6 +2,16 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Usa Amortiguador hasta tener en frete a Absol y cambia a Gengar, Otra Vez, +2 + Precision X  🔔absol tiene banda focus🔔",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Repite Amortiguador hasta que aparezca Absol.",
+      "variant": [
+        {
+          "detail": "Cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Absol tiene Banda Focus.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/aza/mismagius.json
+++ b/src/data/teselia/aza/mismagius.json
@@ -2,28 +2,16 @@
   "id": "mismagius",
   "name": "Mismagius",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Onda Certera de (Zoroark) ➜ Gengar usa Otra Vez cambiar a Slowbro y usar Bostezo frente a Mismagius, Volcarona +2",
-      "variant": []
-    },
-    {
-      "detail": "Samurott ➜ Cambiar a Slowbro luego cambiar a Chansey",
+      "detail": "Si usa Onda Certera, es Zoroark. Cambia a Gengar y usa Otra Vez.",
       "variant": [
         {
-          "detail": "Poder Oculto Eléctrico ➜ Cambiar a Slowbro y usar Bostezo, sacrifica a Politoed, Poliwrath +6 🐸🥊",
-          "variant": []
-        },
-        {
-          "detail": "Serperior ➜ Usar Amortiguador",
+          "detail": "Luego cambia a Slowbro y usa Bostezo frente a Mismagius.",
           "variant": [
             {
-              "detail": "Samurott ➜ 💊Gengar 2+2 + Precision X💊",
-              "variant": []
-            },
-            {  
-              "detail": "Tyranitar ➜ Sacrifica a Politoed, Poliwrath +6 🐸🥊",
+              "detail": "Después entra con Volcarona y usa Danza Aleteo x2.",
               "variant": []
             }
           ]
@@ -31,8 +19,40 @@
       ]
     },
     {
-      "detail": "Absol ➜ Gengar Otra vez +2 + Precision X 🔔(Absol tiene Banda Focus)🔔",
-      "variant": []
+      "detail": "Si sale Samurott, cambia a Slowbro y luego a Chansey.",
+      "variant": [
+        {
+          "detail": "Si usa Poder Oculto Eléctrico, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Serperior, usa Amortiguador.",
+          "variant": [
+            {
+              "detail": "Si vuelve Samurott, entra con Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Tyranitar, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Absol, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Otra Vez, Maquinación hasta +2 y Precisión X. Absol tiene Banda Focus.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/aza/roserade.json
+++ b/src/data/teselia/aza/roserade.json
@@ -2,6 +2,16 @@
   "id": "roserade",
   "name": "Roserade",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro frente a Samurott, usar Bostezo  sacrificar a Politoed y entrar con Poliwrath +6",
-  "tricks": []
-} 
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Frente a Samurott, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/teselia/aza/salamence.json
+++ b/src/data/teselia/aza/salamence.json
@@ -2,21 +2,26 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "❤️Encanto❤️ ",
+  "initialMove": "Usa Encanto.",
   "tricks": [
     {
-      "detail": "Garra Dragón --> Usar Amortiguador frente a Absol cambiar a Gengar +2 +1 precision seguido de Otra Vez (absol banda focus)",
-      "variant": []
-    },
-    {
-      "detail": "Absol --> Poner 🪨TrampaRocas recomendar usar Amortiguador🪨",
+      "detail": "Si usa Garra Dragón, usa Amortiguador frente a Absol.",
       "variant": [
         {
-          "detail": "Luxray --> Gengar Gengar +2 +1 precision 🔔No usar Otra Vez🔔",
+          "detail": "Luego cambia a Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Absol tiene Banda Focus.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Absol, usa 🪨 Trampa Rocas 🪨 y recomienda usar Amortiguador.",
+      "variant": [
+        {
+          "detail": "Si sale Luxray, entra con Gengar, usa Maquinación hasta +2 y Precisión X. No uses Otra Vez.",
           "variant": []
         },
         {
-          "detail": "Samurott --> Gengar +2 +1 precision",
+          "detail": "Si sale Samurott, entra con Gengar, usa Maquinación hasta +2 y Precisión X.",
           "variant": []
         }
       ]

--- a/src/data/teselia/aza/samurott.json
+++ b/src/data/teselia/aza/samurott.json
@@ -2,32 +2,52 @@
   "id": "samurott",
   "name": "Samurott",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro y usar Bostezo🥱",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Megacuerno --> Cambiar a chansey y usar Amortiguador frente a Absol; entrar con Gengar +2 + Precision X + Otra Vez 🔔(Absol Banda Focus)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Poder Oculto Eléctrico --> Sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Serperior Cambiar a Chansey y usar Amortiguador",
+      "detail": "Usa Bostezo.",
       "variant": [
         {
-          "detail": "Samurot --> 💊Gengar 2+2 + Precision X💊",
-          "variant": []
+          "detail": "Si usa Megacuerno, cambia a Chansey y usa Amortiguador frente a Absol.",
+          "variant": [
+            {
+              "detail": "Luego entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Absol tiene Banda Focus.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Tyranitar --> Sacrificar a Politoed y entrar con Poliwrath +6",
-          "variant": []
+          "detail": "Si usa Poder Oculto Eléctrico, entra Politoed como pivote.",
+          "variant": [
+            {
+              "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Serperior, cambia a Chansey y usa Amortiguador.",
+          "variant": [
+            {
+              "detail": "Si vuelve Samurott, entra con Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Tyranitar, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Mismagius, cambia a Chansey y usa Amortiguador frente a Absol.",
+          "variant": [
+            {
+              "detail": "Luego entra con Gengar, usa Otra Vez, Maquinación hasta +2 y Precisión X. Absol tiene Banda Focus.",
+              "variant": []
+            }
+          ]
         }
       ]
-    },
-    {
-      "detail": "Mismagius --> Cambiar a Chansey y usar Amortiguador frente a Absol; entrar con Gengar +2 + Precision X + Otra Vez 🔔(Absol Banda Focus)🔔",
-      "variant": []
     }
   ]
 }

--- a/src/data/teselia/aza/scrafty.json
+++ b/src/data/teselia/aza/scrafty.json
@@ -2,6 +2,16 @@
   "id": "scrafty",
   "name": "Scrafty",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed y entrar con Poliwrath +6💡",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/aza/serperior.json
+++ b/src/data/teselia/aza/serperior.json
@@ -2,6 +2,16 @@
   "id": "serperior",
   "name": "Serperior",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Usar Amortiguador frente a Samurott; entrar con Gengar +2 + 2 x1 precisión💡",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Frente a Samurott, mantén la línea con Amortiguador.",
+      "variant": [
+        {
+          "detail": "Luego entra con Gengar, usa Maquinación hasta +2, Velocidad X para +2 Velocidad y Precisión X.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/aza/sharpedo.json
+++ b/src/data/teselia/aza/sharpedo.json
@@ -2,6 +2,16 @@
   "id": "sharpedo",
   "name": "Sharpedo",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚 cambiar a Slowbro , usar Bostezo frente a Chandelure sacrificar a Politoed y entrar con Poliwrath +6",
-  "tricks": []
-} 
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Luego cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/teselia/aza/spiritomb.json
+++ b/src/data/teselia/aza/spiritomb.json
@@ -2,15 +2,30 @@
   "id": "spiritomb",
   "name": "Spiritomb",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🥚Amortiguador🥚",
+  "initialMove": "Usa Amortiguador.",
   "tricks": [
     {
-      "detail": "Staraptor / Garchomp ➜ Cambiar a Slowbro y usa bostezo ➜ frente a Chandelure ➜ sacrifica a Politoed ➜ entra con Poliwrath +6🐸🥊 🔔(Puño Drenaje a Sharpedo)🔔",
-      "variant": []
+      "detail": "Si sale Staraptor o Garchomp, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Sharpedo.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Honchkrow ➜ Cambiar a Slowbro y usa Bostezo ➜ frente a Chandelure ➜ sacrifica a Politoed ➜ entra con Poliwrath +6🐸🥊",
-      "variant": []
+      "detail": "Si sale Honchkrow, cambia a Slowbro y usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/aza/staraptor.json
+++ b/src/data/teselia/aza/staraptor.json
@@ -2,6 +2,16 @@
   "id": "staraptor",
   "name": "Staraptor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "❗Cambiar a Slowbro y usar Bostezo frente a Chandelure; sacrificar a Politoed y entrar con Poliwrath +6❗",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo frente a Chandelure.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/aza/tyranitar.json
+++ b/src/data/teselia/aza/tyranitar.json
@@ -2,6 +2,11 @@
   "id": "tyranitar",
   "name": "Tyranitar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Sacrificar a Politoed y entrar con Poliwrath +6💡",
-  "tricks": []
+  "initialMove": "Entra Politoed como pivote.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+      "variant": []
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Cleans all Teselia Aza Spanish strategy JSON files.
- Keeps `initialMove` limited to the opening switch/action only.
- Moves follow-up routes into `tricks.detail` and nested `variant` entries.
- Keeps the scope limited to `src/data/teselia/aza`.

## Scope
- Teselia Aza strategy JSON files only.
- No English, asset, or frontend changes.

## Files
- 24 files under `src/data/teselia/aza`.