### PR TITLE
Fix Teselia Lotto Breloom setup wording

### DIFF
--- a/src/data/teselia/lotto/breloom.json
+++ b/src/data/teselia/lotto/breloom.json
@@ -29,7 +29,7 @@
               ]
             },
             {
-              "detail": "Si después de Gengar +2 entra Conkeldurr, cambia a Slowbro y usa Bostezo frente a Magnezone.",
+              "detail": "Si después de que Gengar usa Maquinación hasta +2 entra Conkeldurr, cambia a Slowbro y usa Bostezo frente a Magnezone.",
               "variant": [
                 {
                   "detail": "Luego usa Protección y Bostezo frente a Breloom. Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",


### PR DESCRIPTION
## Summary
- Fixes one leftover shorthand setup phrase in Teselia Lotto Breloom.
- Replaces `Gengar +2` style wording with the approved Maquinación wording.

## Scope
- Only `src/data/teselia/lotto/breloom.json`.
- No English, asset, or frontend changes.