### PR TITLE
Clean Teselia Mirto Spanish strategy structure

### DIFF
--- a/src/data/teselia/mirto/archeops.json
+++ b/src/data/teselia/mirto/archeops.json
@@ -2,6 +2,21 @@
   "id": "archeops",
   "name": "Archeops",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Sacrificar a Gengar ➜ Slowbro usa Bostezo frente a Volcarona ➜ sacrifica a Politoed ➜  Poliwrath +6 🔔(Puño drenaje a Volcarona)🔔",
-  "tricks": []
-}  
+  "initialMove": "Deja que Gengar quede debilitado.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Slowbro y usa Bostezo frente a Volcarona.",
+      "variant": [
+        {
+          "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/teselia/mirto/bouffalant.json
+++ b/src/data/teselia/mirto/bouffalant.json
@@ -2,6 +2,21 @@
   "id": "bouffalant",
   "name": "Bouffalant",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 usar Teletransporte para sacar a Slowbro , usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6 🔔(Poliwrath Puño drenaje a Volcarona)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Usa Teletransporte para sacar a Slowbro y usar Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/braviary.json
+++ b/src/data/teselia/mirto/braviary.json
@@ -2,6 +2,21 @@
   "id": "braviary",
   "name": "Braviary",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Gengar usa Otra Vez ➜ cambiar a Chansey ante Vaporeon usar 🪨Trampa Rocas🪨 frente Lucario ➜ Cambia a Slowbro y usa Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊💡",
-  "tricks": []
+  "initialMove": "Cambia a Gengar.",
+  "tricks": [
+    {
+      "detail": "Gengar usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Luego cambia a Chansey ante Vaporeon y usa 🪨 Trampa Rocas 🪨 frente a Lucario.",
+          "variant": [
+            {
+              "detail": "Cambia a Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/chandelure.json
+++ b/src/data/teselia/mirto/chandelure.json
@@ -2,15 +2,35 @@
   "id": "chandelure",
   "name": "Chandelure",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Llamarada ➜ Sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño drenaje a Volcarona)🔔",
-      "variant": []
+      "detail": "Si usa Llamarada, entra Politoed como pivote.",
+      "variant": [
+        {
+          "detail": "Luego entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Excadrill ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño drenaje a Volcarona)🔔",
-      "variant": []
+      "detail": "Si sale Excadrill, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/mirto/conkeldurr.json
+++ b/src/data/teselia/mirto/conkeldurr.json
@@ -2,6 +2,21 @@
   "id": "conkeldurr",
   "name": "Conkeldurr",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambia a Slowbro y usa Bostezo ➜ Frente a Volcarona ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊💡 🔔(Puño drenaje a Volcarona)🔔",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Volcarona, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/dragonite.json
+++ b/src/data/teselia/mirto/dragonite.json
@@ -2,6 +2,21 @@
   "id": "dragonite",
   "name": "Dragonite",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Lucario ➜ cambiar a Slowbro y usar Bostezo ➜ sacrifica a Politoed ➜  Poliwrath +6🐸🥊💡 🔔(Puño drenaje a Volcarona)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Lucario, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/druddigon.json
+++ b/src/data/teselia/mirto/druddigon.json
@@ -2,6 +2,21 @@
   "id": "druddigon",
   "name": "Druddigon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro ➜ Frente a Conkeldurr/Braviary ➜ usar Bostezo ➜ Frente a Volcarona ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño drenaje a Volcarona)🔔",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Frente a Conkeldurr o Braviary, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Volcarona, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/escavalier.json
+++ b/src/data/teselia/mirto/escavalier.json
@@ -2,6 +2,21 @@
   "id": "escavalier",
   "name": "Escavalier",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 Slowbro usa Bostezo ➜ Frente a Volcarona ➜ sacrifica a Politoed ➜  Poliwrath +6🐸🥊 🔔(Puño drenaje a Volcarona)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Volcarona, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/excadrill.json
+++ b/src/data/teselia/mirto/excadrill.json
@@ -2,76 +2,135 @@
   "id": "excadrill",
   "name": "Excadrill",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Terremoto --> Revisar objeto equipado",
+      "detail": "Si usa Terremoto, revisa el objeto equipado.",
       "variant": [
         {
-          "detail": "Vidasfera --> Sacrifica a Gengar, saca a Slowbro y usa Bostezo",
+          "detail": "Si tiene Vidaesfera, deja que Gengar quede debilitado y entra con Slowbro.",
           "variant": [
             {
-              "detail": "Si se queda --> Sacrificar a Politoed y entrar con Poliwrath +6 🔔(Observa Quien sale Primero)🔔",
+              "detail": "Slowbro usa Bostezo.",
               "variant": [
                 {
-                  "detail": "Si sale Vanilluxe primero --> 💊Tomar una velocidad X y presionar de nuevo💊",
+                  "detail": "Si Excadrill se queda, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": [
+                    {
+                      "detail": "Observa quién sale primero.",
+                      "variant": [
+                        {
+                          "detail": "Si sale Vanilluxe primero, usa Velocidad X y sigue presionando.",
+                          "variant": []
+                        },
+                        {
+                          "detail": "Si sale Volcarona primero, mantén presión completa.",
+                          "variant": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "detail": "Si sale Volcarona, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
+                  "variant": [
+                    {
+                      "detail": "Usa Puño Drenaje contra Volcarona.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si no tiene Vidaesfera, usa Teletransporte.",
+          "variant": [
+            {
+              "detail": "Si Excadrill se queda, saca a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Drenaje contra Volcarona. Si Volcarona despierta, no es amenaza.",
                   "variant": []
                 },
                 {
-                  "detail": "Si sale Volcarona primero --> Presión completa",
+                  "detail": "Si aún no cambia, continúa usando Bostezo hasta obligarlo a cambiar a sus Pokémon de reserva.",
+                  "variant": []
+                },
+                {
+                  "detail": "Cuando salga el Pokémon de reserva, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
                   "variant": []
                 }
               ]
             },
             {
-              "detail": "Volcarona --> Sacrificar a Politoed y entrar con Poliwrath +6+2 🔔(Puño drenaje contra Volcarona)🔔",
-              "variant": []
-            }
-          ]
-        },
-        { 
-          "detail": "No tiene Vidasfera --> Usa Teletransporte",
-          "variant": [  
-            {
-              "detail": "Si se queda --> Saca a Slowbro y usa Bostezo 🔔(Puño drenaje contra Volcarona / Si Volcarona se despierta no es una Amenaza)🔔",
+              "detail": "Si sale Lucario, Conkeldurr o Archeops, saca a Slowbro y usa Bostezo.",
               "variant": [
                 {
-                  "detail": "Si aun no cambia --> Continua haciendo Bostezo hasta que lo obligues a cambiar a sus Pokémon de reserva",
-                  "variant": []
-                },    
-                {
-                  "detail": "Sale su poke de reserva --> Sacrifica a Politoed y entra con Poliwarth +6",
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
                   "variant": []
                 }
               ]
-            },  
+            },
             {
-              "detail": "Lucario / Conkeldurr / Archeops --> Sacar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6",
-              "variant": []
-            },  
-            {  
-              "detail": "Escavalier/Magcargo --> Saca a Poliwrath luego cambia Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6",
+              "detail": "Si sale Escavalier o Magcargo, saca a Poliwrath, luego cambia a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lucario, saca a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Si Volcarona despierta, no es amenaza.",
               "variant": []
             }
-          ]  
-        } 
-      ]    
-    },    
-    {
-      "detail": "Lucario --> Sacar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6 🔔(Volcarona despierta no es amenaza)🔔",
-      "variant": []
+          ]
+        }
+      ]
     },
     {
-      "detail": "Escavalier / Magcargo --> Slowbro usa Bostezo al enfrentar a Volcarona; sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño drenaje contra Volcarona)🔔",
-      "variant": []
+      "detail": "Si sale Escavalier o Magcargo, Slowbro usa Bostezo al enfrentar a Volcarona.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Conkeldurr --> Cambiar a Slowbro y usar Bostezo al enfrentar a Volcarona; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Conkeldurr, cambia a Slowbro y usa Bostezo al enfrentar a Volcarona.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     },
     {
-       "detail": "Archeops --> Sacrificar a Gengar; Slowbro usa Bostezo al enfrentar a Volcarona, sacrificar a Politoed y entrar con Poliwrath +6",
-       "variant": []
+      "detail": "Si sale Archeops, deja que Gengar quede debilitado y entra con Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo al enfrentar a Volcarona. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/mirto/feraligatr.json
+++ b/src/data/teselia/mirto/feraligatr.json
@@ -2,19 +2,44 @@
   "id": "feraligatr",
   "name": "Feraligatr",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Se Qeuda Feraligatr ➜ Sacrifica a Gengar y Slowbro usa Bostezo, sacrifica a Politoed y entra con Poliwrath +6🐸🥊 🔔Puño drenaje a Volcarona🔔",
-      "variant": []
+      "detail": "Si Feraligatr se queda, deja que Gengar quede debilitado y entra con Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Lucario ➜ Slowbro usa Bostezo y sacrifica a Politoed , entra con Poliwrath +6🐸🥊 🔔Puño drenaje a Volcarona🔔",
-      "variant": []
+      "detail": "Si sale Lucario, Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Escavalier ➜ Slowbro usa Bostezo y sacrifica a Politoed , entrar con Poliwrath +6🐸🥊",
-      "variant": []
+      "detail": "Si sale Escavalier, Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/mirto/floatzel.json
+++ b/src/data/teselia/mirto/floatzel.json
@@ -2,6 +2,21 @@
   "id": "floatzel",
   "name": "Floatzel",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 al enfrentar a Escavalier cambia a Slowbro usa Bostezo ➜ Frente a Volcarona ➜ sacrifica a Politoed ➜ Poliwrath +6🐸🥊 🔔(Puño drenaje/hielo a Volcarona)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Escavalier, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Frente a Volcarona, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje o Puño Hielo contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/gigalith.json
+++ b/src/data/teselia/mirto/gigalith.json
@@ -2,29 +2,48 @@
   "id": "gigalith",
   "name": "Gigalith",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💕Usar Encanto, luego 🪨Trampa Rocas🪨 🔔(Si no cambia Usar Amortiguador)🔔",
+  "initialMove": "Usa Encanto.",
   "tricks": [
     {
-      "detail": "Excadrill --> Teletransporte para sacar a Slowbro y usar Bostezo😴",
+      "detail": "Luego usa 🪨 Trampa Rocas 🪨.",
       "variant": [
         {
-          "detail": "Si se queda --> Sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño drenaje contra Volcarona)🔔",
+          "detail": "Si Gigalith no cambia, usa Amortiguador.",
           "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Excadrill, usa Teletransporte para sacar a Slowbro y usar Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Excadrill se queda, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Latios --> Usar Proteccion y luego Bostezo",
+          "detail": "Si sale Latios, usa Protección y luego Bostezo.",
           "variant": [
-           {
-             "detail": "Volcarona --> Sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño drenaje contra Volcarona)🔔",
-             "variant": []
-           },    
-           {
-             "detail": "Seismitoad --> Cambia a Volcarona +2",
-             "variant": []  
-           }
+            {
+              "detail": "Si sale Volcarona, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Drenaje contra Volcarona.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Seismitoad, cambia a Volcarona y usa Danza Aleteo x2.",
+              "variant": []
+            }
           ]
         }
       ]
     }
-  ]  
-}  
+  ]
+}

--- a/src/data/teselia/mirto/krookodile.json
+++ b/src/data/teselia/mirto/krookodile.json
@@ -2,6 +2,16 @@
   "id": "krookodile",
   "name": "Krookodile",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨; entrar con Gengar +4 🔔(No usar Otra Vez)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Gengar y usa Maquinación hasta +4.",
+      "variant": [
+        {
+          "detail": "No uses Otra Vez.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/latias.json
+++ b/src/data/teselia/mirto/latias.json
@@ -2,19 +2,44 @@
   "id": "latias",
   "name": "Latias",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda --> Usar Teletransporte para sacar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño drenaje contra Volcarona)🔔",
-      "variant": []
+      "detail": "Si Latias se queda, usa Teletransporte para sacar a Slowbro y usar Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Lucario --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6 🔔(Usar Cascada contra Reuniclus / Si Volcarona despierta no es amenaza)🔔",
-      "variant": []
+      "detail": "Si sale Lucario, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Cascada contra Reuniclus. Si Volcarona despierta, no es amenaza.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Excadrill --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Excadrill, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/mirto/latios.json
+++ b/src/data/teselia/mirto/latios.json
@@ -2,33 +2,53 @@
   "id": "latios",
   "name": "Latios",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Excadrill --> Sacrificar a Gengar; Slowbro usa Bostezo",
+      "detail": "Si sale Excadrill, deja que Gengar quede debilitado y entra con Slowbro.",
       "variant": [
         {
-          "detail": "Si se queda --> Sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño drenaje contra Excadrill / Observa Quien sale Primero)🔔",
+          "detail": "Slowbro usa Bostezo.",
           "variant": [
             {
-              "detail": "Si sale Vanilluxe primero --> 💊Tomar una velocidad X y presionar de nuevo💊",
-              "variant": []
+              "detail": "Si Excadrill se queda, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Drenaje contra Excadrill y observa quién sale primero.",
+                  "variant": [
+                    {
+                      "detail": "Si sale Vanilluxe primero, usa Velocidad X y sigue presionando.",
+                      "variant": []
+                    },
+                    {
+                      "detail": "Si sale Volcarona primero, mantén presión completa.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
             },
             {
-              "detail": "Si sale Volcarona primero --> Presión completa",
-              "variant": []
+              "detail": "Si sale Volcarona, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Drenaje contra Volcarona.",
+                  "variant": []
+                }
+              ]
             }
           ]
-        },
-        {
-          "detail": "Volcarona --> Sacrificar a Politoed y entrar con Poliwrath +6+2 🔔(Puño drenaje contra Volcarona)🔔",
-          "variant": []
         }
-      ]  
+      ]
     },
     {
-      "detail": "Escavalier/Magcargo --> Slowbro usa Bostezo al enfrentar a Volcarona; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Escavalier o Magcargo, Slowbro usa Bostezo al enfrentar a Volcarona.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/mirto/lucario.json
+++ b/src/data/teselia/mirto/lucario.json
@@ -2,24 +2,64 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻Cambia a Gengar👻",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Patada Salto Alta ➜ Revisar PS de Lucario",
+      "detail": "Si usa Patada Salto Alta, revisa los PS de Lucario.",
       "variant": [
         {
-          "detail": "PS Amarillo ➜ Gengar usa Maquinacion frente a Sandslash ➜ Chansey usa 🪨Trampa Rocas 🪨 Frente a Braviary entra con Slowbro usa Bostezo ➜ sacrifica a Politoed y entra con Poliwrath +6 🔔(Puño drenaje a Volcarona)🔔",
-          "variant": []
+          "detail": "Si queda en PS amarillo, Gengar usa Maquinación frente a Sandslash.",
+          "variant": [
+            {
+              "detail": "Luego Chansey usa 🪨 Trampa Rocas 🪨 frente a Braviary.",
+              "variant": [
+                {
+                  "detail": "Entra con Slowbro y usa Bostezo. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": [
+                    {
+                      "detail": "Usa Puño Drenaje contra Volcarona.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "PS Verde ➜ Gengar Otra Vez +2 y si sale Excadrill usa Bola Sombra para sacrificarlo, sacar a Slowbro y usar Bostezo frente a Volcarona y sacrifica a Politoed y entra con Poliwrath +6 🔔(Puño drenaje a Volcarona y  Cascada a Reuniclus / Volcarona No te mata usa tambor tranquilo )🔔",
-          "variant": []
+          "detail": "Si queda en PS verde, Gengar usa Otra Vez y Maquinación hasta +2.",
+          "variant": [
+            {
+              "detail": "Si sale Excadrill, usa Bola Sombra para dejar que Gengar quede debilitado.",
+              "variant": [
+                {
+                  "detail": "Luego entra con Slowbro y usa Bostezo frente a Volcarona. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": [
+                    {
+                      "detail": "Usa Puño Drenaje contra Volcarona y Cascada contra Reuniclus. Volcarona no debilita a Poliwrath, usa Tambor con calma.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "A Bocajarro ➜ Cambiar a Slowbro y usar Bostezo ➜ sacrifica a Politoed y entra con Poliwrath +6 🔔(Puño drenaje a Volcarona/Manectric)🔔",
-      "variant": []
+      "detail": "Si usa A Bocajarro, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona o Manectric.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/mirto/manectric.json
+++ b/src/data/teselia/mirto/manectric.json
@@ -2,6 +2,21 @@
   "id": "manectric",
   "name": "Manectric",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Lucario / Braviary; cambiar a Slowbro y usar Bostezo, sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño Drenaje a Volcarona)🔔",
-  "tricks": []
-}   
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Lucario o Braviary, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/teselia/mirto/reuniclus.json
+++ b/src/data/teselia/mirto/reuniclus.json
@@ -2,6 +2,25 @@
   "id": "reuniclus",
   "name": "Reuniclus",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Usar 🪨Trampa Rocas🪨 al enfrentar a Lucario; Slowbro usa Bostezo, sacrificar a Politoed y entrar con Poliwrath +6💡 🔔(Puño drenaje a Volcarona y Cascada a Reuniclus / Si Volcarona despierta no es amenza)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Al enfrentar a Lucario, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona y Cascada contra Reuniclus.",
+              "variant": []
+            },
+            {
+              "detail": "Si Volcarona despierta, no es amenaza.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/samurott.json
+++ b/src/data/teselia/mirto/samurott.json
@@ -2,6 +2,25 @@
   "id": "samurott",
   "name": "Samurott",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Lucario; cambiar a Slowbro y usar Bostezo, sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño Drenaje a Volcarona y Cascada a Reuniclus)🔔 🚨(Si Volcarona despierta no hay Amenaza)🚨 ",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
+  "tricks": [
+    {
+      "detail": "Frente a Lucario, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona y Cascada contra Reuniclus.",
+              "variant": []
+            },
+            {
+              "detail": "Si Volcarona despierta, no es amenaza.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/sandslash.json
+++ b/src/data/teselia/mirto/sandslash.json
@@ -2,44 +2,79 @@
   "id": "sandslash",
   "name": "Sandslash",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Excadrill --> Sacrificar a Gengar; Slowbro usa Bostezo",
+      "detail": "Si sale Excadrill, deja que Gengar quede debilitado y entra con Slowbro.",
       "variant": [
         {
-          "detail": "Si se queda --> Sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño drenaje contra Excadrill / Observa Quien sale Primero)🔔",
+          "detail": "Slowbro usa Bostezo.",
           "variant": [
             {
-              "detail": "Si sale Vanilluxe primero --> 💊Tomar una velocidad X y presionar de nuevo💊",
-              "variant": []
+              "detail": "Si Excadrill se queda, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Drenaje contra Excadrill y observa quién sale primero.",
+                  "variant": [
+                    {
+                      "detail": "Si sale Vanilluxe primero, usa Velocidad X y sigue presionando.",
+                      "variant": []
+                    },
+                    {
+                      "detail": "Si sale Volcarona primero, mantén presión completa.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
             },
             {
-              "detail": "Si sale Volcarona primero --> Presión completa",
+              "detail": "Si sale Volcarona, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Drenaje contra Volcarona.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lucario o Braviary, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si usa Puño Certero, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si Sandslash se queda, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Presiona hasta Vanilluxe y usa Velocidad X. Usa Puño Drenaje contra Volcarona.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "Volcarona --> Sacrificar a Politoed y entrar con Poliwrath +6+2 🔔(Puño drenaje a Volcarona)🔔",
-          "variant": []
-        }
-      ]  
-    },
-    {
-      "detail": "Lucario / Braviary --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño drenaje a Volcarona)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Puño Certero --> Cambia a Slowbro y usa Bostezo",
-      "variant": [
-        {
-          "detail": "Si se queda --> Sacrificar a Politoed y entrar con Poliwrath +6; presionar hasta Vanillish y usar Velocidad X 🔔(Puño drenaje a Volcarona)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Volcarona --> Sacrificar a Politoed y entrar con Poliwrath 6+2 🔔(Puño drenaje a Volcarona)🔔",
-          "variant": []
+          "detail": "Si sale Volcarona, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/teselia/mirto/seismitoad.json
+++ b/src/data/teselia/mirto/seismitoad.json
@@ -2,6 +2,21 @@
   "id": "seismitoad",
   "name": "Seismitoad",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño Drenaje a Excadrill)🔔",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Slowbro usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Excadrill.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/vanilluxe.json
+++ b/src/data/teselia/mirto/vanilluxe.json
@@ -2,6 +2,16 @@
   "id": "vanilluxe",
   "name": "Vanilluxe",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "💡Cambiar a Slowbro y usar Bostezo al enfrentar a Volcarona; sacrificar a Politoed y entrar con Poliwrath +6+2💡",
-  "tricks": []
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo al enfrentar a Volcarona.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/teselia/mirto/vaporeon.json
+++ b/src/data/teselia/mirto/vaporeon.json
@@ -2,41 +2,86 @@
   "id": "vaporeon",
   "name": "Vaporeon",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Conkeldurr --> Cambiar a Slowbro y usar Bostezo al enfrentar a Volcarona; sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño Drenaje a Volcarona)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Archeops --> Sacrificar a Gengar; Slowbro usa Bostezo al enfrentar a Volcarona; sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño Drenaje a Volcarona)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Lucario/Braviary --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño Drenaje a Volcarona)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill --> Sacrificar a Gengar; Slowbro usa Bostezo",
+      "detail": "Si sale Conkeldurr, cambia a Slowbro y usa Bostezo al enfrentar a Volcarona.",
       "variant": [
         {
-          "detail": "Si se queda --> Sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño drenaje contra Excadrill / Observa Quien sale Primero)🔔",
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": [
             {
-              "detail": "Si sale Vanilluxe primero --> 💊Tomar una velocidad X y presionar de nuevo💊",
-              "variant": []
-            },
-            {
-              "detail": "Si sale Volcarona primero --> Presión completa",
+              "detail": "Usa Puño Drenaje contra Volcarona.",
               "variant": []
             }
           ]
-        },
-        {
-          "detail": "Volcarona --> Sacrificar a Politoed y entrar con Poliwrath 6+2 🔔(Puño drenaje a Volcarona)🔔",
-          "variant": []
         }
-      ] 
+      ]
+    },
+    {
+      "detail": "Si sale Archeops, deja que Gengar quede debilitado y entra con Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo al enfrentar a Volcarona. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lucario o Braviary, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Excadrill, deja que Gengar quede debilitado y entra con Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si Excadrill se queda, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Drenaje contra Excadrill y observa quién sale primero.",
+                  "variant": [
+                    {
+                      "detail": "Si sale Vanilluxe primero, usa Velocidad X y sigue presionando.",
+                      "variant": []
+                    },
+                    {
+                      "detail": "Si sale Volcarona primero, mantén presión completa.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Volcarona, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Drenaje contra Volcarona.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/teselia/mirto/volcarona.json
+++ b/src/data/teselia/mirto/volcarona.json
@@ -2,53 +2,118 @@
   "id": "volcarona",
   "name": "Volcarona",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 TRAMPA ROCAS 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda --> Sacrificar a Gengar; Slowbro usa Bostezo, sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño drenaje contra Volcarona)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Conkeldurr --> Slowbro usa Bostezo al enfrentar a Volcarona; sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño drenaje contra Volcarona)🔔",
-      "variant": []
-    },
-    {
-      "detail": "Excadrill --> Sacrificar a Gengar; Slowbro usa Bostezo",
+      "detail": "Si Volcarona se queda, deja que Gengar quede debilitado y entra con Slowbro.",
       "variant": [
         {
-          "detail": "Si se queda --> Sacrificar a Politoed y entrar con Poliwrath +6; revisar orden de Volcarona/Vanillish",
+          "detail": "Slowbro usa Bostezo. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": [
             {
-              "detail": "Si sale Vanillish primero --> Recibir golpe, usar Velocidad X y presionar de nuevo",
-              "variant": []
-            },
-            {
-              "detail": "Si sale Volcarona primero --> Presión completa",
+              "detail": "Usa Puño Drenaje contra Volcarona.",
               "variant": []
             }
           ]
-        },
-        {   
-           "detail": "Volcarona --> Sacrificar a Politoed y entrar con Poliwrath +6+2 🔔(Puño drenaje contra Volcarona)🔔",
-           "variant": []
-        }  
-      ] 
+        }
+      ]
     },
     {
-      "detail": "Escavalier/Magcargo --> Slowbro usa Bostezo al enfrentar a Volcarona; sacrificar a Politoed y entrar con Poliwrath +6 🔔(Puño drenaje contra Volcarona)🔔",
-      "variant": []
+      "detail": "Si sale Conkeldurr, Slowbro usa Bostezo al enfrentar a Volcarona.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Lucario --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed y entrar con Poliwrath +6 🔔Puño drenaje contra Volcarona / Usar Cascada contra Reuniclus / Volcarona despierta no es amenaza🔔",
-      "variant": []
+      "detail": "Si sale Excadrill, deja que Gengar quede debilitado y entra con Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Si Excadrill se queda, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": [
+                {
+                  "detail": "Revisa el orden de Volcarona y Vanilluxe.",
+                  "variant": [
+                    {
+                      "detail": "Si sale Vanilluxe primero, recibe el golpe, usa Velocidad X y sigue presionando.",
+                      "variant": []
+                    },
+                    {
+                      "detail": "Si sale Volcarona primero, mantén presión completa.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Volcarona, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque y Velocidad X para +2 Velocidad.",
+              "variant": [
+                {
+                  "detail": "Usa Puño Drenaje contra Volcarona.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Archeops --> Sacrificar a Gengar; Slowbro usa Bostezo al enfrentar a Volcarona; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Escavalier o Magcargo, Slowbro usa Bostezo al enfrentar a Volcarona.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     },
     {
-      "detail": "Braviary --> Slowbro usa Bostezo al enfrentar a Volcarona; sacrificar a Politoed y entrar con Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Lucario, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Volcarona y Cascada contra Reuniclus. Si Volcarona despierta, no es amenaza.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Archeops, deja que Gengar quede debilitado y entra con Slowbro.",
+      "variant": [
+        {
+          "detail": "Slowbro usa Bostezo al enfrentar a Volcarona. Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Braviary, Slowbro usa Bostezo al enfrentar a Volcarona.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Cleans all Teselia Mirto Spanish strategy JSON files.
- Keeps `initialMove` limited to the opening switch/action only.
- Moves follow-up routes into `tricks.detail` and nested `variant` entries.
- Keeps the scope limited to `src/data/teselia/mirto`.

## Scope
- Teselia Mirto strategy JSON files only.
- No English, asset, or frontend changes.

## Files
- 24 files under `src/data/teselia/mirto`.