### PR TITLE
Clean Kanto Lorelei Spanish strategy structure

### DIFF
--- a/src/data/kanto/lorelei/articuno.json
+++ b/src/data/kanto/lorelei/articuno.json
@@ -2,6 +2,16 @@
   "id": "articuno",
   "name": "Articuno",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Lucario; cambiar a Slowbro y usar Bostezo frente a Lapras; sacrificar a Politoed; Poliwrath +6 🐸",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Lucario.",
+  "tricks": [
+    {
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Lapras.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/kanto/lorelei/bronzong.json
+++ b/src/data/kanto/lorelei/bronzong.json
@@ -2,67 +2,102 @@
   "id": "bronzong",
   "name": "Bronzong",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda --> Ver Movimiento",
+      "detail": "Si Bronzong se queda, revisa el movimiento.",
       "variant": [
         {
-          "detail": "Giro Bola --> Cambiar a Volcarona; usar Especial X y Barrer; 🔔(Si Bronzong se quema puedes usar Danza Aleteo x2 // Usar Ataques súper Efectivos)🔔",
-          "variant": []
-        },
-        {
-          "detail": "Autodestrucción y entra su Chansey --> Sacrificar a Politoed; Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Cabezazo Zen / Terremoto --> Cambiar a Slowbro y usar Bostezo frente a Nidoking; sacrificar a Politoed; Poliwrath +6",
-          "variant": []
-        },  
-        {
-          "detail": "Autodestrucción y sale Nidoking --> Chansey usa Amortiguador para curar al máximo",
+          "detail": "Si usa Giro Bola, cambia a Volcarona.",
           "variant": [
             {
-              "detail": "Si se queda --> Teletransporte; Slowbro usa Bostezo; sacrificar a Politoed; Poliwrath +6",
+              "detail": "Usa Especial X y barre. Si Bronzong se quema, puedes usar Danza Aleteo x2. Usa ataques súper efectivos.",
               "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Autodestrucción y entra Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Cabezazo Zen o Terremoto, cambia a Slowbro y usa Bostezo frente a Nidoking.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Autodestrucción y sale Nidoking, Chansey usa Amortiguador para quedar con PS completos.",
+          "variant": [
+            {
+              "detail": "Si Nidoking se queda, usa Teletransporte, entra con Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             },
             {
-              "detail": "Chansey --> Sacrificar a Politoed; Poliwrath +6",
+              "detail": "Si sale Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
-            }  
+            }
           ]
         }
       ]
     },
     {
-      "detail": "Hariyama --> Ver Objeto",
+      "detail": "Si sale Hariyama, revisa el objeto.",
       "variant": [
         {
-          "detail": "Llamasfera --> Cambiar a Slowbro; luego a Gengar Otra Vez 4+2 🔔(Barrer con Bola Sombra)🔔",
-          "variant": []
+          "detail": "Si tiene Llamasfera, cambia a Slowbro y luego a Gengar.",
+          "variant": [
+            {
+              "detail": "Gengar usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
         },
         {
-          "detail": "Sin Llamasfera --> Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6 🔔(Puño Drenaje a Jynx)🔔",
-          "variant": []
+          "detail": "Si no tiene Llamasfera, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque. Usa Puño Drenaje contra Jynx.",
+              "variant": []
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Walrein o Dewgong --> Gengar Otra Vez +2",
+      "detail": "Si sale Walrein o Dewgong, Gengar usa Otra Vez y Maquinación hasta +2.",
       "variant": [
         {
-          "detail": "Si se queda --> Gengar +6 🔔(Barrer con Bola Sombra)🔔",
+          "detail": "Si se queda, Gengar usa Maquinación hasta +6 y barre con Bola Sombra.",
           "variant": []
         },
         {
-          "detail": "Cambia a Lapras --> Barrer hasta Bronzong; Volcarona +1",
-          "variant": []
+          "detail": "Si cambia a Lapras, barre hasta Bronzong y entra con Volcarona.",
+          "variant": [
+            {
+              "detail": "Volcarona usa Danza Aleteo x1.",
+              "variant": []
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Lucario --> Gengar Otra Vez 4+2 🔔(Barrer con Bola Sombra)🔔",
-      "variant": []
+      "detail": "Si sale Lucario, Gengar usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+      "variant": [
+        {
+          "detail": "Barre con Bola Sombra.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/lorelei/chansey.json
+++ b/src/data/kanto/lorelei/chansey.json
@@ -2,26 +2,41 @@
   "id": "chansey",
   "name": "Chansey",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Bronzong luego usa Encanto❤️",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Bronzong.",
   "tricks": [
     {
-      "detail": "Cabezazo Zen / Terremoto --> Cambiar a Slowbro y usar Bostezo frente a Nidoking; sacrificar a Politoed; Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Autodestrucción y sale su Chansey --> Sacrificar a Politoed; Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Autodestrucción y sale Nidoking --> Amortiguador para curar al máximo",
+      "detail": "Luego usa Encanto ❤️ y revisa el movimiento de Bronzong.",
       "variant": [
         {
-          "detail": "Si se queda --> Teletransporte; Slowbro usa Bostezo; sacrificar a Politoed; Poliwrath +6",
+          "detail": "Si usa Cabezazo Zen o Terremoto, cambia a Slowbro y usa Bostezo frente a Nidoking.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Autodestrucción y sale Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Cambia a Chansey --> Sacrificar a Politoed; Poliwrath +6",
-          "variant": []
+          "detail": "Si usa Autodestrucción y sale Nidoking, usa Amortiguador para curar al máximo.",
+          "variant": [
+            {
+              "detail": "Si Nidoking se queda, usa Teletransporte, saca a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si cambia a Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
     }

--- a/src/data/kanto/lorelei/claydol.json
+++ b/src/data/kanto/lorelei/claydol.json
@@ -2,6 +2,16 @@
   "id": "claydol",
   "name": "Claydol",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨 frente a Lucario; cambiar a Slowbro y usar Bostezo frente a Lapras; sacrificar a Politoed; Poliwrath +6 🐸",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Lucario.",
+  "tricks": [
+    {
+      "detail": "Cambia a Slowbro y usa Bostezo frente a Lapras.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/kanto/lorelei/dragonite.json
+++ b/src/data/kanto/lorelei/dragonite.json
@@ -2,7 +2,21 @@
   "id": "dragonite",
   "name": "Dragonite",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 frente a Lucario; Gengar Otra Vez 4+2 🔔(Barrer con Bola Sombra)🔔",
-  "tricks": []
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨 frente a Lucario.",
+  "tricks": [
+    {
+      "detail": "Luego entra con Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Barre con Bola Sombra 🔔.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
-  

--- a/src/data/kanto/lorelei/exeggutor.json
+++ b/src/data/kanto/lorelei/exeggutor.json
@@ -2,22 +2,61 @@
   "id": "exeggutor",
   "name": "Exeggutor",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨Trampa Rocas🪨 🔔(Si no cambia usa Amortiguador)🔔",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Lapras ➜ Cambiar a Politoed luego cambiar a Slowbro frente a Mantine ➜ usar Bostezo frente a Magnezone ➜ sacrificar a Poliwrath ➜ Volcarona +1 + Especial X 🔔(Psíquico a Mantine)🔔",
+      "detail": "Si Exeggutor no cambia, usa Amortiguador.",
       "variant": []
     },
     {
-      "detail": "Golduck ➜ Cambiar a Gengar",
+      "detail": "Si sale Lapras, cambia a Politoed y luego a Slowbro frente a Mantine.",
       "variant": [
         {
-          "detail": "Si se queda ➜ Cambiar a Slowbro frente a Mantine ➜ usar Bostezo frente a Magnezone ➜ sacrificar a Poliwrath ➜ Volcarona +1 + Especial X 🔔(Psíquico a Mantine)🔔",
-          "variant": []
+          "detail": "Usa Bostezo frente a Magnezone.",
+          "variant": [
+            {
+              "detail": "Entra Poliwrath como pivote hasta que quede debilitado y entra con Volcarona.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Mantine.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Golduck, cambia a Gengar.",
+      "variant": [
+        {
+          "detail": "Si Golduck se queda, cambia a Slowbro frente a Mantine y usa Bostezo frente a Magnezone.",
+          "variant": [
+            {
+              "detail": "Entra Poliwrath como pivote hasta que quede debilitado y entra con Volcarona.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x1 y Especial X. Usa Psíquico contra Mantine.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Lapras ➜ Cambiar a Slowbro y usar Bostezo frente a Magnezone ➜ sacrificar a Poliwrath ➜ Volcarona +2 + Especial X 🔔(Psíquico a Mantine)🔔",
-          "variant": []
+          "detail": "Si sale Lapras, cambia a Slowbro y usa Bostezo frente a Magnezone.",
+          "variant": [
+            {
+              "detail": "Entra Poliwrath como pivote hasta que quede debilitado y entra con Volcarona.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x2 y Especial X. Usa Psíquico contra Mantine.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/kanto/lorelei/golduck.json
+++ b/src/data/kanto/lorelei/golduck.json
@@ -2,14 +2,34 @@
   "id": "golduck",
   "name": "Golduck",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "👻 Mira Abajo 👻",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "🪨 Trampa Rocas 🪨 cambia a Gengar ➜ cambia a Slowbro y entra Mantine ➜ usar Bostezo frente a Magnezone ➜ sacrificar a poliwrath ➜ Volcarona +1 + Especial X",
+      "detail": "👻 Cambia a Gengar 👻.",
       "variant": [
         {
-          "detail": "🔔Usar Psíquico contra Mantine; dar Revivir Hierba a Poliwrath + Medicina pequeña continuar🔔",
-          "variant": []
+          "detail": "Luego cambia a Slowbro y espera la entrada de Mantine.",
+          "variant": [
+            {
+              "detail": "Usa Bostezo frente a Magnezone.",
+              "variant": [
+                {
+                  "detail": "Entra Poliwrath como pivote hasta que quede debilitado y luego entra con Volcarona.",
+                  "variant": [
+                    {
+                      "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+                      "variant": [
+                        {
+                          "detail": "Usa Psíquico contra Mantine. Después revive a Poliwrath con Revivir Hierba y usa una medicina pequeña para continuar.",
+                          "variant": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/kanto/lorelei/golurk.json
+++ b/src/data/kanto/lorelei/golurk.json
@@ -1,12 +1,12 @@
 {
-    "id": "golurk",
-    "name": "Golurk",
-    "image": "/placeholder.svg?height=80&width=80",
-    "initialMove": "👀",
-    "tricks": [
-        {
-            "detail": "U cant see me",
-            "variant": []
-        }
-    ]
+  "id": "golurk",
+  "name": "Golurk",
+  "image": "/placeholder.svg?height=80&width=80",
+  "initialMove": "👀",
+  "tricks": [
+    {
+      "detail": "Ruta pendiente de confirmar.",
+      "variant": []
+    }
+  ]
 }

--- a/src/data/kanto/lorelei/hariyama.json
+++ b/src/data/kanto/lorelei/hariyama.json
@@ -2,6 +2,21 @@
   "id": "hariyama",
   "name": "Hariyama",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🐌 Cambiar a Slowbro y usar Bostezo; sacrificar a Politoed; Poliwrath +6 🐸 Puño Drenaje a Jynx",
-  "tricks": []
-}   
+  "initialMove": "Cambia a Slowbro.",
+  "tricks": [
+    {
+      "detail": "Slowbro usa Bostezo 🐌.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Jynx.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/kanto/lorelei/jynx.json
+++ b/src/data/kanto/lorelei/jynx.json
@@ -2,6 +2,21 @@
   "id": "jynx",
   "name": "Jynx",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambiar de Slowbro a Hariyama; usar Bostezo; sacrificar a Politoed; Poliwrath +6 🐸 Puño Drenaje a Jynx",
-  "tricks": []
+  "initialMove": "Cambia de Slowbro a Hariyama.",
+  "tricks": [
+    {
+      "detail": "Usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Jynx.",
+              "variant": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/data/kanto/lorelei/lapras.json
+++ b/src/data/kanto/lorelei/lapras.json
@@ -2,98 +2,168 @@
   "id": "lapras",
   "name": "Lapras",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si se queda --> Ver movimiento",
+      "detail": "Si Lapras se queda, revisa el movimiento.",
       "variant": [
         {
-          "detail": "Rayo Hielo --> Sacrificar a Politoed; Poliwrath +6 Cascada a Banette 【 Si Rayo Hielo crítico mata a Poliwrath, se sugiere cambiar de estrategia 】",
-          "variant": []
-        },
-        {
-          "detail": "Acua Cola --> Cambiar a Politoed; cambiar a Slowbro y luego a Mantine; usar Bostezo frente a Magnezone; sacrificar a Poliwrath; Volcarona +1 + Especial X 🔔Psíquico contra Mantine🔔",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Golduck --> Cambiar a Gengar",
-      "variant": [
-        {
-          "detail": "Si se queda --> Cambiar a Slowbro y luego a Mantine; usar Bostezo frente a Magnezone; sacrificar a Poliwrath; Volcarona +1 + Especial X 🔔Psíquico contra Mantine; dar Revivir Hierba a Poliwrath + Medicina pequeña; continuar🔔",
-          "variant": []
-        },
-        {
-          "detail": "Lapras --> Cambiar a Slowbro y usar Bostezo frente a Magnezone; sacrificar a Poliwrath; Volcarona +2 + Especial X 🔔Psíquico contra Mantine; dar Revivir Hierba a Poliwrath + Medicina pequeña; continuar🔔",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Hariyama --> Cambiar a Slowbro y usar Bostezo",
-      "variant": [
-        {
-          "detail": "Nidoking --> Sacrificar a Politoed; Poliwrath +6 🔔Puño drenaje a Jynx🔔",
-          "variant": []
-        },
-        {
-          "detail": "Jynx --> Volcarona +2",
-          "variant": []
-        }
-      ]
-    },
-    {
-      "detail": "Lucario --> Opción para resolver",
-      "variant": [
-        {
-          "detail": "Rápido --> Teletransporte para ver objeto",
+          "detail": "Si usa Rayo Hielo, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": [
             {
-              "detail": "Vidasfera --> Gengar, otra vez, +4 +2",
-              "variant": []
-            },
-            {
-              "detail": "Sin Vidasfera --> Enviar a Slowbro y usar Bostezo frente a Lapras; sacrificar a Politoed; Poliwrath +6",
+              "detail": "Usa Cascada contra Banette. Si Rayo Hielo crítico debilita a Poliwrath, se sugiere cambiar de estrategia.",
               "variant": []
             }
           ]
         },
         {
-          "detail": "¿Ahorrar dinero? --> Gengar, otra vez, +2",
+          "detail": "Si usa Acua Cola, cambia a Politoed, luego a Slowbro y después a Mantine.",
           "variant": [
             {
-              "detail": "Si se queda --> Gengar, otra vez, +4 +2; barrer con Bola Sombra",
-              "variant": []
-            },
-            {
-              "detail": "Mantine --> Cambiar a Chansey y usar Amortiguador frente a Lucario; Gengar +4 +2; 🔔barrer con Bola Sombra🔔",
-              "variant": []
+              "detail": "Usa Bostezo frente a Magnezone.",
+              "variant": [
+                {
+                  "detail": "Luego entra Poliwrath 🐸🥊 como pivote y entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+                  "variant": [
+                    {
+                      "detail": "Usa Psíquico contra Mantine.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
       ]
     },
     {
-      "detail": "Bronzong --> Chansey usa Encanto",
+      "detail": "Si sale Golduck, cambia a Gengar.",
       "variant": [
         {
-          "detail": "Psíquico / Tierra --> Cambiar a Slowbro y usar Bostezo frente a Nidoking; sacrificar a Politoed; Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Autodestrucción frente a Chansey --> Sacrificar a Politoed; Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Autodestrucción frente a Nidoking --> Chansey usa Amortiguador para curar al máximo",
+          "detail": "Si Golduck se queda, cambia a Slowbro y luego a Mantine.",
           "variant": [
             {
-              "detail": "Si se queda --> Teletransporte; Slowbro usa Bostezo; sacrificar a Politoed; Poliwrath +6",
+              "detail": "Usa Bostezo frente a Magnezone. Luego entra Poliwrath 🐸🥊 como pivote y entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+              "variant": [
+                {
+                  "detail": "Usa Psíquico contra Mantine. Después usa Revivir Hierba en Poliwrath, una medicina pequeña y continúa 🔔.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Lapras, cambia a Slowbro y usa Bostezo frente a Magnezone.",
+          "variant": [
+            {
+              "detail": "Luego entra Poliwrath 🐸🥊 como pivote y entra con Volcarona para usar Danza Aleteo x2 y Especial X.",
+              "variant": [
+                {
+                  "detail": "Usa Psíquico contra Mantine. Después usa Revivir Hierba en Poliwrath, una medicina pequeña y continúa 🔔.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Hariyama, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Nidoking, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Usa Puño Drenaje contra Jynx 🔔.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Jynx, entra con Volcarona y usa Danza Aleteo x2.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lucario, elige una ruta.",
+      "variant": [
+        {
+          "detail": "Ruta rápida: usa Teletransporte para ver el objeto.",
+          "variant": [
+            {
+              "detail": "Si tiene Vidaesfera, entra con Gengar, usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
               "variant": []
             },
             {
-              "detail": "Chansey --> Sacrificar a Politoed; Poliwrath +6",
+              "detail": "Si no tiene Vidaesfera, saca a Slowbro y usa Bostezo frente a Lapras.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Ruta económica: entra con Gengar, usa Otra Vez y Maquinación hasta +2.",
+          "variant": [
+            {
+              "detail": "Si Lucario se queda, Gengar usa Otra Vez, Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+              "variant": [
+                {
+                  "detail": "Barre con Bola Sombra.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Mantine, cambia a Chansey y usa Amortiguador frente a Lucario.",
+              "variant": [
+                {
+                  "detail": "Luego entra con Gengar, usa Maquinación hasta +4 y Velocidad X para +2 Velocidad. Barre con Bola Sombra 🔔.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Bronzong, Chansey usa Encanto.",
+      "variant": [
+        {
+          "detail": "Si usa Psíquico o Terremoto, cambia a Slowbro y usa Bostezo frente a Nidoking.",
+          "variant": [
+            {
+              "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Autodestrucción frente a Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Autodestrucción frente a Nidoking, Chansey usa Amortiguador para curar al máximo.",
+          "variant": [
+            {
+              "detail": "Si Nidoking se queda, usa Teletransporte, saca a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Después entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]

--- a/src/data/kanto/lorelei/lucario.json
+++ b/src/data/kanto/lorelei/lucario.json
@@ -2,24 +2,44 @@
   "id": "lucario",
   "name": "Lucario",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Gengar, Otra Vez → Cambia a Slowbro (Mira el item)",
+  "initialMove": "Cambia a Gengar.",
   "tricks": [
     {
-      "detail": "Vidaesfera → Cambia a Chansey, sale Lapras. Usa trampa rocas → Sale Lucario → Cambia a Slowbro, Bostezo",
+      "detail": "Gengar usa Otra Vez y luego cambia a Slowbro para revisar el objeto.",
       "variant": [
         {
-          "detail": "Si se queda → Teletransporte a Volcarona, +1. Derrotalo, sale Dragonite, usa 1 X SpAtk. Derrotalos (Mantener HP +35%).",
-          "variant": []
+          "detail": "Si tiene Vidaesfera, cambia a Chansey frente a Lapras y usa 🪨 Trampa Rocas 🪨 frente a Lucario.",
+          "variant": [
+            {
+              "detail": "Cambia a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Si Lucario se queda, usa Teletransporte para entrar con Volcarona y usa Danza Aleteo x1.",
+                  "variant": [
+                    {
+                      "detail": "Debilítalo. Frente a Dragonite, usa Especial X y sigue barriendo. Mantén PS sobre 35%.",
+                      "variant": []
+                    }
+                  ]
+                },
+                {
+                  "detail": "Si sale Lapras, entra con Volcarona y usa Danza Aleteo x2. Mantén PS sobre 46%.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Sale Lapras → Volcarona, +2. (Mantener HP +46%)",
-          "variant": []
+          "detail": "Si no tiene Vidaesfera, cambia a Chansey y usa 🪨 Trampa Rocas 🪨.",
+          "variant": [
+            {
+              "detail": "Luego cambia a Slowbro y usa Bostezo. Frente a Lapras, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
-    },
-    {
-      "detail": "Sin Vidaesfera → Cambia a Chansey, trampa rocas. Luego cambia a Slowbro, Bostezo. Sale lapras → Politoed (sacrificar), Poliwrah +6",
-      "variant": []
     }
   ]
 }

--- a/src/data/kanto/lorelei/magnezone.json
+++ b/src/data/kanto/lorelei/magnezone.json
@@ -2,24 +2,59 @@
   "id": "magnezone",
   "name": "Magnezone",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "TRAMPA ROCAS y mantener Amortiguador hasta el cambio",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Golduck → cambiar a Gengar",
+      "detail": "Mantén Amortiguador hasta que el rival cambie.",
       "variant": [
         {
-          "detail": "Se queda → Cambiar a Slowbro, sale Mantine → Usa Bostezo, sale Magnezone, sacrificar a POLIWRATH → Volcarona +1 + X SpAtk. (Psychic a Mantine).",
-          "variant": []
+          "detail": "Si sale Golduck, cambia a Gengar y revisa si se queda.",
+          "variant": [
+            {
+              "detail": "Si Golduck se queda, cambia a Slowbro. Frente a Mantine, usa Bostezo al enfrentar a Magnezone.",
+              "variant": [
+                {
+                  "detail": "Luego entra Poliwrath 🐸🥊 como pivote y entra con Volcarona para usar Danza Aleteo x1 y Especial X.",
+                  "variant": [
+                    {
+                      "detail": "Usa Psíquico contra Mantine.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Lapras, cambia a Slowbro y usa Bostezo al enfrentar a Magnezone.",
+              "variant": [
+                {
+                  "detail": "Luego entra Poliwrath 🐸🥊 como pivote y entra con Volcarona para usar Danza Aleteo x2 y Especial X.",
+                  "variant": [
+                    {
+                      "detail": "Usa Psíquico contra Mantine.",
+                      "variant": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Lapras → Slowbro, bostezo → Sale a Magnezone → sacrificar a POLIWRATH → Volcarona +2 + X SpAtk. (Psychic Mantine).",
-          "variant": []
+          "detail": "Si sale Lapras, cambia a Slowbro y usa Bostezo al enfrentar a Magnezone.",
+          "variant": [
+            {
+              "detail": "Luego entra Poliwrath 🐸🥊 como pivote y entra con Volcarona para usar Danza Aleteo x2 y Especial X.",
+              "variant": [
+                {
+                  "detail": "Usa Psíquico contra Mantine.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
-    },
-    {
-      "detail": "Lapras → Slowbro, bostezo → Sale a Magnezone → sacrificar a POLIWRATH → Volcarona +2 + X SpAtk. (Psychic Mantine).",
-      "variant": []
     }
   ]
 }

--- a/src/data/kanto/lorelei/mantine.json
+++ b/src/data/kanto/lorelei/mantine.json
@@ -2,36 +2,66 @@
   "id": "mantine",
   "name": "Mantine",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Trampa Rocas",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Lapras → Cambia a Poliwrath, Cambia a Slowbro, sale Mantine → bostezo, sale Magnezone → Sacrificar a POLIWRATH → Volcarona +1 + SpAtk X",
-      "variant": []
-    },
-    {
-      "detail": "Lucario → Cambia a Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Bronzong → Encanto",
+      "detail": "Si sale Lapras, cambia a Poliwrath y luego a Slowbro.",
       "variant": [
         {
-          "detail": "Ataque tipo Psiquico / Tierra → Cambia a Slowbro, Bostezo → Politoed (sacrificar), Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Explosión, sale su Chansey → Saca Politoed (sacrificar), Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Explosión, sale Nidoking → Amortiguador, HP FULL",
+          "detail": "Cuando salga Mantine, usa Bostezo frente a Magnezone.",
           "variant": [
             {
-              "detail": "Se queda → Teletransporte → Slowbro, bostezo → Politoed (sacrificar), Poliwrath +6",
+              "detail": "Entra Poliwrath como pivote hasta que quede debilitado y luego entra con Volcarona.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Lucario, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Bronzong, usa Encanto.",
+      "variant": [
+        {
+          "detail": "Si usa ataque tipo Psíquico o Tierra, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Explosión y sale Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Explosión y sale Nidoking, usa Amortiguador hasta quedar con PS completos.",
+          "variant": [
+            {
+              "detail": "Si Nidoking se queda, usa Teletransporte, entra con Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             },
             {
-              "detail": "Su Chansey → Politoed (sacrificar), Poliwrath +6",
+              "detail": "Si sale Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
@@ -39,15 +69,35 @@
       ]
     },
     {
-      "detail": "Golduck → Cambia a Gengar",
+      "detail": "Si sale Golduck, cambia a Gengar.",
       "variant": [
         {
-          "detail": "se queda → cambia a Slowbro, sale Mantine → Bostezo, frente a Magnezone → Sacrificar a POLIWRATH → Volcarona +1 + SpAtk X",
-          "variant": []
+          "detail": "Si Golduck se queda, cambia a Slowbro y espera a Mantine.",
+          "variant": [
+            {
+              "detail": "Usa Bostezo frente a Magnezone. Luego entra Poliwrath como pivote hasta que quede debilitado y entra con Volcarona.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         },
         {
-          "detail": "Lapras → Cambia a Slowbro, Bostezo frente a Magnezone → Sacrificar a POLIWRATH → Volcarona +2 + SpAtk X",
-          "variant": []
+          "detail": "Si sale Lapras, cambia a Slowbro y usa Bostezo frente a Magnezone.",
+          "variant": [
+            {
+              "detail": "Luego entra Poliwrath como pivote hasta que quede debilitado y entra con Volcarona.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x2 y Especial X.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/data/kanto/lorelei/mantine.json
+++ b/src/data/kanto/lorelei/mantine.json
@@ -5,13 +5,13 @@
   "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si sale Lapras, cambia a Poliwrath y luego a Slowbro.",
+      "detail": "Si sale Lapras, cambia a Poliwrath 🐸🥊 y luego a Slowbro.",
       "variant": [
         {
           "detail": "Cuando salga Mantine, usa Bostezo frente a Magnezone.",
           "variant": [
             {
-              "detail": "Entra Poliwrath como pivote hasta que quede debilitado y luego entra con Volcarona.",
+              "detail": "Entra Poliwrath 🐸🥊 como pivote hasta que quede debilitado y luego entra con Volcarona.",
               "variant": [
                 {
                   "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
@@ -75,7 +75,7 @@
           "detail": "Si Golduck se queda, cambia a Slowbro y espera a Mantine.",
           "variant": [
             {
-              "detail": "Usa Bostezo frente a Magnezone. Luego entra Poliwrath como pivote hasta que quede debilitado y entra con Volcarona.",
+              "detail": "Usa Bostezo frente a Magnezone. Luego entra Poliwrath 🐸🥊 como pivote hasta que quede debilitado y entra con Volcarona.",
               "variant": [
                 {
                   "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
@@ -89,7 +89,7 @@
           "detail": "Si sale Lapras, cambia a Slowbro y usa Bostezo frente a Magnezone.",
           "variant": [
             {
-              "detail": "Luego entra Poliwrath como pivote hasta que quede debilitado y entra con Volcarona.",
+              "detail": "Luego entra Poliwrath 🐸🥊 como pivote hasta que quede debilitado y entra con Volcarona.",
               "variant": [
                 {
                   "detail": "Volcarona usa Danza Aleteo x2 y Especial X.",

--- a/src/data/kanto/lorelei/nidoking.json
+++ b/src/data/kanto/lorelei/nidoking.json
@@ -2,45 +2,90 @@
   "id": "nidoking",
   "name": "Nidoking",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "🪨 Trampa Rocas 🪨",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Lapras → Cambia a Poliwrath → Cambia a Slowbro → sale Mantine → Bostezo → sale Magnezone → Sacrificar a Poliwrath → Volcarona +1 + SpAtk X",
-      "variant": []
-    },
-    {
-      "detail": "Golduck → Cambia a Gengar",
+      "detail": "Si sale Lapras, cambia a Poliwrath y luego a Slowbro.",
       "variant": [
         {
-          "detail": "Se queda → Cambia a Slowbro → sale Mantine → Bostezo → frente a Magnezone → Sacrificar a Poliwrath → Volcarona +1 + SpAtk X",
-          "variant": []
-        },
-        {
-          "detail": "Lapras → Cambia a Slowbro → Bostezo → frente a Magnezone → Sacrificar a Poliwrath → Volcarona +2 + SpAtk X",
-          "variant": []
+          "detail": "Cuando salga Mantine, usa Bostezo frente a Magnezone.",
+          "variant": [
+            {
+              "detail": "Entra Poliwrath como pivote hasta que quede debilitado y luego entra con Volcarona.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "detail": "Bronzong → Encanto",
+      "detail": "Si sale Golduck, cambia a Gengar.",
       "variant": [
         {
-          "detail": "Ataque tipo Psíquico/Tierra → Cambia a Slowbro → Bostezo → Politoed (sacrificar) → Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Explosión → sale Chansey → Saca Politoed (sacrificar) → Poliwrath +6",
-          "variant": []
-        },
-        {
-          "detail": "Explosión → sale Nidoking → Amortiguador → HP full",
+          "detail": "Si Golduck se queda, cambia a Slowbro y espera la entrada de Mantine.",
           "variant": [
             {
-              "detail": "Se queda → Teletransporte → Slowbro → Bostezo → Politoed (sacrificar) → Poliwrath +6",
+              "detail": "Usa Bostezo frente a Magnezone. Entra Poliwrath como pivote hasta que quede debilitado y luego entra con Volcarona.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Lapras, cambia a Slowbro y usa Bostezo frente a Magnezone.",
+          "variant": [
+            {
+              "detail": "Entra Poliwrath como pivote hasta que quede debilitado y luego entra con Volcarona.",
+              "variant": [
+                {
+                  "detail": "Volcarona usa Danza Aleteo x2 y Especial X.",
+                  "variant": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "detail": "Si sale Bronzong, usa Encanto.",
+      "variant": [
+        {
+          "detail": "Si usa ataque tipo Psíquico o Tierra, cambia a Slowbro y usa Bostezo.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Explosión y sale Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        },
+        {
+          "detail": "Si usa Explosión y sale Nidoking, usa Amortiguador hasta quedar con PS completos.",
+          "variant": [
+            {
+              "detail": "Si Nidoking se queda, usa Teletransporte, entra con Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
             },
             {
-              "detail": "Sale Chansey → Politoed (sacrificar) → Poliwrath +6",
+              "detail": "Si sale Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
               "variant": []
             }
           ]
@@ -48,8 +93,13 @@
       ]
     },
     {
-      "detail": "Lucario → Cambia a Slowbro → Bostezo → Politoed (sacrificar) → Poliwrath +6",
-      "variant": []
+      "detail": "Si sale Lucario, cambia a Slowbro y usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/lorelei/nidoking.json
+++ b/src/data/kanto/lorelei/nidoking.json
@@ -5,13 +5,13 @@
   "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Si sale Lapras, cambia a Poliwrath y luego a Slowbro.",
+      "detail": "Si sale Lapras, cambia a Poliwrath 🐸🥊 y luego a Slowbro.",
       "variant": [
         {
           "detail": "Cuando salga Mantine, usa Bostezo frente a Magnezone.",
           "variant": [
             {
-              "detail": "Entra Poliwrath como pivote hasta que quede debilitado y luego entra con Volcarona.",
+              "detail": "Entra Poliwrath 🐸🥊 como pivote hasta que quede debilitado y luego entra con Volcarona.",
               "variant": [
                 {
                   "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
@@ -30,7 +30,7 @@
           "detail": "Si Golduck se queda, cambia a Slowbro y espera la entrada de Mantine.",
           "variant": [
             {
-              "detail": "Usa Bostezo frente a Magnezone. Entra Poliwrath como pivote hasta que quede debilitado y luego entra con Volcarona.",
+              "detail": "Usa Bostezo frente a Magnezone. Entra Poliwrath 🐸🥊 como pivote hasta que quede debilitado y luego entra con Volcarona.",
               "variant": [
                 {
                   "detail": "Volcarona usa Danza Aleteo x1 y Especial X.",
@@ -44,7 +44,7 @@
           "detail": "Si sale Lapras, cambia a Slowbro y usa Bostezo frente a Magnezone.",
           "variant": [
             {
-              "detail": "Entra Poliwrath como pivote hasta que quede debilitado y luego entra con Volcarona.",
+              "detail": "Entra Poliwrath 🐸🥊 como pivote hasta que quede debilitado y luego entra con Volcarona.",
               "variant": [
                 {
                   "detail": "Volcarona usa Danza Aleteo x2 y Especial X.",

--- a/src/data/kanto/lorelei/nidoqueen.json
+++ b/src/data/kanto/lorelei/nidoqueen.json
@@ -2,15 +2,25 @@
   "id": "nidoqueen",
   "name": "Nidoqueen",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro, sale Hariyama → Bostezo",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Nidoking → Politoed (sacrificar). Poliwrath +6. (Piel Seca Jynx)",
-      "variant": []
-    },
-    {
-      "detail": "Jynx → Volcarona +3",
-      "variant": []
+      "detail": "Cuando salga Hariyama, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Si sale Nidoking, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Ten en cuenta Piel Seca de Jynx.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si sale Jynx, entra con Volcarona y usa Danza Aleteo x3.",
+          "variant": []
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/lorelei/raichu.json
+++ b/src/data/kanto/lorelei/raichu.json
@@ -2,11 +2,21 @@
   "id": "raichu",
   "name": "Raichu",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Trampa Rocas, Sale Lucario → Cambia a Gengar, Otra Vez, +4 +2",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Mantener Otra Vez cada que puedas, a todos los barres con Bola Sombra",
-      "variant": []
+      "detail": "Si sale Lucario, cambia a Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Mantén Otra Vez cada vez que puedas y barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/lorelei/slowbro.json
+++ b/src/data/kanto/lorelei/slowbro.json
@@ -2,11 +2,21 @@
   "id": "slowbro",
   "name": "Slowbro",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Trampa Rocas, Sale Lucario → Cambia a Gengar, Otra Vez, +4 +2",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Mantener Otra Vez cada que puedas, a todos los barres con Bola Sombra",
-      "variant": []
+      "detail": "Si sale Lucario, cambia a Gengar y usa Otra Vez.",
+      "variant": [
+        {
+          "detail": "Gengar usa Maquinación hasta +4 y Velocidad X para +2 Velocidad.",
+          "variant": [
+            {
+              "detail": "Mantén Otra Vez cada vez que puedas y barre con Bola Sombra.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/lorelei/togekiss.json
+++ b/src/data/kanto/lorelei/togekiss.json
@@ -2,11 +2,21 @@
   "id": "togekiss",
   "name": "Togekiss",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Cambia a Slowbro, sale Hariyama",
+  "initialMove": "Cambia a Slowbro.",
   "tricks": [
     {
-      "detail": "Bostezo → Politoed (sacrificar). Poliwrath +6. (Piel Seca Jynx)",
-      "variant": []
+      "detail": "Cuando salga Hariyama, usa Bostezo.",
+      "variant": [
+        {
+          "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+          "variant": [
+            {
+              "detail": "Ten en cuenta Piel Seca de Jynx.",
+              "variant": []
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/data/kanto/lorelei/vileplume.json
+++ b/src/data/kanto/lorelei/vileplume.json
@@ -2,26 +2,41 @@
   "id": "vileplume",
   "name": "Vileplume",
   "image": "/placeholder.svg?height=80&width=80",
-  "initialMove": "Trampa Rocas → sale Bronzong → Encanto",
+  "initialMove": "Usa 🪨 Trampa Rocas 🪨.",
   "tricks": [
     {
-      "detail": "Ataque Psíquico / Terremoto → cambiar a Slowbro → Bostezo → sale Nidoking → Politoed (sacrificar) → Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Explosión → sale Chansey → Politoed (sacrificar) → Poliwrath +6",
-      "variant": []
-    },
-    {
-      "detail": "Explosión → sale Nidoking → Amortiguador → HP full",
+      "detail": "Si sale Bronzong, usa Encanto.",
       "variant": [
         {
-          "detail": "Se queda → Teletransporte → Slowbro → Bostezo → Politoed (sacrificar) → Poliwrath +6",
+          "detail": "Si usa Psíquico o Terremoto, cambia a Slowbro y usa Bostezo frente a Nidoking.",
+          "variant": [
+            {
+              "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
+        },
+        {
+          "detail": "Si usa Explosión y sale Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
           "variant": []
         },
         {
-          "detail": "Sale Chansey → Politoed (sacrificar) → Poliwrath +6",
-          "variant": []
+          "detail": "Si usa Explosión y sale Nidoking, usa Amortiguador hasta quedar con PS al máximo.",
+          "variant": [
+            {
+              "detail": "Si Nidoking se queda, usa Teletransporte, saca a Slowbro y usa Bostezo.",
+              "variant": [
+                {
+                  "detail": "Luego entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+                  "variant": []
+                }
+              ]
+            },
+            {
+              "detail": "Si sale Chansey, entra Politoed como pivote y entra con Poliwrath 🐸🥊 para usar Tambor hasta +6 Ataque.",
+              "variant": []
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Cleans all Kanto Lorelei Spanish strategy JSON files.
- Keeps `initialMove` limited to the opening switch/action only.
- Moves follow-up routes into `tricks.detail` and nested `variant` entries.
- Keeps the scope limited to `src/data/kanto/lorelei`.

## Scope
- Kanto Lorelei strategy JSON files only.
- No English, asset, or frontend changes.

## Files
- 20 files under `src/data/kanto/lorelei`.