### PR TITLE
Clean Teselia Lotto Spanish strategy structure

### DIFF
--- a/src/data/teselia/lotto/aggron.json
+++ b/src/data/teselia/lotto/aggron.json
@@ -2,26 +2,55 @@
   "id": "aggron",
   "name": "Aggron",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambia a Poliwrath y usa Puño Drenaje💡",
+  "initialMove": "Cambia a Poliwrath.",
   "tricks": [
     {
-      "detail": "Seismitoad / Skarmory --> Cambiar a Chansey y usar 🪨Trampa Rocas🪨 frente a Conkeldurr; Gengar usa Otra Vez, cambiar a Volcarona ante Seismitoad; 💊Volcarona +1 + Especial X💊",
-      "variant": []
-    },
-    {
-      "detail": "Conkeldurr --> Gengar usa Otra Vez, cambiar a Chansey y usar 🪨Trampa Rocas🪨 (⬆️Ver Solucion Arriba⬆️)",
-      "variant": []
-    },
-    {
-      "detail": "Dusknoir --> Cambiar a Volcarona, luego a Chansey y usar 🪨Trampa Rocas🪨 🔔(Si la rana no tiene PS, curalo al máximo)🔔",
+      "detail": "Usa Puño Drenaje.",
       "variant": [
         {
-          "detail": "Si se queda --> Sacrificar a Politoed y entrar con Poliwrath +6",
-          "variant": []
+          "detail": "Si sale Seismitoad o Skarmory, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 frente a Conkeldurr.",
+          "variant": [
+            {
+              "detail": "Gengar usa Otra Vez y luego cambia a Volcarona ante Seismitoad.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Conkeldurr --> Gengar usa Otra Vez, cambiar a Volcarona ante Seismitoad; 💊Volcarona +1 + Especial X💊",
-          "variant": []
+          "detail": "Si sale Conkeldurr, Gengar usa Otra Vez.",
+          "variant": [
+            {
+              "detail": "Luego cambia a Chansey y usa 🪨 Trampa Rocas 🪨. Sigue la ruta de Seismitoad si aparece.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Dusknoir, cambia a Volcarona, luego a Chansey y usa 🪨 Trampa Rocas 🪨.",
+          "variant": [
+            {
+              "detail": "Si Poliwrath tiene poco PS, cúralo al máximo.",
+              "variant": []
+            },
+            {
+              "detail": "Si Dusknoir se queda, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Conkeldurr, Gengar usa Otra Vez y luego cambia a Volcarona ante Seismitoad.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/teselia/lotto/breloom.json
+++ b/src/data/teselia/lotto/breloom.json
@@ -2,19 +2,44 @@
   "id": "breloom",
   "name": "Breloom",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar Otra Vez +2 y Debilitar💡",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Magnezone --> Cambiar a Chansey y usar 🪨Trampa Rocas🪨 frente a Conkeldurr; cambiar a Slowbro y usar Bostezo frente a Magnezone; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Conkeldurr --> Cambiar a Slowbro, luego a Chansey y usar 🪨Trampa Rocas🪨 frente a Conkeldurr; Slowbro usa Bostezo frente a Magnezone; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Gengar +2 y entra Conkeldurr --> Cambiar a Slowbro y usar Bostezo frente a Magnezone, luego usa Proteccion y Bostezo frente a Breloom, despues sacrifica a politoed y entra con Poliwrath +6",
-      "variant": []
+      "detail": "Gengar usa Otra Vez y Maquinación hasta +2.",
+      "variant": [
+        {
+          "detail": "Debilita a Breloom.",
+          "variant": [
+            {
+              "detail": "Si sale Magnezone, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 frente a Conkeldurr.",
+              "variant": [
+                {
+                  "detail": "Luego cambia a Slowbro y usa Bostezo frente a Magnezone. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Conkeldurr, cambia a Slowbro, luego a Chansey y usa 🪨 Trampa Rocas 🪨 frente a Conkeldurr.",
+              "variant": [
+                {
+                  "detail": "Slowbro usa Bostezo frente a Magnezone. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si después de Gengar +2 entra Conkeldurr, cambia a Slowbro y usa Bostezo frente a Magnezone.",
+              "variant": [
+                {
+                  "detail": "Luego usa Protección y Bostezo frente a Breloom. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/lotto/carracosta.json
+++ b/src/data/teselia/lotto/carracosta.json
@@ -2,15 +2,30 @@
   "id": "carracosta",
   "name": "Carracosta",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Conkeldurr ➜ Gengar Otra Vez +4",
-      "variant": []
+      "detail": "Si sale Conkeldurr, entra con Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4.",
+          "variant": []
+        }
+      ]
     },
     {
-      "detail": "Haxorus ➜ Gengar Otra Vez +4 🔔(Si huye a Conkeldurr, cambiar a Chansey y luego a Gengar Otra vez +4)🔔",
-      "variant": []
+      "detail": "Si sale Haxorus, entra con Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4.",
+          "variant": [
+            {
+              "detail": "Si cambia a Conkeldurr, cambia a Chansey y luego vuelve a Gengar para usar Otra Vez y Maquinación hasta +4.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/lotto/conkeldurr.json
+++ b/src/data/teselia/lotto/conkeldurr.json
@@ -2,114 +2,182 @@
   "id": "conkeldurr",
   "name": "Conkeldurr",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Cambia a Gengar y usa Otra Vez👻",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "A bocajarro + Llamasfera ➜ Gengar +4 y Bola Sombra 🔔(Ver quien entra)🔔",
+      "detail": "Gengar usa Otra Vez y revisa movimiento/objeto.",
       "variant": [
         {
-          "detail": "Skarmory ➜ Cambiar a Chansey y usar 🪨Trampa Rocas🪨 al enfrentar a Haxorus; Gengar +4 🔔(Bola Sombra a todo)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Sawk ➜ Cambiar a Chansey y usar 🪨Trampa Rocas🪨 al enfrentar a Krookodile; Gengar 4+2 🔔(Bola Sombra a todo)🔔",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "A bocajarro + Vidasfera --> Gengar +4 🔔(Bola Sombra a todo)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Puño Drenaje + Llamasfera ➜ Cambiar a Chansey Frente a Seismitoad luego usar Encanto",
-      "variant": [
-        {
-          "detail": "Conkeldurr ➜ Usar Encanto otra vez hasta que salga Aggron luego poner 🪨Trampa Rocas🪨",
+          "detail": "Si usa A Bocajarro y tiene Llamasfera, Gengar usa Maquinación hasta +4.",
           "variant": [
             {
-              "detail": "Conkeldurr ➜ Gengar usa otra vez y cambia a Volcarona frente a Seismitoad, 💊Volcarona +1 + Especial X💊",
-              "variant": []
-            },
-            {
-              "detail": "Dusknoir ➜ Sacrifica a Politoed, entrar con Poliwrath +6",
-              "variant": []
-            }  
-          ]  
-        },
-        {  
-          "detail": "Aggron ➜ Poner Trampas frente a Conkeldurr, Gengar Otra vez y cambia a Volcarona frente a Seismitoad, 💊Volcarona +1 + Especial X💊",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Puño Drenaje + Sin Llamasfera ➜ Bola Sombra 🔔(Observa si tiene Restos)🔔",
-      "variant": [
-        {
-          "detail": "Si tiene Restos ➜ Gengar Otra vez +6",
-          "variant": []
-        },
-        {
-          "detail": "Sin Restos ➜ Maquinación, Otra Vez, cambiar a Slowbro 🔔(Observar si tiene Vidasfera)🔔",
-          "variant": [
-            {
-              "detail": "Tiene Vidasfera ➜ Bostezo",
+              "detail": "Usa Bola Sombra contra todos y revisa quién entra.",
               "variant": [
                 {
-                  "detail": "Se queda/Electivire ➜ Sacrificar a Politoed, entrar con Poliwrath +6 🔔(Puño drenaje contra Electivire/Crawdaunt)🔔",
-                  "variant": []
-                },
-                {
-                  "detail": "Magnezone ➜ Protección y Bostezo, sacrifica a Politoed, entrar con Poliwrath +6",
-                  "variant": []
-                },
-                {
-                   "detail": "Crawdaunt ➜ Sacrificar a Politoed, entrar con Poliwrath +6",
-                   "variant": []
-                }  
-              ]
-            },
-            {
-              "detail": "Sin Vidasfera ➜ Bostezo",
-              "variant": [
-                {
-                  "detail": "Magnezone ➜ Cambiar a Chansey y usar Encanto frente a Breloom, 💊cambia a Gengar +4 + Precisión X💊",
+                  "detail": "Si sale Skarmory, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 al enfrentar a Haxorus.",
                   "variant": [
                     {
-                      "detail": "Si sale Conkeldurr ➜ Cambiar a Slowbro y usar Bostezo, sacrificar a Politoed, entra con Poliwrath +6",
+                      "detail": "Luego entra con Gengar, usa Maquinación hasta +4 y barre con Bola Sombra.",
                       "variant": []
-                    } 
-                  ]        
+                    }
+                  ]
                 },
                 {
-                  "detail": "Breloom ➜ Protección y Bostezo frente a Magnezone, cambiar a Chansey y usar Amortiguador esperando a Conkeldurr, 💊Gengar +4 + Precisión X💊",
-                  "variant": []
+                  "detail": "Si sale Sawk, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 al enfrentar a Krookodile.",
+                  "variant": [
+                    {
+                      "detail": "Luego entra con Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+                      "variant": []
+                    }
+                  ]
                 }
-              ] 
+              ]
             }
-          ]  
-        },      
+          ]
+        },
         {
-          "detail": "Si sale Gyarados --> Verificar Intimidación",
+          "detail": "Si usa A Bocajarro y tiene Vidaesfera, Gengar usa Maquinación hasta +4.",
           "variant": [
             {
-              "detail": "Con Intimidación ➜ Cambiar a Chansey y poner Trampas frente a Breloom, 💊Gengar +4 + Precisión X💊",
-              "variant": []
-            },
-            {
-              "detail": "Sin Intimidación ➜ Cambiar a Chansey y usar Amortiguador frente a Breloom, Slowbro usa Bostezo, sacrificar a Politoed, entrar con Poliwrath +6",
+              "detail": "Usa Bola Sombra contra todos.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Si sale Machamp ➜ Cambiar a Slowbro y usar Bostezo frente a Electivire, sacrificar a Politoed, entrar con Poliwrath +6",
-          "variant": []   
+          "detail": "Si usa Puño Drenaje y tiene Llamasfera, cambia a Chansey frente a Seismitoad y usa Encanto.",
+          "variant": [
+            {
+              "detail": "Si vuelve Conkeldurr, usa Encanto otra vez hasta que salga Aggron y luego usa 🪨 Trampa Rocas 🪨.",
+              "variant": [
+                {
+                  "detail": "Si vuelve Conkeldurr, Gengar usa Otra Vez y cambia a Volcarona frente a Seismitoad.",
+                  "variant": [
+                    {
+                      "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+                      "variant": []
+                    }
+                  ]
+                },
+                {
+                  "detail": "Si sale Dusknoir, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Aggron, usa 🪨 Trampa Rocas 🪨 frente a Conkeldurr.",
+              "variant": [
+                {
+                  "detail": "Gengar usa Otra Vez y cambia a Volcarona frente a Seismitoad.",
+                  "variant": [
+                    {
+                      "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Puño Drenaje y no tiene Llamasfera, usa Bola Sombra y revisa si tiene Restos.",
+          "variant": [
+            {
+              "detail": "Si tiene Restos, Gengar usa Otra Vez y Maquinación hasta +6.",
+              "variant": []
+            },
+            {
+              "detail": "Si no tiene Restos, Gengar usa Maquinación, Otra Vez y luego cambia a Slowbro para revisar si tiene Vidaesfera.",
+              "variant": [
+                {
+                  "detail": "Si tiene Vidaesfera, Slowbro usa Bostezo.",
+                  "variant": [
+                    {
+                      "detail": "Si Conkeldurr se queda o sale Electivire, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": [
+                        {
+                          "detail": "Usa Puño Drenaje contra Electivire o Crawdaunt.",
+                          "variant": []
+                        }
+                      ]
+                    },
+                    {
+                      "detail": "Si sale Magnezone, usa Protección y Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": []
+                    },
+                    {
+                      "detail": "Si sale Crawdaunt, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": []
+                    }
+                  ]
+                },
+                {
+                  "detail": "Si no tiene Vidaesfera, Slowbro usa Bostezo.",
+                  "variant": [
+                    {
+                      "detail": "Si sale Magnezone, cambia a Chansey y usa Encanto frente a Breloom.",
+                      "variant": [
+                        {
+                          "detail": "Luego entra con Gengar, usa Maquinación hasta +4 y Precisión X.",
+                          "variant": [
+                            {
+                              "detail": "Si sale Conkeldurr, cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                              "variant": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "detail": "Si sale Breloom, usa Protección y Bostezo frente a Magnezone.",
+                      "variant": [
+                        {
+                          "detail": "Luego cambia a Chansey y usa Amortiguador esperando a Conkeldurr. Después entra con Gengar, usa Maquinación hasta +4 y Precisión X.",
+                          "variant": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Gyarados, revisa si tiene Intimidación.",
+              "variant": [
+                {
+                  "detail": "Con Intimidación, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 frente a Breloom.",
+                  "variant": [
+                    {
+                      "detail": "Luego entra con Gengar, usa Maquinación hasta +4 y Precisión X.",
+                      "variant": []
+                    }
+                  ]
+                },
+                {
+                  "detail": "Sin Intimidación, cambia a Chansey y usa Amortiguador frente a Breloom.",
+                  "variant": [
+                    {
+                      "detail": "Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Machamp, cambia a Slowbro y usa Bostezo frente a Electivire.",
+              "variant": [
+                {
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }
   ]
 }
-
-

--- a/src/data/teselia/lotto/crawdaunt.json
+++ b/src/data/teselia/lotto/crawdaunt.json
@@ -2,45 +2,57 @@
   "id": "crawdaunt",
   "name": "Crawdaunt",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Cambia a Gengar👻",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "A bocajarro --> Gengar +4 + Otra Vez, luego usa Bola sombra 🔔(Mira tu situacion)🔔",
+      "detail": "Si usa A Bocajarro, Gengar usa Otra Vez y Maquinación hasta +4.",
       "variant": [
         {
-          "detail": "La banda focus se rompe --> 💊Toma un Velocidad X luego sigue Barriendo💊",
-          "variant": []
-        },
-        {
-          "detail": "Mienshao --> Continuar presionando; 🔔(Mienshao tiene banda Focus no te preocupes)🔔",
+          "detail": "Luego usa Bola Sombra y revisa la situación.",
           "variant": [
             {
-              "detail": "💀Crítico💀 --> Sacrificar a Politoed; Slowbro usa Bostezo ante Salamence; usar Teletransporte para entrar con Poliwrath +6",
+              "detail": "Si la Banda Focus se rompe, usa Velocidad X y sigue barriendo.",
+              "variant": []
+            },
+            {
+              "detail": "Si sale Mienshao, continúa presionando. Mienshao tiene Banda Focus.",
+              "variant": [
+                {
+                  "detail": "Si recibe crítico, entra Politoed como pivote. Luego Slowbro usa Bostezo ante Salamence y usa Teletransporte para entrar con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Gliscor o Gyarados, continúa presionando hasta Magnezone.",
+              "variant": [
+                {
+                  "detail": "Cambia a Chansey y usa Amortiguador para atraer al tipo lucha. Luego entra con Gengar y usa Maquinación hasta +6.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Medicham, Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Magnezone, usa Protección y Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Gliscor / Gyarados --> Continuar presionando hasta Magnezone; Cambia a Chansey y usa Amortiguador para atraer al tipo lucha; Gengar +6",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Medicham --> Slowbro usa Bostezo",
-      "variant": [
-        {
-          "detail": "Magnezone --> Protección y Bostezo; sacrificar a Politoed y entrar con Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Crawdaunt --> Sacrificar a Politoed y entrar con Poliwrath +6",
+          "detail": "Si sale Crawdaunt, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     }
   ]
 }
-
-    
-    

--- a/src/data/teselia/lotto/dusknoir.json
+++ b/src/data/teselia/lotto/dusknoir.json
@@ -2,37 +2,62 @@
   "id": "dusknoir",
   "name": "Dusknoir",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Demolición ➜ Sacrificar a Politoed y entrar con Poliwrath +6 🐸",
-      "variant": []
-    },
-    {
-      "detail": "Aggron ➜ Cambiar a Poliwrath, y usa Puño Drenaje 🥊",
+      "detail": "Si usa Demolición, entra Politoed como pivote.",
       "variant": [
         {
-          "detail": "Seismitoad/Skarmory --> Cambiar a Chansey y usar Amortiguador esperando a Conkeldurr, Gengar usa Otra Vez, cambiar a Volcarona frente a Seismitoad, Volcarona usa Expecial X 🔔(Si es crítico, ver nota de Seismitoad)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Conkeldurr ➜ Gengar usa Otra Vez, cambiar a Volcarona ante Seismitoad ➜ Volcarona Usa Expecial X 🔔(Si es crítico, ver nota de Seismitoad)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Dusknoir ➜ Sacrificar a Politoed y entrar con Poliwrath +6 🐸",
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
-      ]  
+      ]
     },
     {
-      "detail": "Breloom ➜ Gengar +4 + Precisión X",
+      "detail": "Si sale Aggron, cambia a Poliwrath 🐸🥊 y usa Puño Drenaje.",
       "variant": [
         {
-          "detail": "Conkeldurr ➜ Cambiar a Slowbro y usar Bostezo, sacrificar a Politoed y entrar con Poliwrath +6 🐸",
+          "detail": "Si sale Seismitoad o Skarmory, cambia a Chansey y usa Amortiguador esperando a Conkeldurr.",
+          "variant": [
+            {
+              "detail": "Gengar usa Otra Vez y cambia a Volcarona frente a Seismitoad.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Especial X. Si hay crítico, sigue la nota de Seismitoad.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Conkeldurr, Gengar usa Otra Vez y cambia a Volcarona ante Seismitoad.",
+          "variant": [
+            {
+              "detail": "Volcarona usa Especial X. Si hay crítico, sigue la nota de Seismitoad.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Dusknoir, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
-        }  
-      ]  
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Breloom, entra con Gengar y usa Maquinación hasta +4 y Precisión X.",
+      "variant": [
+        {
+          "detail": "Si sale Conkeldurr, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/lotto/electivire.json
+++ b/src/data/teselia/lotto/electivire.json
@@ -2,11 +2,21 @@
   "id": "electivire",
   "name": "Electivire",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar usa Otra Vez💡",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Cambia a Slowbro, bostezo → Politoed (sacrificar), Poliwrath +6.",
-      "variant": []
+      "detail": "Gengar usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/lotto/gliscor.json
+++ b/src/data/teselia/lotto/gliscor.json
@@ -2,6 +2,21 @@
   "id": "gliscor",
   "name": "Gliscor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Usar Amortiguador para aguantar Acróbata, cambiar a Slowbro aguanta el ataque de mienshao , usar Bostezo, sacrificar a Politoed y entrar con Poliwrath +6💡",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Aguanta Acróbata y luego cambia a Slowbro para resistir el ataque de Mienshao.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/lotto/golurk.json
+++ b/src/data/teselia/lotto/golurk.json
@@ -2,23 +2,37 @@
   "id": "golurk",
   "name": "Golurk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Puño Drenaje --> Ver si es Golpe Crítico ",
+      "detail": "Si usa Puño Drenaje, revisa si fue golpe crítico.",
       "variant": [
         {
-          "detail": "Normal --> Gengar +4",
+          "detail": "Si no fue crítico, entra con Gengar y usa Maquinación hasta +4.",
           "variant": []
         },
         {
-          "detail": "sale critico--> Teletransporte;  si usa Puño Drenaje , Gengar +4 +2 si usa Terremoto; saca a Slowbro bostezo  frente a Lucario, sacrifica a politoed y entra Poliwrath +6.",
-          "variant": []
+          "detail": "Si fue crítico, usa Teletransporte y revisa el siguiente movimiento.",
+          "variant": [
+            {
+              "detail": "Si usa Puño Drenaje, entra con Gengar y usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+              "variant": []
+            },
+            {
+              "detail": "Si usa Terremoto, saca a Slowbro y usa Bostezo frente a Lucario.",
+              "variant": [
+                {
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Conkeldurr --> Gengar +4",
+      "detail": "Si sale Conkeldurr, entra con Gengar y usa Maquinación hasta +4.",
       "variant": []
     }
   ]

--- a/src/data/teselia/lotto/gyarados.json
+++ b/src/data/teselia/lotto/gyarados.json
@@ -2,30 +2,58 @@
   "id": "gyarados",
   "name": "Gyarados",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Toxicroack --> Cambiar a Slowbro y usar Bostezo frente a Magnezone, sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Breloom ➜ Gengar +4 + Precisión X",
+      "detail": "Si sale Toxicroak, cambia a Slowbro y usa Bostezo frente a Magnezone.",
       "variant": [
         {
-          "detail": "Conkeldurr ➜ Cambiar a Slowbro y usar Bostezo, sacrificar a Politoed y entrar con Poliwrath +6 🐸 🔔(Puño Drenaje a Tyranitar)🔔",
+          "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
-        } 
-      ]  
-    },        
-    {     
-      "detail": "Conkeldurr + Sin Llamasfera --> Cambiar a Slowbro y usar Bostezo al enfrentar a Magnezone; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
+        }
+      ]
     },
     {
-      "detail": "🔥Conkeldurr + Llamasfera🔥 --> Gengar +4 +2 🔔(Barre con Bola Sombra)🔔 🚨(Si cambia a Gyarados, cambia a Chansey y aguanta hasta que cambie denuevo)🚨",
-      "variant": []
+      "detail": "Si sale Breloom, entra con Gengar y usa Maquinación hasta +4 y Precisión X.",
+      "variant": [
+        {
+          "detail": "Si sale Conkeldurr, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Drenaje contra Tyranitar.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Conkeldurr sin Llamasfera, cambia a Slowbro y usa Bostezo al enfrentar a Magnezone.",
+      "variant": [
+        {
+          "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Conkeldurr con Llamasfera, entra con Gengar.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+          "variant": [
+            {
+              "detail": "Si cambia a Gyarados, cambia a Chansey y aguanta hasta que vuelva a cambiar.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }
-  
-

--- a/src/data/teselia/lotto/haxorus.json
+++ b/src/data/teselia/lotto/haxorus.json
@@ -2,15 +2,40 @@
   "id": "haxorus",
   "name": "Haxorus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar Otra Vez +2💡",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Quedarse --> bola sombra  al enfrentar a Lucario / Skarmory; cambiar a Chansey y usar 🪨Trampa Rocas🪨 al enfrentar a Conkeldurr; Gengar +4 🔔Bola Sombra a todo🔔",
-      "variant": []
-    },
-    {
-      "detail": "Conkeldurr --> Cambiar a Chansey y luego a Gengar +2; bola sombra  al enfrentar a Skarmory; Chansey usa 🪨Trampa Rocas🪨 al enfrentar a Haxorus; Gengar +4 🔔Bola Sombra a todo🔔",
-      "variant": []
+      "detail": "Gengar usa Otra Vez y Maquinación hasta +2.",
+      "variant": [
+        {
+          "detail": "Si Haxorus se queda, usa Bola Sombra al enfrentar a Lucario o Skarmory.",
+          "variant": [
+            {
+              "detail": "Luego cambia a Chansey y usa 🪨 Trampa Rocas 🪨 al enfrentar a Conkeldurr.",
+              "variant": [
+                {
+                  "detail": "Después entra con Gengar y usa Maquinación hasta +4. Usa Bola Sombra contra todos.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Conkeldurr, cambia a Chansey y luego entra con Gengar.",
+          "variant": [
+            {
+              "detail": "Gengar usa Maquinación hasta +2 y Bola Sombra al enfrentar a Skarmory.",
+              "variant": [
+                {
+                  "detail": "Chansey usa 🪨 Trampa Rocas 🪨 al enfrentar a Haxorus. Luego entra con Gengar y usa Maquinación hasta +4. Usa Bola Sombra contra todos.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/lotto/krookodile.json
+++ b/src/data/teselia/lotto/krookodile.json
@@ -2,6 +2,31 @@
   "id": "krookodile",
   "name": "Krookodile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar otra vez +2 usar Bola Sombra hasta debilitarlo ➜ si sale Sawk o Luxray ➜ cambiar a Chansey Trampa Rocas ➜ frente a Conkeldurr ➜ Gengar +4 +2 💡si cambia a Gyarados, cambiar a Chansey y volver a atraer💡",
-  "tricks": []
+  "initialMove": "Cambia a Gengar.",
+  "tricks": [
+    {
+      "detail": "Gengar usa Otra Vez y Maquinación hasta +2.",
+      "variant": [
+        {
+          "detail": "Usa Bola Sombra hasta debilitarlo.",
+          "variant": [
+            {
+              "detail": "Si sale Sawk o Luxray, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 frente a Conkeldurr.",
+              "variant": [
+                {
+                  "detail": "Luego entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+                  "variant": [
+                    {
+                      "detail": "Si cambia a Gyarados, cambia a Chansey y vuelve a atraer la ruta.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/lotto/lucario.json
+++ b/src/data/teselia/lotto/lucario.json
@@ -2,15 +2,20 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Conkeldurr --> Gengar +4",
+      "detail": "Si sale Conkeldurr, entra con Gengar y usa Maquinación hasta +4.",
       "variant": []
     },
     {
-      "detail": "Haxorus --> Gengar +4 🔔Si huye a Conkeldurr, cambiar a Chansey y luego a Gengar +4🔔",
-      "variant": []
+      "detail": "Si sale Haxorus, entra con Gengar y usa Maquinación hasta +4.",
+      "variant": [
+        {
+          "detail": "Si cambia a Conkeldurr, cambia a Chansey y luego vuelve a Gengar para usar Maquinación hasta +4.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/lotto/luxray.json
+++ b/src/data/teselia/lotto/luxray.json
@@ -2,6 +2,21 @@
   "id": "luxray",
   "name": "Luxray",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Usar Amortiguador y poner Trampa Rocas frente a Conkeldurr; entrar con Gengar Otra vez  +4 +2 🔔si huye a Gyarados, cambiar a Chansey y volver a atraer🔔💡",
-  "tricks": []
+  "initialMove": "Usa Amortiguador.",
+  "tricks": [
+    {
+      "detail": "Usa 🪨 Trampa Rocas 🪨 frente a Conkeldurr.",
+      "variant": [
+        {
+          "detail": "Entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Si cambia a Gyarados, cambia a Chansey y vuelve a atraer la ruta.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/lotto/machamp.json
+++ b/src/data/teselia/lotto/machamp.json
@@ -2,6 +2,16 @@
   "id": "machamp",
   "name": "Machamp",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambiar a Gengar, luego cambiar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6💡",
-  "tricks": []
-}  
+  "initialMove": "Cambia a Gengar.",
+  "tricks": [
+    {
+      "detail": "Luego cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/teselia/lotto/magnezone.json
+++ b/src/data/teselia/lotto/magnezone.json
@@ -2,33 +2,53 @@
   "id": "magnezone",
   "name": "Magnezone",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Breloom --> Gengar, Otra Vez, +4 y Precisión (Mantener Otra Vez)",
+      "detail": "Si sale Breloom, entra con Gengar y usa Otra Vez.",
       "variant": [
         {
-          "detail": "Huir de Conkeldurr --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6",
-          "variant": []
+          "detail": "Gengar usa Maquinación hasta +4 y Precisión X. Mantén Otra Vez.",
+          "variant": [
+            {
+              "detail": "Si sale Conkeldurr, cambia a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Medicham --> Cambiar a Slowbro y usar Bostezo",
+      "detail": "Si sale Medicham, cambia a Slowbro y usa Bostezo.",
       "variant": [
         {
-          "detail": "Magnezone --> Protección y Bostezo; sacrificar a Politoed y entrar con Poliwrath +6",
-          "variant": []
+          "detail": "Si sale Magnezone, usa Protección y Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Crawdaunt --> Sacrificar a Politoed y entrar con Poliwrath +6",
+          "detail": "Si sale Crawdaunt, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Toxicroak / Conkeldurr --> Cambiar a Slowbro y usar Bostezo frente a Magnezone; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Toxicroak o Conkeldurr, cambia a Slowbro y usa Bostezo frente a Magnezone.",
+      "variant": [
+        {
+          "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/lotto/medicham.json
+++ b/src/data/teselia/lotto/medicham.json
@@ -2,15 +2,25 @@
   "id": "medicham",
   "name": "Medicham",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Slowbro usa Bostezo💡",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Magnezone --> Protección y Bostezo; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Crawdaunt --> Sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Magnezone, usa Protección y Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Crawdaunt, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/lotto/metagross.json
+++ b/src/data/teselia/lotto/metagross.json
@@ -2,31 +2,56 @@
   "id": "metagross",
   "name": "Metagross",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Puño Meteoro ➜ Revisar si sube el Ataque",
+      "detail": "Si usa Puño Meteoro, revisa si sube el Ataque.",
       "variant": [
         {
-          "detail": "No sube +1 ➜ Slowbro usa Bostezo ➜ Frente a Emolga ➜ sacrifica a Politoed y entra con Poliwrath +6🐸🥊",
-          "variant": []
+          "detail": "Si no sube el Ataque, Slowbro usa Bostezo frente a Emolga.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Si sube +1 ➜ Cambiar a Volcarona ➜ Frente usar Salamence ➜ Slowbro y Bostezo ante Emolga ➜ sacrifica a Politoed ➜ entra con Poliwrath +6🐸🥊",
-          "variant": []
+          "detail": "Si sube el Ataque, cambia a Volcarona.",
+          "variant": [
+            {
+              "detail": "Frente a Salamence, cambia a Slowbro y usa Bostezo ante Emolga.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Conkeldurr ➜ Cambiar a Gengar 🔔revisar objeto🔔",
+      "detail": "Si sale Conkeldurr, cambia a Gengar y revisa su objeto.",
       "variant": [
         {
-          "detail": "Llamasfera ➜ Gengar Otra Vez +4 +2 🔔Bola Sombra a todo 🔔 Si cambia a gyarados cuando estas bosteandote cambia a chansey para atraer al tipo lucha (gengar +4 +2)",
-          "variant": []
+          "detail": "Si tiene Llamasfera, Gengar usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos. Si cambia a Gyarados durante la ruta de Bostezo, cambia a Chansey para atraer al tipo lucha y repetir Gengar con Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Sin Llamasfera ➜ Gengar Otra Vez +4 🔔Bola Sombra a todo🔔",
-          "variant": []
+          "detail": "Si no tiene Llamasfera, Gengar usa Otra Vez y Maquinación hasta +4.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/teselia/lotto/mienshao.json
+++ b/src/data/teselia/lotto/mienshao.json
@@ -2,15 +2,35 @@
   "id": "mienshao",
   "name": "Mienshao",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambiar a Gengar, luego cambiar a Slowbro y usar Bostezo💡",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Salamence --> Protección y Bostezo al enfrentar a Crawdaunt; sacrificar a Politoed y entrar con Poliwrath +6 💡Usar Cascada contra Metagross💡",
-      "variant": []
-    },
-    {
-      "detail": "Crawdaunt --> Sacrificar a Politoed y entrar con Poliwrath +6 💡Usar Cascada contra Metagross💡",
-      "variant": []
+      "detail": "Luego cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Salamence, usa Protección y Bostezo al enfrentar a Crawdaunt.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Usa Cascada contra Metagross.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Crawdaunt, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Cascada contra Metagross.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/lotto/salamence.json
+++ b/src/data/teselia/lotto/salamence.json
@@ -2,45 +2,85 @@
   "id": "salamence",
   "name": "Salamence",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🔔Ver habilidad🔔",
+  "initialMove": "Revisa la habilidad.",
   "tricks": [
     {
-      "detail": "Intimidación ➜ Usar Trampa Rocas ➜ Frente a Conkeldurr Sacar a Gengar otra vez +2 🔔Mira abajo🔔",
+      "detail": "Si tiene Intimidación, usa 🪨 Trampa Rocas 🪨.",
       "variant": [
         {
-          "detail": "Conkeldurr Se queda ➜ Gengar otra vez +4 🔔 bola sombra a Todos🔔",
-          "variant": []
-        },
-        {
-          "detail": "Si Entra Salamence ➜ Matalo De un Bola sombra y Frente a Metagross ➜ Slowbro Bostezo y Sacrifica a Politoed entra Con  Poliwrath +6 🔔 Cascada a Metagross🔔",
-          "variant": []
+          "detail": "Frente a Conkeldurr, entra con Gengar y usa Otra Vez.",
+          "variant": [
+            {
+              "detail": "Gengar usa Maquinación hasta +2.",
+              "variant": [
+                {
+                  "detail": "Si Conkeldurr se queda, Gengar usa Maquinación hasta +4 y barre con Bola Sombra.",
+                  "variant": []
+                },
+                {
+                  "detail": "Si entra Salamence, debilítalo con Bola Sombra.",
+                  "variant": [
+                    {
+                      "detail": "Frente a Metagross, Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                      "variant": [
+                        {
+                          "detail": "Usa Cascada contra Metagross.",
+                          "variant": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Sin Intimidación ➜ Usar Trampa Rocas",
+      "detail": "Si no tiene Intimidación, usa 🪨 Trampa Rocas 🪨.",
       "variant": [
         {
-          "detail": "Colmillo Ígneo ➜ Cambiar a Slowbro y usar Bostezo y sacrifica a Politoed y entra con Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Machamp ➜ Cambiar a Gengar luego a Slowbro y usa Bostezo, sacrifica a Politoed y entra Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Conkeldurr ➜ Cambia a Gengar y usa Otra Vez, cambia a Slowbro y usa Bostezo, sacrifica a Politoed, entra Poliwrath +6 ",
-          "variant": []
-        },
-        {
-          "detail": "Medicham ➜ Cambia a Slowbro y usa Bostezo",
+          "detail": "Si usa Colmillo Ígneo, cambia a Slowbro y usa Bostezo.",
           "variant": [
             {
-              "detail": "Magnezone ➜ Protección y Bostezo ➜ sacrifica a Politoed y entrar con Poliwrath +6",
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Machamp, cambia a Gengar y luego a Slowbro.",
+          "variant": [
+            {
+              "detail": "Slowbro usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Conkeldurr, cambia a Gengar y usa Otra Vez.",
+          "variant": [
+            {
+              "detail": "Luego cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Medicham, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si sale Magnezone, usa Protección y Bostezo.",
+              "variant": [
+                {
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             },
             {
-              "detail": "Crawdaunt ➜ Sacrificar a Politoed y entrar con Poliwrath +6",
+              "detail": "Si sale Crawdaunt, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]

--- a/src/data/teselia/lotto/sawk.json
+++ b/src/data/teselia/lotto/sawk.json
@@ -2,11 +2,25 @@
   "id": "sawk",
   "name": "Sawk",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Usar 🪨Trampa Rocas🪨 frente a Conkeldurr; entrar con Gengar Otra Vez  +4 +2 🔔Bola Sombra a todo🔔💡",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "❗Si cambia a Gyarados, cambiar a Chansey y volver a atraer❗",
-      "variant": []
+      "detail": "Frente a Conkeldurr, entra con Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            },
+            {
+              "detail": "Si cambia a Gyarados, cambia a Chansey y vuelve a atraer la ruta.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
-}      
+}

--- a/src/data/teselia/lotto/seismitoad.json
+++ b/src/data/teselia/lotto/seismitoad.json
@@ -2,43 +2,65 @@
   "id": "seismitoad",
   "name": "Seismitoad",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🐸Cambiar a Poliwrath🐸",
+  "initialMove": "Cambia a Poliwrath.",
   "tricks": [
     {
-      "detail": "Aggron ➜  Poliwrath mata a Aggron  ",
+      "detail": "Si sale Aggron, Poliwrath usa Puño Drenaje para debilitarlo.",
       "variant": [
         {
-          "detail": "Seismitoad / Skarmory ➜ Cambiar a Chansey y usar 🪨Trampa Rocas🪨 al enfrentar a Conkeldurr; Gengar usa Otra Vez y cambiar a Volcarona ante Seismitoad; Volcarona +1 x especial ",
-          "variant": []
+          "detail": "Si sale Seismitoad o Skarmory, cambia a Chansey y usa 🪨 Trampa Rocas 🪨 al enfrentar a Conkeldurr.",
+          "variant": [
+            {
+              "detail": "Gengar usa Otra Vez y luego cambia a Volcarona ante Seismitoad.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Conkeldurr ➜ Gengar usa Otra Vez y cambiar a Chansey ante Seismitoad; usar 🪨Trampa Rocas🪨 frente a Conkeldurr; Gengar usa Otra Vez y cambiar a Volcarona ante Seismitoad; Volcarona +1 x especial . ",
-          "variant": []
+          "detail": "Si sale Conkeldurr, Gengar usa Otra Vez y cambia a Chansey ante Seismitoad.",
+          "variant": [
+            {
+              "detail": "Usa 🪨 Trampa Rocas 🪨 frente a Conkeldurr. Luego Gengar usa Otra Vez y cambia a Volcarona ante Seismitoad.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Dusknoir ➜ Cambiar a Volcarona y luego a Chansey usar 🪨Trampa Rocas🪨",
-          "variant": []
-        },
+          "detail": "Si sale Dusknoir, cambia a Volcarona y luego a Chansey para usar 🪨 Trampa Rocas 🪨.",
+          "variant": [
+            {
+              "detail": "Si Dusknoir se queda, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Medicham, cambia a Slowbro y usa Bostezo.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Magnezone, usa Protección y luego Bostezo.",
+      "variant": [
         {
-          "detail": "Se Queda Dusknoir ➜ Sacrifica a Politoed y entrar con Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Conkeldurr ➜ Gengar usa Otra Vez y cambiar a Volcarona ante Seismitoad ➜ Volcarona x1 danza aleteo x especial . ",
+          "detail": "Cuando Magnezone quede dormido, usa Bostezo otra vez. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]
     },
     {
-      "detail": "Medicham ➜ Cambia a Slowbro y usa Bostezo",
-      "variant": []
-    },
-    {
-      "detail": "Magnezone ➜ Protección ➜ Magnezone se duerme usa otra vez Bostezo y sacrifica a Politoed y entra con Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Crawdaunt ➜ Sacrifica a Politoed y entrar con Poliwrath +6",
+      "detail": "Si sale Crawdaunt, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
       "variant": []
     }
   ]

--- a/src/data/teselia/lotto/skarmory.json
+++ b/src/data/teselia/lotto/skarmory.json
@@ -2,43 +2,77 @@
   "id": "skarmory",
   "name": "Skarmory",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa rocas 🪨 🔔se queda sigue usando Amortiguador🔔",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Conkeldurr ➜ Cambiar a Gengar y usa Otra Vez 🔔revisar movimiento🔔",
+      "detail": "Si Skarmory se queda, sigue usando Amortiguador.",
+      "variant": []
+    },
+    {
+      "detail": "Si sale Conkeldurr, cambia a Gengar y usa Otra Vez. Revisa el movimiento.",
       "variant": [
         {
-          "detail": "A Bocajarro ➜ Gengar Otra Vez +4 🔔Bola Sombra a todo🔔",
-          "variant": []
+          "detail": "Si usa A Bocajarro, Gengar usa Maquinación hasta +4.",
+          "variant": [
+            {
+              "detail": "Usa Bola Sombra contra todos.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Puño Drenaje ➜ Cambia a Volcarona ante Seismitoad ➜ Volcarona x1 Danza aleteo + Especial x",
-          "variant": []
+          "detail": "Si usa Puño Drenaje, cambia a Volcarona ante Seismitoad.",
+          "variant": [
+            {
+              "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+              "variant": []
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Haxorus ➜ Gengar +4 🔔Bola Sombra a todo🔔",
+      "detail": "Si sale Haxorus, entra con Gengar y usa Maquinación hasta +4.",
       "variant": [
         {
-          "detail": "Conkeldurr ➜ Gengar ➜ Cambia a Poliwrath y luego a Gengar Otra vez +4",
-          "variant": []
+          "detail": "Usa Bola Sombra contra todos.",
+          "variant": [
+            {
+              "detail": "Si sale Conkeldurr, entra con Gengar, luego cambia a Poliwrath 🐸🥊 y vuelve a Gengar para usar Otra Vez y Maquinación hasta +4.",
+              "variant": []
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Aggron ➜ Cambia a Poliwrath y matalo",
+      "detail": "Si sale Aggron, cambia a Poliwrath 🐸🥊 y debilítalo con Puño Drenaje.",
       "variant": [
         {
-          "detail": "Seismitoad / Skarmory ➜ Cambia a Chansey ,Amortiguador Frente a Conkeldurr ➜ Gengar usa Otra Vez y cambia a Volcarona Frente a Seismitoad, Volcarona +1 danza aleteo + Especial x 🔔si volcarona muere de un critico vuelve a repetir el proceso de la ruta de seismitoad🔔",
-          "variant": []
+          "detail": "Si sale Seismitoad o Skarmory, cambia a Chansey y usa Amortiguador frente a Conkeldurr.",
+          "variant": [
+            {
+              "detail": "Gengar usa Otra Vez y cambia a Volcarona frente a Seismitoad.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x1 y Especial X. Si Volcarona queda debilitada por crítico, repite la ruta de Seismitoad.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Conkeldurr ➜ Gengar usa Otra Vez y cambiar a Volcarona Frente a Seismitoad ➜ Volcarona x1 Danza aleteo + Especial x",
-          "variant": []
+          "detail": "Si sale Conkeldurr, Gengar usa Otra Vez y cambia a Volcarona frente a Seismitoad.",
+          "variant": [
+            {
+              "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Dusknoir ➜ Sacrifica a Politoed y entrar con Poliwrath +6",
+          "detail": "Si sale Dusknoir, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         }
       ]

--- a/src/data/teselia/lotto/throh.json
+++ b/src/data/teselia/lotto/throh.json
@@ -2,24 +2,39 @@
   "id": "throh",
   "name": "Throh",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "❤️Encanto❤️",
+  "initialMove": "Usa Encanto.",
   "tricks": [
     {
-      "detail": "Aggron --> Usar 🪨Trampa Rocas🪨 al enfrentar a Conkeldurr; Gengar usa Otra Vez y cambiar a Volcarona frente a Seismitoad; 💊1 Danza Aleteo + Especial X💊",
-      "variant": []
-    },
-    {
-      "detail": "Conkeldurr --> Usa Encanto contra Aggron y pon las Trampa Rocas",
+      "detail": "Si sale Aggron, usa 🪨 Trampa Rocas 🪨 al enfrentar a Conkeldurr.",
       "variant": [
         {
-          "detail": "Conkeldurr --> Ver el caso anterior de Conkeldurr",
+          "detail": "Gengar usa Otra Vez y luego cambia a Volcarona frente a Seismitoad.",
+          "variant": [
+            {
+              "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Conkeldurr, usa Encanto contra Aggron y luego usa 🪨 Trampa Rocas 🪨.",
+      "variant": [
+        {
+          "detail": "Si vuelve Conkeldurr, sigue la ruta anterior de Conkeldurr.",
           "variant": []
         },
         {
-          "detail": "Dusknoir --> Sacrificar a Politoed y entrar con Poliwrath +6 🔔(Si Aggron entra contra Politoed, espera que muera y luego entra con Poliwrath +6)🔔",
-          "variant": []
-        } 
-      ]  
+          "detail": "Si sale Dusknoir, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Si Aggron entra contra Politoed, deja que Politoed quede debilitado y luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/lotto/toxicroak.json
+++ b/src/data/teselia/lotto/toxicroak.json
@@ -2,6 +2,16 @@
   "id": "toxicroak",
   "name": "Toxicroak",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Slowbro usa Bostezo; sacrificar a Politoed y entrar con Poliwrath +6💡",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/lotto/tyranitar.json
+++ b/src/data/teselia/lotto/tyranitar.json
@@ -2,15 +2,30 @@
   "id": "tyranitar",
   "name": "Tyranitar",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Mira Abajo Que Ruta Seguir",
+  "initialMove": "Elige una ruta.",
   "tricks": [
     {
-      "detail": "Ruta Segura ➜ Teletransporte, Slowbro usa Bostezo, sacrifica a Politoed, Poliwrath a +6🐸🥊",
-      "variant": []
+      "detail": "Ruta segura: usa Teletransporte y entra con Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Ruta Arriesgada ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊",
-      "variant": []
+      "detail": "Ruta arriesgada: entra Politoed como pivote directo.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Cleans all Teselia Lotto Spanish strategy JSON files.
- Keeps `initialMove` limited to the opening switch/action only.
- Moves follow-up routes into `tricks.detail` and nested `variant` entries.
- Keeps the scope limited to `src/data/teselia/lotto`.

## Scope
- Teselia Lotto strategy JSON files only.
- No English, asset, or frontend changes.

## Files
- 26 files under `src/data/teselia/lotto`.